### PR TITLE
#20 - Should.Throw should return the exception itself

### DIFF
--- a/src/Shouldly.Tests/Should.cs
+++ b/src/Shouldly.Tests/Should.cs
@@ -7,7 +7,7 @@ namespace Shouldly.Tests
     {
         public static void Error(Action action, string errorMessage)
         {
-            Shouldly.Should.Throw<ChuckedAWobbly>(action).ShouldBeCloseTo(errorMessage);
+            Shouldly.Should.Throw<ChuckedAWobbly>(action).Message.ShouldBeCloseTo(errorMessage);
         }
 
         public static void NotError(Action action)

--- a/src/Shouldly/ShouldThrowTestExtensions.cs
+++ b/src/Shouldly/ShouldThrowTestExtensions.cs
@@ -7,7 +7,7 @@ namespace Shouldly
     [ShouldlyMethods]
     public static class Should
     {
-        public static string Throw<TException>(Action actual) where TException : Exception
+        public static TException Throw<TException>(Action actual) where TException : Exception
         {
             try
             {
@@ -15,7 +15,7 @@ namespace Shouldly
             }
             catch (TException e)
             {
-                return e.Message;
+                return e;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Hi Guys,
Implementing this as response to #20.
this is better to run additional verification on exception, for example WebFaultException
