### PR TITLE
Some minor clean ups. 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1340,7 +1340,6 @@ Shouldly.ChuckedAWobbly :
 ... and stops further execution and assertion. But the following is a better test which ...
 
 ```c#
-// NOTE: Currently not in the latest Nuget version of Shouldly (version - 2.3.0 )
 [Test]
 public void ShouldSatisfyAllConditions()
 {

--- a/src/Shouldly/ShouldSatisfyAllConditionsTestExtensions.cs
+++ b/src/Shouldly/ShouldSatisfyAllConditionsTestExtensions.cs
@@ -7,7 +7,7 @@ using JetBrains.Annotations;
 
 namespace Shouldly
 {
-    //[DebuggerStepThrough]
+    [DebuggerStepThrough]
     [ShouldlyMethods]
     public static class ShouldSatisfyAllConditionsTestExtensions
     {


### PR DESCRIPTION
Updated documentation to remove the 'Not currently available in nuget version 2.3.0' comment. Also reenabled a 'DebuggerStepThrough' attribute that was temporarily commented out during development.
