### PR TITLE
Add ShouldNotBe for IEnumerables

### DIFF
--- a/src/Shouldly.Tests/ShouldBeStringTests.cs
+++ b/src/Shouldly.Tests/ShouldBeStringTests.cs
@@ -5,6 +5,40 @@ namespace Shouldly.Tests
     [TestFixture]
     public class ShouldBeStringTests
     {
+        public class ShouldBe
+        {
+            [Test]
+            public void ShouldBe_ArrayOfCharsComparedToString_WhenSame_ShouldNotThrow()
+            {
+                (new[] { 'a', 'b', 'c'}).ShouldBe("abc");
+            }
+
+            [Test]
+            public void ShouldBe_ArrayOfCharsComparedToString_WhenNotSame_ShouldThrow()
+            {
+                Should.Error(
+                    () => (new[] { 'a', 'b', 'c' }).ShouldBe("abcd"),
+                    "() => (new[] { 'a', 'b', 'c' }) should be \"abcd\" but was [a, b, c]");
+            }
+        }
+
+        public class ShouldNotBe
+        {
+            [Test]
+            public void ShouldNotBe_ArrayOfCharsComparedToString_WhenSame_ShouldThrow()
+            {
+                Should.Error(
+                    () => (new[]{'a', 'b', 'c'}).ShouldNotBe("abc"),
+                    "() => (new[] { 'a', 'b', 'c' }) should not be \"abc\" but was [a, b, c]");
+            }
+
+            [Test]
+            public void ShouldNotBe_ArrayOfCharsComparedToString_WhenNotSame_ShouldNotThrow()
+            {
+                (new[] {'a', 'b', 'c'}).ShouldNotBe("abcd");
+            }
+        }
+
         [Test]
         public void ShouldContainWithoutWhitespace_IsPrettyLoose()
         {

--- a/src/Shouldly/ShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldBeTestExtensions.cs
@@ -19,6 +19,11 @@ namespace Shouldly
             actual.AssertAwesomely(v => Is.Equal(v, expected, ignoreOrder), actual, expected);
         }
 
+        public static void ShouldNotBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool ignoreOrder = false)
+        {
+            actual.AssertAwesomely(v => !Is.Equal(v, expected, ignoreOrder), actual, expected);
+        }
+
         public static T ShouldBeAssignableTo<T>(this object actual)
         {
             ShouldBeAssignableTo(actual, typeof(T));


### PR DESCRIPTION
There's no `ShouldNotBe` for `IEnumerables`. This still won't work at all for normal enumerables but it works for strings, comparing to arrays of chars.
