### PR TITLE
Issue 5 - Highlight differences in collections

### DIFF
--- a/src/Shouldly/DifferenceHighlighterHelpers.cs
+++ b/src/Shouldly/DifferenceHighlighterHelpers.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Text;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Shouldly
+{
+    public static class DifferenceHighlighterHelpers
+    {
+        private const string HIGHLIGHT_CHARACTER = "*";
+
+        private static List<IHighlighter> _highlighters = new List<IHighlighter>() {
+            new EnumerableHighlighter()
+        };
+
+        /// <summary>
+        /// Compares an actual value against an expected one and creates
+        /// a string with the differences highlighted
+        /// </summary>
+        public static string HighlightDifferencesFrom(this object actualValue, object expectedValue)
+        {
+            IHighlighter validHighlighter = GetHighlighterFor(expectedValue, actualValue);
+
+            if (validHighlighter != null)
+            {
+                return validHighlighter.HighlightDifferences(expectedValue, actualValue);
+            }
+            else
+            {
+                return actualValue.Inspect();
+            }
+        }
+
+        public static bool CanCompareAgainst(this object actual, object expected)
+        {
+            return GetHighlighterFor(expected, actual) != null;
+        }
+
+        private static IHighlighter GetHighlighterFor(object expected, object actual)
+        {
+            return (from highlighter in _highlighters
+                    where highlighter.CanProcess(expected, actual)
+                    select highlighter).FirstOrDefault();
+        }
+
+        private static string HighlightItem(string item)
+        {
+            return HIGHLIGHT_CHARACTER + item + HIGHLIGHT_CHARACTER;
+        }
+
+        private static IList ToList(this IEnumerable value)
+        {
+            if (value is IList)
+            {
+                return value.As<IList>();
+            }
+
+            ArrayList convertedList = new ArrayList();
+            foreach (var item in value)
+            {
+                convertedList.Add(item);
+            }
+
+            return convertedList;
+        }
+
+        /// <summary>
+        /// Interface for classes which can highlight differences in things
+        /// </summary>
+        private interface IHighlighter
+        {
+            bool CanProcess(object expected, object actual);
+            string HighlightDifferences(object expected, object actual);
+        }
+
+        /// <summary>
+        /// Highlights differences between IEnumerables of the same type,
+        /// marking differences with asterisks
+        /// </summary>
+        private class EnumerableHighlighter : IHighlighter
+        {
+            private const int MAX_ELEMENTS_TO_SHOW = 1000;
+
+            public bool CanProcess(object expected, object actual)
+            {
+                return (expected is IEnumerable)
+                        & !(expected is string)
+                        && (expected.GetType() == actual.GetType());
+            }
+
+            public string HighlightDifferences(object expected, object actual)
+            {
+
+                if (CanProcess(expected, actual))
+                {
+                    StringBuilder returnMessage = new StringBuilder("[");
+
+                    var actualList = actual.As<IEnumerable>().ToList();
+                    var expectedList = expected.As<IEnumerable>().ToList();
+
+                    int highestCount = actualList.Count > expectedList.Count ? actualList.Count : expectedList.Count;
+
+                    return HighlightDifferencesBetweenLists(actualList, expectedList, highestCount);
+                }
+                else
+                {
+                    return actual.Inspect();
+                }
+            }
+
+            private static string HighlightDifferencesBetweenLists(IList actualList, IList expectedList, int highestListCount)
+            {
+                StringBuilder returnMessage = new StringBuilder("[");
+
+                for (int listItem = 0; listItem < highestListCount; listItem++)
+                {
+                    if (listItem >= MAX_ELEMENTS_TO_SHOW)
+                    {
+                        returnMessage.Append("...");
+                        break;
+                    }
+
+                    returnMessage.Append(GetComparedItemString(actualList, expectedList, listItem));
+
+                    if (listItem < highestListCount - 1)
+                    {
+                        returnMessage.Append(", ");
+                    }
+                }
+
+                return returnMessage.Append("]").ToString();
+            }
+
+            private static string GetComparedItemString(IList actualList, IList expectedList, int itemPosition)
+            {
+                if (expectedList.Count <= itemPosition)
+                {
+                    return HighlightItem(actualList[itemPosition].Inspect());
+                }
+
+                if (actualList.Count <= itemPosition)
+                {
+                    return HIGHLIGHT_CHARACTER;
+                }
+
+                if (Is.EqualTo(actualList[itemPosition]).Matches(expectedList[itemPosition]))
+                {
+                    return actualList[itemPosition].Inspect();
+                }
+                else
+                {
+                    return HighlightItem(actualList[itemPosition].Inspect());
+                }
+            }
+        }
+    }
+}

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DifferenceHighlighterHelpers.cs" />
     <Compile Include="Create.cs" />
     <Compile Include="ObjectHelpers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -50,12 +50,24 @@ namespace Shouldly
                 codeLines.Substring(0, shouldMethodIndex - 1).Trim() : 
                 possibleCodeLines[0];
 
-            return string.Format(@"{0}
+            return CreateActualVsExpectedMessage(actual, expected, environment, codePart);
+        }
+
+        private static string CreateActualVsExpectedMessage(object actual, object expected, TestEnvironment environment, string codePart) {
+            string message = string.Format(@"{0}
         {1}
     {2}
         but was
     {3}",
                 codePart, environment.ShouldMethod.PascalToSpaced(), expected.Inspect(), actual.Inspect());
+
+            if (actual.CanCompareAgainst(expected)) {
+                message += string.Format(@"
+        difference
+    {0}",
+                actual.HighlightDifferencesFrom(expected));
+            }
+            return message;
         }
 
         private static string GenerateShouldMessage(object expected)

--- a/src/Tests/DifferenceHighlighterHelpersTests.cs
+++ b/src/Tests/DifferenceHighlighterHelpersTests.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Tests
+{
+    [TestFixture]
+    public class DifferenceHighlighterHelpersTests
+    {
+        [Test]
+        public void HighlightDifferencesFrom_IntegerListsSameExceptOne_HighlightsDifference()
+        {
+            new int[] { 2, 2, 3 }.HighlightDifferencesFrom(new int[] { 1, 2, 3 }).ShouldBe("[*2*, 2, 3]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_ListsSame_DisplaysActualWithoutHighlight()
+        {
+            new int[] { 1, 2, 3 }.HighlightDifferencesFrom(new int[] { 1, 2, 3 }).ShouldBe("[1, 2, 3]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_ListsActualHasMoreElements_HighlightsMissingElements()
+        {
+            new int[] { 1, 2, 3 }.HighlightDifferencesFrom(new int[] { 1 }).ShouldBe("[1, *2*, *3*]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_ListsActualHasLessElements_HighlightsMissingElements()
+        {
+            new int[] { 1 }.HighlightDifferencesFrom(new int[] { 1, 2, 3 }).ShouldBe("[1, *, *]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_DifferentTypes_DisplaysActualWithoutHighlight()
+        {
+            new string[] { "hi", "mum" }.HighlightDifferencesFrom(new int[] { 1, 2 }).ShouldBe("[\"hi\", \"mum\"]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_NotEnumerables_DisplaysActualWithoutHighlight()
+        {
+            "hello".HighlightDifferencesFrom("goodbye").ShouldBe("\"hello\"");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_ListsSameElementsInDifferentOrder_HighlightAllAsDifferent()
+        {
+            new int[] { 2, 3, 1 }.HighlightDifferencesFrom(new int[] { 1, 2, 3 }).ShouldBe("[*2*, *3*, *1*]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_StringLists_HighlightsDifference()
+        {
+            new string[] { "rita", "sue", "betty" }.HighlightDifferencesFrom(new string[] { "rita", "sue", "bob" }).ShouldBe("[\"rita\", \"sue\", *\"betty\"*]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_EnumLists_HighlightsDifference()
+        {
+            new Weapons[] { Weapons.Screwdriver, Weapons.Axe }.HighlightDifferencesFrom(new Weapons[] { Weapons.Chainsaw, Weapons.Axe }).ShouldBe("[*Weapons.Screwdriver*, Weapons.Axe]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_BoolLists_HighlightsDifference()
+        {
+            new bool[] { true, true, false }.HighlightDifferencesFrom(new bool[] { true, false, true }).ShouldBe("[True, *True*, *False*]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_ListOfObjectWithEqualsDefined_HighlightsDifference()
+        {
+            new EqualType[] { new EqualType("t1"), new EqualType("t3") }
+                .HighlightDifferencesFrom(
+               new EqualType[] { new EqualType("t1"), new EqualType("t2") })
+               .ShouldBe("[t1, *t3*]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_ListOfObjectWithoutEqualsDefined_HighlightsEverythingAsDifference()
+        {
+            new NonEqualType[] { new NonEqualType("t1"), new NonEqualType("t2") }
+                .HighlightDifferencesFrom(
+               new NonEqualType[] { new NonEqualType("t1"), new NonEqualType("t2") })
+               .ShouldBe("[*t1*, *t2*]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_GenericList_HighlightsDifference()
+        {
+            new List<int>() { 1, 4, 3 }.HighlightDifferencesFrom(new List<int>() { 1, 2, 3 }).ShouldBe("[1, *4*, 3]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_ArrayList_HighlightsDifference()
+        {
+            new ArrayList() { 9, 7, 8 }.HighlightDifferencesFrom(new ArrayList() { 9, 8, 7 }).ShouldBe("[9, *7*, *8*]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_PureEnumerable_HighlightsDifference()
+        {
+            new PureEnumerable() { 9, 8, 6 }.HighlightDifferencesFrom(new PureEnumerable() { 9, 8, 7 }).ShouldBe("[9, 8, *6*]");
+        }
+
+        [Test]
+        public void HighlightDifferencesFrom_BigList_OnlyShowsFirst1000Elements()
+        {
+
+            int[] actualList = new int[2000];
+            int[] expectedList = new int[2000];
+
+            for (int count = 0; count < 2000; count++)
+            {
+                actualList[count] = count;
+                expectedList[count] = count;
+            }
+            actualList[0] = 666;
+
+            actualList.HighlightDifferencesFrom(expectedList)
+                .ShouldBe("[*666*, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444, 445, 446, 447, 448, 449, 450, 451, 452, 453, 454, 455, 456, 457, 458, 459, 460, 461, 462, 463, 464, 465, 466, 467, 468, 469, 470, 471, 472, 473, 474, 475, 476, 477, 478, 479, 480, 481, 482, 483, 484, 485, 486, 487, 488, 489, 490, 491, 492, 493, 494, 495, 496, 497, 498, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 512, 513, 514, 515, 516, 517, 518, 519, 520, 521, 522, 523, 524, 525, 526, 527, 528, 529, 530, 531, 532, 533, 534, 535, 536, 537, 538, 539, 540, 541, 542, 543, 544, 545, 546, 547, 548, 549, 550, 551, 552, 553, 554, 555, 556, 557, 558, 559, 560, 561, 562, 563, 564, 565, 566, 567, 568, 569, 570, 571, 572, 573, 574, 575, 576, 577, 578, 579, 580, 581, 582, 583, 584, 585, 586, 587, 588, 589, 590, 591, 592, 593, 594, 595, 596, 597, 598, 599, 600, 601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615, 616, 617, 618, 619, 620, 621, 622, 623, 624, 625, 626, 627, 628, 629, 630, 631, 632, 633, 634, 635, 636, 637, 638, 639, 640, 641, 642, 643, 644, 645, 646, 647, 648, 649, 650, 651, 652, 653, 654, 655, 656, 657, 658, 659, 660, 661, 662, 663, 664, 665, 666, 667, 668, 669, 670, 671, 672, 673, 674, 675, 676, 677, 678, 679, 680, 681, 682, 683, 684, 685, 686, 687, 688, 689, 690, 691, 692, 693, 694, 695, 696, 697, 698, 699, 700, 701, 702, 703, 704, 705, 706, 707, 708, 709, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719, 720, 721, 722, 723, 724, 725, 726, 727, 728, 729, 730, 731, 732, 733, 734, 735, 736, 737, 738, 739, 740, 741, 742, 743, 744, 745, 746, 747, 748, 749, 750, 751, 752, 753, 754, 755, 756, 757, 758, 759, 760, 761, 762, 763, 764, 765, 766, 767, 768, 769, 770, 771, 772, 773, 774, 775, 776, 777, 778, 779, 780, 781, 782, 783, 784, 785, 786, 787, 788, 789, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799, 800, 801, 802, 803, 804, 805, 806, 807, 808, 809, 810, 811, 812, 813, 814, 815, 816, 817, 818, 819, 820, 821, 822, 823, 824, 825, 826, 827, 828, 829, 830, 831, 832, 833, 834, 835, 836, 837, 838, 839, 840, 841, 842, 843, 844, 845, 846, 847, 848, 849, 850, 851, 852, 853, 854, 855, 856, 857, 858, 859, 860, 861, 862, 863, 864, 865, 866, 867, 868, 869, 870, 871, 872, 873, 874, 875, 876, 877, 878, 879, 880, 881, 882, 883, 884, 885, 886, 887, 888, 889, 890, 891, 892, 893, 894, 895, 896, 897, 898, 899, 900, 901, 902, 903, 904, 905, 906, 907, 908, 909, 910, 911, 912, 913, 914, 915, 916, 917, 918, 919, 920, 921, 922, 923, 924, 925, 926, 927, 928, 929, 930, 931, 932, 933, 934, 935, 936, 937, 938, 939, 940, 941, 942, 943, 944, 945, 946, 947, 948, 949, 950, 951, 952, 953, 954, 955, 956, 957, 958, 959, 960, 961, 962, 963, 964, 965, 966, 967, 968, 969, 970, 971, 972, 973, 974, 975, 976, 977, 978, 979, 980, 981, 982, 983, 984, 985, 986, 987, 988, 989, 990, 991, 992, 993, 994, 995, 996, 997, 998, 999, ...]");
+        }
+
+        private enum Weapons
+        {
+            Axe,
+            Chainsaw,
+            Nailgun,
+            Screwdriver
+        }
+
+        private class EqualType
+        {
+            private string _description;
+
+            public EqualType(string description)
+            {
+                _description = description;
+            }
+
+            public override string ToString()
+            {
+                return _description;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return this._description == ((EqualType)obj)._description;
+            }
+        }
+
+        private class NonEqualType
+        {
+            private string _description;
+
+            public NonEqualType(string description)
+            {
+                _description = description;
+            }
+
+            public override string ToString()
+            {
+                return _description;
+            }
+        }
+
+        private class PureEnumerable : IEnumerable
+        {
+            private List<int> _numbers = new List<int>();
+
+            public void Add(int number)
+            {
+                _numbers.Add(number);
+            }
+
+            public IEnumerator GetEnumerator()
+            {
+                return _numbers.GetEnumerator();
+            }
+        }
+    }
+}

--- a/src/Tests/ShouldlyMessageTests.cs
+++ b/src/Tests/ShouldlyMessageTests.cs
@@ -17,5 +17,41 @@ namespace Tests
         but was
     ""actual""");
         }
+
+        [Test]
+        public void ShouldlyMessage_PassedCollectionsWhichCanBeCompared_ShouldShowDifferences() 
+        {
+            new ShouldlyMessage(new int[] { 1, 2, 3 }, new int[] { 2, 2, 3 }).ToString()
+            .ShouldBe(@"            new ShouldlyMessage(new int[] { 1, 2, 3 }, new int[] { 2, 2, 3 }).ToString()
+        shouldly message_ passed collections which can be compared_ should show differences
+    [1, 2, 3]
+        but was
+    [2, 2, 3]
+        difference
+    [*2*, 2, 3]");
+        }
+
+        [Test]
+        public void ShouldlyMessage_PassedObjectsWhichCannotCompared_ShouldNotShowDifferences() 
+        {
+            new ShouldlyMessage(new UncomparableClass("ted"), new UncomparableClass("bob")).ToString()
+            .ShouldBe(@"            new ShouldlyMessage(new UncomparableClass(""ted""), new UncomparableClass(""bob"")).ToString()
+        shouldly message_ passed objects which cannot compared_ should not show differences
+    ted
+        but was
+    bob");
+        }
+
+        private class UncomparableClass {
+            private string _description;
+
+            public UncomparableClass(string description) {
+                _description = description;
+            }
+
+            public override string ToString() {
+                return _description;
+            }
+        }
     }
 }

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -49,6 +49,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DifferenceHighlighterHelpersTests.cs" />
     <Compile Include="Should.cs" />
     <Compile Include="ShouldBeDictionaryTests.cs" />
     <Compile Include="ShouldBeEnumerableTests.cs" />


### PR DESCRIPTION
I added a static class to perform highlighting of differences, which gets called by ShouldlyMessage if it can highlight differences between two objects.

This only works for IEnumerables at the moment, but I set it up so you can easily add more (for example, for strings) by implementing IHighlighter and adding it to the _highlighters collection in DifferenceHighlighterHelpers.

I realised this should probably have been in a branch, hopefully being in master won't be a problem.  Also the GitHub diff thing is showing small changes to files as removing all lines and adding them again, not sure what's going on there, hopefully my changes will make sense!
