### PR TITLE
Issue 58 shouldbeoneof

### DIFF
--- a/src/Shouldly.Tests/EnumerableHighlighterTests.cs
+++ b/src/Shouldly.Tests/EnumerableHighlighterTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Shouldly.DifferenceHighlighting;
+
+namespace Shouldly.Tests
+{
+    [TestFixture]
+    public class EnumerableHighlighterTests
+    {
+        private EnumerableHighlighter _context = new EnumerableHighlighter(new DifferenceHighlighter());
+
+        [Test]
+        public void CanProcessTwoEnumerables()
+        {
+            _context
+                .CanProcess(new[]{1,2,3}, new[]{4,5,6})
+                .ShouldBe(true);
+        }
+
+        [Test]
+        public void CannotProcessTwoInts()
+        {
+            _context
+                .CanProcess(1, 2)
+                .ShouldBe(false);
+        }
+
+        [Test]
+        public void CannotProcessEnumerableActualAndIntExpected()
+        {
+            _context
+                .CanProcess(new[]{1,2,3}, 4)
+                .ShouldBe(false);
+        }
+
+        [Test]
+        public void CannotProcessStringActualAndStringExpected()
+        {
+            _context
+                .CanProcess("one", "two")
+                .ShouldBe(false);
+        }
+
+        [Test]
+        public void CannotProcessEnumerableActualAndStringExpected()
+        {
+            _context
+                .CanProcess(new[]{1,2,3}, "four")
+                .ShouldBe(false);
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeOneOfTests.cs
+++ b/src/Shouldly.Tests/ShouldBeOneOfTests.cs
@@ -20,5 +20,13 @@ namespace Shouldly.Tests
         {
             Shouldly.Should.Throw<ChuckedAWobbly>(() => 5.ShouldBeOneOf(1, 2, 3));
         }
+
+        [Test]
+        public void ErrorMessageShouldBeNiceWhenValueIsNotInTheParams()
+        {
+            Should.Error(
+                () => 5.ShouldBeOneOf(1, 2, 3),
+                "() => 5 should be one of [1, 2, 3] but was 5");
+        }
     }
 }

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -53,6 +53,7 @@
   <ItemGroup>
     <Compile Include="DifferenceHighlighterHelpersTests.cs" />
     <Compile Include="EnumerableExtensionHelpers.cs" />
+    <Compile Include="EnumerableHighlighterTests.cs" />
     <Compile Include="Should.cs" />
     <Compile Include="ShouldBeDictionaryTests.cs" />
     <Compile Include="ShouldBeEnumerableTests.cs" />

--- a/src/Shouldly/DifferenceHighlighting/EnumerableHighlighter.cs
+++ b/src/Shouldly/DifferenceHighlighting/EnumerableHighlighter.cs
@@ -28,7 +28,9 @@ namespace Shouldly.DifferenceHighlighting
         {
             return expected != null && actual != null
                    && (expected is IEnumerable)
-                   && !(expected is string);
+                   && !(expected is string)
+                   && (actual is IEnumerable)
+                   && !(actual is string);
         }
 
         public string HighlightDifferences<T1, T2>(T1 expected, T2 actual)

--- a/src/Shouldly/ShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldBeTestExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using NUnit.Framework;
 
 namespace Shouldly
@@ -96,7 +97,8 @@ namespace Shouldly
 
         public static void ShouldBeOneOf<T>(this T actual, params T[] expected)
         {
-            expected.ShouldContain(actual);
+            if (!expected.Contains(actual))
+                throw new ChuckedAWobbly(new ShouldlyMessage(expected, actual).ToString());
         }
     }
 }


### PR DESCRIPTION
Sorry about the line endings, I've got core.autocrlf set to true but my git-fu is too weak to figure out the problem.

I was just using enums as an example. This should be pretty generic. The error message is fairly understandable. I had to make a slight change to `DifferenceHighlighter` so it didn't get picked up and throw an `InvalidCastException` with the `actual` not being `IEnumerable`.
