### PR TITLE
String.ShouldBeCloseTo should ignore case

### DIFF
--- a/src/Shouldly/ShouldBeStringTestExtensions.cs
+++ b/src/Shouldly/ShouldBeStringTestExtensions.cs
@@ -27,7 +27,7 @@ namespace Shouldly
         }
 
         /// <summary>
-        /// Strip out whitespace (whitespace, tabs, line-endings, etc) and compare the two strings
+        /// Strip out whitespace (whitespace, tabs, line-endings, etc) and compare the two strings case-insensitively
         /// </summary>
         /// <param name="actual"></param>
         /// <param name="expected"></param>


### PR DESCRIPTION
I reckon it should! Of course it might have been a deliberate decision not to, but I assumed it would ignore case when writing a test. Perhaps a separate method would be a better idea - String.ShouldBeCloseToIgnoringCase, but it seems a little wordy.
