### PR TITLE
#53 add ShouldBe with tolerance overrides for decimal values

### DIFF
--- a/src/Shouldly.Tests/ShouldBeTests.cs
+++ b/src/Shouldly.Tests/ShouldBeTests.cs
@@ -91,6 +91,19 @@ namespace Shouldly.Tests
         }
 
         [Test]
+        public void ShouldNotBe_WithDecimalEnumerable_ShouldAllowTolerance()
+        {
+            var firstSet = new[] { 1.23m, 2.34m, 3.45001m };
+            var passingSet = new[] { 1.2301m, 2.34m, 3.45m };
+            var failingSet = new[] { 1.2301m, 2.34m, 3.47m };
+            const decimal tolerance = 0.01m;
+
+            firstSet.ShouldNotBe(passingSet);
+            firstSet.ShouldNotBe(failingSet, tolerance);
+            Shouldly.Should.Throw<ChuckedAWobbly>(() => firstSet.ShouldNotBe(passingSet, tolerance));
+        }
+
+        [Test]
         public void ShouldBeTypeOf_ShouldNotThrowForStrings()
         {
             "Sup yo".ShouldBeTypeOf(typeof(string));

--- a/src/Shouldly/ShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldBeTestExtensions.cs
@@ -64,12 +64,17 @@ namespace Shouldly
             actual.AssertAwesomely(Is.EqualTo(expected).Within(tolerance), actual, expected);
         }
 
+        public static void ShouldNotBe(this decimal actual, decimal expected, decimal tolerance)
+        {
+            actual.AssertAwesomely(Is.Not.EqualTo(expected).Within(tolerance), actual, expected);
+        }
+
         public static void ShouldBe(this IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance)
         {
             actual.AssertAwesomely(Is.EqualTo(expected).Within(tolerance), actual, expected);
         }
 
-        public static void ShouldNotBe(this decimal actual, decimal expected, decimal tolerance)
+        public static void ShouldNotBe(this IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance)
         {
             actual.AssertAwesomely(Is.Not.EqualTo(expected).Within(tolerance), actual, expected);
         }


### PR DESCRIPTION
Ok I fixed the whitespace fudge from the previous PR. This adds two overloads to `ShouldBeTestExtensions` to support tolerances with `decimal` and `IEnumerable<decimal>` inputs.
