### PR TITLE
Specs (BDDish) extension

### DIFF
--- a/Shouldly.sln
+++ b/Shouldly.sln
@@ -1,0 +1,26 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 10.00
+# Visual Studio 2008
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shouldly", "src\Shouldly\Shouldly.csproj", "{CF49E8A3-57E1-4F43-B2DC-7092D2B7677F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shouldly.Tests", "src\Shouldly.Tests\Shouldly.Tests.csproj", "{7E798127-21FE-4F49-A221-53B53B40D6BE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CF49E8A3-57E1-4F43-B2DC-7092D2B7677F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF49E8A3-57E1-4F43-B2DC-7092D2B7677F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF49E8A3-57E1-4F43-B2DC-7092D2B7677F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF49E8A3-57E1-4F43-B2DC-7092D2B7677F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E798127-21FE-4F49-A221-53B53B40D6BE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E798127-21FE-4F49-A221-53B53B40D6BE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E798127-21FE-4F49-A221-53B53B40D6BE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E798127-21FE-4F49-A221-53B53B40D6BE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ShouldlyMessageTests.cs" />
     <Compile Include="ShouldlyRhinoTests.cs" />
+    <Compile Include="ShouldlySpecsTests.cs" />
     <Compile Include="ShouldThrowTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Shouldly.Tests/ShouldlySpecsTests.cs
+++ b/src/Shouldly.Tests/ShouldlySpecsTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Shouldly.Tests
+{
+    [TestFixture]
+    public class ShouldlySpecsTests
+    {
+        [Test]
+        public void ShouldlySpecs_PassedPassingSpecifications_ShouldPass()
+        {
+            Should.NotError(() =>
+                "Math is working".Spec(() => 2.ShouldBe(2)));
+            Should.NotError(() =>
+                "String has correct length".Spec(() => "Five".Length.ShouldBe(4)));
+        }
+
+        [Test]
+        public void ShouldlySpecs_PassedSpecThatThrowsNormalException_ShouldShowException()
+        {
+            Should.Error(
+                () => "Feature should be implemented".Spec(() => { throw new NotImplementedException(); }),
+                "Feature should be implemented: System.NotImplementedException: The method or operation is not implemented."
+                );
+        }
+        [Test]
+        public void ShouldlySpecs_PassedSpecThatShouldlyFails_ShouldShowException()
+        {
+            Should.Error(
+                () => "True should be false".Spec(() => true.ShouldBe(false)),
+                "True should be false: () => true should be False but was True"
+            );
+        }
+    }
+}

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -68,6 +68,7 @@
     <Compile Include="ShouldlyMessage.cs" />
     <Compile Include="ShouldlyMethodsAttribute.cs" />
     <Compile Include="ShouldlyRhinoExtensions.cs" />
+    <Compile Include="ShouldlySpecs.cs" />
     <Compile Include="ShouldThrowTestExtensions.cs" />
     <Compile Include="StringHelpers.cs" />
     <Compile Include="ChuckedAWobbly.cs" />

--- a/src/Shouldly/ShouldlySpecs.cs
+++ b/src/Shouldly/ShouldlySpecs.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Shouldly
+{
+    [ShouldlyMethods]
+    public static class ShouldlySpecs
+    {
+        public static void Spec(this string spec, Action test)
+        {
+            string message = "";
+
+            try
+            {
+                test();
+                return;
+            }
+            catch (ChuckedAWobbly e)
+            {
+                message = e.Message.Replace(
+                    string.Format("\"{0}\".Spec(() => ", spec),
+                    "    ");
+            }
+            catch (Exception e)
+            {
+                message = string.Format(
+@"{0}: {1}",
+                    e.GetType().ToString(),
+                    e.Message);
+            }
+
+            throw new ChuckedAWobbly(string.Format(
+@"{0}:
+{1}",
+                spec,
+                message));
+        }
+    }
+}


### PR DESCRIPTION
Extension method to add a BDDish specification syntax. Eg:

```
"Team should have 5 points".Spec(() => team.Points.ShouldBe(5));
"Team should be awesome".Spec(() => team.IsAwesome.ShouldBe(true));
```

I'm on VS2008 so I created a new solution (shouldly.sln). I don't have VS010 so I couldn't add this to the current sln, sorry!
