### PR TITLE
Fixed bug with ShouldBeTypeOf<T> assert method

### DIFF
--- a/src/Shouldly.Tests/ShouldlyMessageTests.cs
+++ b/src/Shouldly.Tests/ShouldlyMessageTests.cs
@@ -3,7 +3,6 @@
 namespace Shouldly.Tests
 {
     [TestFixture]
-    [ShouldlyMethods]
     public class ShouldlyMessageTests
     {
         [Test]
@@ -31,6 +30,15 @@ namespace Shouldly.Tests
                 () => (new[] { 1, 2, 3 }).ShouldBe(new[] { 2, 2, 3 }),
                 "() => (new[] { 1, 2, 3 }) should be [2, 2, 3] but was [1, 2, 3] difference [*1*, 2, 3]"
             );
+        }
+
+        [Test]
+        public void ShouldlyMessage_CanGenerateForOfTypeAssertion()
+        {
+            Should.Error(
+                () => 2.ShouldBeTypeOf<double>(),
+                "() => 2 should be type of System.Double but was System.Int32"
+                );
         }
 
         [Test]

--- a/src/Shouldly/ShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldBeTestExtensions.cs
@@ -20,7 +20,7 @@ namespace Shouldly
 
         public static void ShouldBeTypeOf(this object actual, Type expected)
         {
-            actual.AssertAwesomely(Is.InstanceOf(expected), actual, expected);
+            actual.AssertAwesomely(Is.InstanceOf(expected), actual.GetType(), expected);
         }
 
         public static void ShouldNotBeTypeOf<T>(this object actual)


### PR DESCRIPTION
In the current build if you start a new project and use NuGet to install Shoudly the generic overload of ShouldBeTypeOf<T> does not give you a good message.  It give you:

> YourProject.Tests.ShouldBeTypeOfTest threw exception: 
> System.IO.IOException: The device is not ready.

I have also updated the implementation so that the message generated makes more sense.  For example:

``` c#
8.ShouldBeTypeOf<double>();
```

Generates:

> 8 should be type of System.Double but was System.Int32

Instead of:

> 2 should be type of System.Double but was 8
