### PR TITLE
ShouldAllBe for IEnumerables

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEnumerableTests.cs
+++ b/src/Shouldly.Tests/ShouldBeEnumerableTests.cs
@@ -31,6 +31,13 @@ namespace Shouldly.Tests
         }
 
         [Test]
+        public void ShouldAllBe_WithPredicate_WhenTrue_ShouldNotThrow()
+        {
+            new[] { 1, 2, 3 }.ShouldAllBe(x => x < 4);
+        }
+
+
+        [Test]
         public void ShouldlyMessage_WhenComparingMatchingStringsOver100Characters_ShouldNotClipStringForComparison()
         {
             var longString = new string('a', 110) + "zzzz";

--- a/src/Shouldly.Tests/ShouldlyMessageTests.cs
+++ b/src/Shouldly.Tests/ShouldlyMessageTests.cs
@@ -136,6 +136,14 @@ namespace Shouldly.Tests
         }
 
         [Test]
+        public void ShouldAllBe()
+        {
+            Should.Error(() =>
+                         new[] { 1, 2, 3 }.ShouldAllBe(x => x + 4 < 7),
+                         "new[]{1,2,3} should all be an element satisfying the condition ((x + 4) < 7) but does not");
+        }
+
+        [Test]
         public void ShouldBeEmpty()
         {
             IEnumerable<object> objects = null;

--- a/src/Shouldly/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldBeEnumerableTestExtensions.cs
@@ -36,6 +36,13 @@ namespace Shouldly
                 throw new ChuckedAWobbly(new ShouldlyMessage(elementPredicate.Body).ToString());
         }
 
+        public static void ShouldAllBe<T>(this IEnumerable<T> actual, Expression<Func<T, bool>> elementPredicate)
+        {
+            var condition = elementPredicate.Compile();
+            if (actual.Any(v => !condition(v)))
+                throw new ChuckedAWobbly(new ShouldlyMessage(elementPredicate.Body).ToString());
+        }
+
         public static void ShouldBeEmpty<T>(this IEnumerable<T> actual)
         {
             if (actual == null || (actual != null && actual.Count() != 0))


### PR DESCRIPTION
Hi!

First, I really like Shouldly (and so do my colleagues), so thanks a lot for it! 

Now, I found that while working with enumerables, I'd often want something that verifies that a certain condition holds for each element in an enumerable.

I discovered that `ShouldNotContain` with a negative condition actually does the trick, but it makes the test somewhat difficult to read due to the double negation.

For example,

``` csharp
// verify that all words start with a "y"
var arr = new[] { "yes", "yay", "yellow" }

arr.ShouldNotContain(s => !s.StartsWith("y"));
```

Can now be written as

``` csharp
arr.ShouldAllBe(s => s.StartsWith("y"));
```

Good idea? I included the obvious unit tests (mostly half-copied from existing tests).

ps. if you're looking for some help in maintaining Shouldly, I'd be happy to. I don't have any internet fame or credentials to speak of, though.
