### PR TITLE
Fix hardcoded datetimes in tests

### DIFF
--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeOffsetScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeOffsetScenario.cs
@@ -13,7 +13,12 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "date should be within 01:00:00 of 1/06/2000 1:00:01 AM +00:00 but was 1/06/2000 12:00:00 AM +00:00"; }
+            get 
+            { 
+                return String.Format("date should be within {0} of {1} but was {2}",
+                    TimeSpan.FromHours(1), new DateTimeOffset(new DateTime(2000, 6, 1, 1, 0, 1), TimeSpan.Zero),
+                        new DateTimeOffset(new DateTime(2000, 6, 1), TimeSpan.Zero)); 
+            }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeScenario.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Shouldly.Tests.TestHelpers;
 
 namespace Shouldly.Tests.ShouldBe.WithTolerance
@@ -16,7 +13,11 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "date should be within 01:00:00 of 1/06/2000 1:00:01 AM but was 1/06/2000 12:00:00 AM"; }
+            get 
+            { 
+                return String.Format("date should be within {0} of {1} but was {2}",
+                    TimeSpan.FromHours(1), new DateTime(2000, 6, 1, 1, 0, 1), new DateTime(2000, 6, 1)); 
+            }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldNotBe/WithTolerance/DateTimeOffsetScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBe/WithTolerance/DateTimeOffsetScenario.cs
@@ -13,7 +13,13 @@ namespace Shouldly.Tests.ShouldNotBe.WithTolerance
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "date should not be within 01:30:00 of 1/06/2000 1:00:01 AM +00:00 but was 1/06/2000 12:00:00 AM +00:00"; }
+            get 
+            { 
+                return String.Format("date should not be within {0} of {1} but was {2}",
+                    TimeSpan.FromHours(1.5),
+                        new DateTimeOffset(new DateTime(2000, 6, 1, 1, 0, 1), TimeSpan.Zero),
+                            new DateTimeOffset(new DateTime(2000, 6, 1), TimeSpan.Zero)); 
+            }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldNotBe/WithTolerance/DateTimeScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBe/WithTolerance/DateTimeScenario.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Shouldly.Tests.TestHelpers;
 
 namespace Shouldly.Tests.ShouldNotBe.WithTolerance
@@ -16,7 +13,11 @@ namespace Shouldly.Tests.ShouldNotBe.WithTolerance
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "date should not be within 01:30:00 of 1/06/2000 1:00:01 AM but was 1/06/2000 12:00:00 AM"; }
+            get 
+            { 
+                return String.Format("date should not be within {0} of {1} but was {2}", 
+                    TimeSpan.FromHours(1.5), new DateTime(2000, 6, 1, 1, 0, 1), new DateTime(2000, 6, 1)); 
+            }
         }
 
         protected override void ShouldPass()


### PR DESCRIPTION
Now tests do not depend on locale.
