### PR TITLE
added string.ShouldBe(string, Case)

### DIFF
--- a/src/Shouldly.Tests/ShouldBeStringTests.cs
+++ b/src/Shouldly.Tests/ShouldBeStringTests.cs
@@ -55,5 +55,19 @@ namespace Shouldly.Tests
         {
             "Cheese".ShouldMatch(@"C.e{2}s[e]");
         }
+
+        [Test]
+        public void ShouldBe_GivenCaseInsensitiveOptionAndStringsDifferingOnlyInCase_ShouldPass()
+        {
+            "SamplE".ShouldBe("sAMPLe", Case.Insensitive);
+        }
+
+        [Test]
+        public void ShouldBe_GivenCaseSensitiveOptionAndStringsDifferingOnlyInCase_ShouldFail()
+        {
+            Should.Error(() =>
+                         "SamplE".ShouldBe("sAMPLe", Case.Sensitive),
+                         "'SamplE' should be 'sAMPLe' but was 'SamplE'");
+        }
     }
 }

--- a/src/Shouldly/Case.cs
+++ b/src/Shouldly/Case.cs
@@ -1,0 +1,8 @@
+namespace Shouldly
+{
+    public enum Case
+    {
+        Sensitive,
+        Insensitive
+    }
+}

--- a/src/Shouldly/ShouldBeStringTestExtensions.cs
+++ b/src/Shouldly/ShouldBeStringTestExtensions.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using System.Diagnostics;
 using NUnit.Framework;
 
@@ -8,6 +7,17 @@ namespace Shouldly
     [ShouldlyMethods]
     public static class ShouldBeStringTestExtensions
     {
+        /// <summary>
+        /// Perform a string comparison, specifying the desired case sensitivity
+        /// </summary>
+        public static void ShouldBe(this string actual, string expected, Case @case)
+        {
+            var constraint = (@case == Case.Sensitive)
+                                 ? Is.EqualTo(expected)
+                                 : Is.EqualTo(expected).IgnoreCase;
+            actual.AssertAwesomely(constraint, actual, expected);
+        }
+
         /// <summary>
         /// Strip out whitespace (whitespace, tabs, line-endings, etc) and compare the two strings
         /// </summary>

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Case.cs" />
     <Compile Include="Create.cs" />
     <Compile Include="DifferenceHighlighting\DifferenceHighlighter.cs" />
     <Compile Include="DifferenceHighlighting\EnumerableHighlighter.cs" />


### PR DESCRIPTION
`string.ShouldBe(string, Case)` asserts that two strings are equal with a case sensitivity constraint that can be either `Case.Sensitive` or `Case.Insensitive`.

Please see https://github.com/shouldly/shouldly/pull/28 for background info on this patch.
