### PR TITLE
Add tests around the examples shown on the shouldly.github.io documentat...

### DIFF
--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ShouldlyMessageTests.cs" />
     <Compile Include="ShouldlyStringExtensionTests.cs" />
+    <Compile Include="ShouldlyWebsiteExampleTests.cs" />
     <Compile Include="ShouldNotBeInRangeTests.cs" />
     <Compile Include="ShouldNotBeOneOfTests.cs" />
     <Compile Include="ShouldThrowAndNotThrowTests.cs" />

--- a/src/Shouldly.Tests/ShouldlyWebsiteExampleTests.cs
+++ b/src/Shouldly.Tests/ShouldlyWebsiteExampleTests.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Shouldly.Tests
+{
+    [TestFixture]
+    public class ShouldlyWebsiteExampleTests
+    {
+        // Tests for the examples shown on http://shouldly.github.io/ (https://github.com/shouldly/shouldly.github.com)
+
+        public class ContestantPoints
+        {
+            [Test]
+            public void NUnit_ContestantPointsShouldBe1337()
+            {
+                var contestant = new Contestant() {Points = 0};
+
+                var exception =
+                    Shouldly.Should.Throw<Exception>(
+                        () => Assert.That(contestant.Points, NUnit.Framework.Is.EqualTo(1337)));
+
+                exception.Message.ShouldContainWithoutWhitespace("Expected: 1337 But was: 0");
+            }
+
+            [Test]
+            public void Shouldly_ContestantPointsShouldBe1337()
+            {
+                var contestant = new Contestant {Points = 0};
+
+                Should.Error(
+                    () => contestant.Points.ShouldBe(1337),
+                    "() => contestant.Points should be 1337 but was 0");
+            }
+
+            [Test]
+            public void Shouldly_ContestantPointsShouldBe1337_HappyPath()
+            {
+                var contestant = new Contestant {Points = 0};
+
+                contestant.Points.ShouldBe(0);
+            }
+
+            private class Contestant
+            {
+                public int Points { get; set; }
+            }
+        }
+
+        public class MapIndexOfBoo
+        {
+            private IList<string> GetMap()
+            {
+                return new[]
+                {
+                    "aoo",
+                    "boo",
+                    "coo"
+                };
+            }
+
+            [Test]
+            public void NUnit_IndexOfBoo()
+            {
+                var map = GetMap();
+
+                var exception =
+                    Shouldly.Should.Throw<Exception>(
+                        () => Assert.That(map.IndexOf("boo"), NUnit.Framework.Is.EqualTo(2)));
+
+                exception.Message.ShouldContainWithoutWhitespace("Expected: 2 But was: 1");
+            }
+
+            [Test]
+            public void Shouldly_IndexOfBoo()
+            {
+                var map = GetMap();
+
+                Should.Error(
+                    () => map.IndexOf("boo").ShouldBe(2),
+                    "() => map.IndexOf(\"boo\") should be 2 but was 1");
+            }
+
+            [Test]
+            public void Shouldly_IndexOfBoo_HappyPath()
+            {
+                var map = GetMap();
+
+                map.IndexOf("boo").ShouldBe(1);
+            }
+        }
+
+        public class CompareTwoCollections
+        {
+            [Test]
+            public void Shouldly_CompareTwoCollections()
+            {
+                Should.Error(
+                    () => (new[] {1, 2, 3}).ShouldBe(new[] {1, 2, 4}),
+                    "() => (new[] {1, 2, 3}) should be [1, 2, 4] but was [1, 2, 3] difference [1, 2, *3*]");
+            }
+
+            [Test]
+            public void Shouldly_CompareTwoCollections_HappyPath()
+            {
+                (new[] {1, 2, 3}).ShouldBe(new[] {1, 2, 3});
+            }
+        }
+
+        public class ShouldThrowException
+        {
+            [Test]
+            public void Shouldly_ShouldThrowException()
+            {
+                var widget = new Widget();
+
+                Shouldly.Should.Throw<ArgumentOutOfRangeException>(() => widget.Twist(-1));
+            }
+
+            [Test]
+            public void Shouldly_ShouldNotThrowException()
+            {
+                var widget = new Widget();
+
+                Shouldly.Should.NotThrow(() => widget.Twist(5));
+            }
+
+            [Test]
+            public void Shouldly_ShouldErrorIfCatchingExceptionOfWrongType()
+            {
+                var widget = new Widget();
+
+                Should.Error(
+                    () => Shouldly.Should.Throw<ArgumentOutOfRangeException>(() => widget.Twist(-2)),
+                    "() => Shouldly.Should throw System.ArgumentOutOfRangeException but was System.InvalidOperationException");
+            }
+
+            [Test]
+            public void Shouldly_ShouldErrorIfNoExceptionWasThrown()
+            {
+                var widget = new Widget();
+
+                Should.Error(
+                    () => Shouldly.Should.Throw<ArgumentOutOfRangeException>(() => widget.Twist(5)),
+                    "() => Shouldly.Should throw System.ArgumentOutOfRangeException but does not");
+            }
+
+            private class Widget
+            {
+                public void Twist(int i)
+                {
+                    if (i == -1)
+                    {
+                        throw new ArgumentOutOfRangeException();
+                    }
+
+                    if (i == -2)
+                    {
+                        throw new InvalidOperationException();
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
...ion site

Addresses some concerns raised in #111

Tests for each documented example is grouped together via a container class. The syntax and error message generated should be compared with and used with Shouldly's documentation. Both the NUnit and Shouldly tests are shown where applicable.

Each group also includes happy path tests showing a passing assertion. The happy path for collections is current failing (#100) so this should probably be merged after that issue is resolved, not before.
