### PR TITLE
#37 - Truncate error string "actual" output on ShouldContain to 100 chars

### DIFF
--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ShouldlyMessageTests.cs" />
     <Compile Include="ShouldlyRhinoTests.cs" />
+    <Compile Include="ShouldlyStringExtensionTests.cs" />
     <Compile Include="ShouldNotThrowTests.cs" />
     <Compile Include="ShouldThrowTests.cs" />
     <Compile Include="Widget.cs" />

--- a/src/Shouldly.Tests/ShouldlyMessageTests.cs
+++ b/src/Shouldly.Tests/ShouldlyMessageTests.cs
@@ -51,12 +51,22 @@ namespace Shouldly.Tests
         }
 
         [Test]
-        public void ShouldlyMessage_WhenComparingLongStrings_ShouldLimitTheMessageTo100Characters()
+        public void ShouldlyMessage_WhenComparingStringsOver100Characters_ShouldLimitTheMessageTo100Characters()
         {
-            var longString = new string('a', 51);
+            var longString = new string('a', 110);
             Should.Error(
               () => longString.ShouldContain("zzzz"),
-              string.Format("() => longString should contain \"zzzz\" but was \"{0}\"",longString.Substring(0,51))
+              string.Format("() => longString should contain \"zzzz\" but was \"{0}\"",longString.Substring(0,100))
+          );
+        }
+
+        [Test]
+        public void ShouldlyMessage_WhenComparingStringsUnder100Characters_ShouldNotLimitTheMessage()
+        {
+            var longString = new string('a', 80);
+            Should.Error(
+              () => longString.ShouldContain("zzzz"),
+              string.Format("() => longString should contain \"zzzz\" but was \"{0}\"", longString)
           );
         }
 

--- a/src/Shouldly.Tests/ShouldlyStringExtensionTests.cs
+++ b/src/Shouldly.Tests/ShouldlyStringExtensionTests.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+
+namespace Shouldly.Tests
+{
+    [TestFixture]
+    public class ShouldlyStringExtensionTests
+    {
+        [Test]
+        public void ClipShouldNotReduceTheSizeOfAStringSmallerThanTheMaximumLength()
+        {
+            "small".ShouldMatch("small".Clip(10));
+        }
+
+        [Test]
+        public void ClipShouldReduceTheSizeOfAStringLongerThanTheMaximumLength()
+        {
+            "largestrin".ShouldMatch("largestringtoclip".Clip(10));
+        }
+
+        [Test]
+        public void ClipShouldHandleEmptyStrings()
+        {
+            string.Empty.ShouldMatch(string.Empty.Clip(10));
+        }
+
+    }
+}

--- a/src/Shouldly/ShouldBeStringTestExtensions.cs
+++ b/src/Shouldly/ShouldBeStringTestExtensions.cs
@@ -51,7 +51,7 @@ namespace Shouldly
 
         public static void ShouldContain(this string actual, string expected)
         {
-            actual.AssertAwesomely(Is.StringContaining(expected).IgnoreCase, actual, expected);
+            actual.AssertAwesomely(Is.StringContaining(expected).IgnoreCase, actual.Clip(100), expected);
         }
 
         public static void ShouldNotContain(this string actual, string expected)

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -76,6 +76,7 @@
     <Compile Include="ShouldlyMessageGenerators.cs" />
     <Compile Include="ShouldlyMethodsAttribute.cs" />
     <Compile Include="ShouldlyRhinoExtensions.cs" />
+    <Compile Include="ShouldlyStringExtensions.cs" />
     <Compile Include="ShouldThrowTestExtensions.cs" />
     <Compile Include="StringHelpers.cs" />
     <Compile Include="ChuckedAWobbly.cs" />

--- a/src/Shouldly/ShouldlyStringExtensions.cs
+++ b/src/Shouldly/ShouldlyStringExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Shouldly
+{
+    internal static class ShouldlyStringExtensions
+    {
+        internal static string Clip(this string stringToClip, int maximumStringLength)
+        {
+            if (stringToClip.Length > maximumStringLength)
+            {
+                stringToClip = stringToClip.Substring(0, maximumStringLength);
+            }
+            return stringToClip;
+        }
+
+
+    }
+}


### PR DESCRIPTION
I've put in some code to limit the "actual" part of the error message returned by a ShouldContain to 100 chars max.
