### PR TITLE
ShouldBeTypeOf should return the object

### DIFF
--- a/src/Shouldly.Tests/ShouldBeTests.cs
+++ b/src/Shouldly.Tests/ShouldBeTests.cs
@@ -80,6 +80,14 @@ namespace Shouldly.Tests
         }
 
         [Test]
+        public void ShouldBeTypeOfWithGenericParameter_ShouldReturnThis()
+        {
+            string str = "Sup yo";
+            string ret = str.ShouldBeTypeOf<string>();
+            ret.ShouldBe(str);
+        }
+
+        [Test]
         public void ShouldNotBeTypeOf_ShouldNotThrowForNonMatchingType()
         {
             "Sup yo".ShouldNotBeTypeOf(typeof(int));

--- a/src/Shouldly/ShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldBeTestExtensions.cs
@@ -14,9 +14,10 @@ namespace Shouldly
             actual.AssertAwesomely(Is.EqualTo(expected), actual, expected);
         }
 
-        public static void ShouldBeTypeOf<T>(this object actual)
+        public static T ShouldBeTypeOf<T>(this object actual)
         {
             ShouldBeTypeOf(actual, typeof(T));
+            return (T) actual;
         }
 
         public static void ShouldBeTypeOf(this object actual, Type expected)


### PR DESCRIPTION
While writing some test, I frequently came across this pattern:

``` csharp
bar.ShouldBeTypeOf<Foo>();
var baz = (Foo) bar;
// do something with baz
```

It would be great if `ShouldBeTypeOf` just would return the object casted to the correct type, so I'd only need to write

``` csharp
var baz = bar.ShouldBeTypeOf<Foo>();
// do something with baz
```

Of course this will break the ABI, so a version bump or a different method name, like `ShouldBeTypeOfAndReturn` or something like that would be necessary...
