### PR TITLE
Show count when .ShouldBeEmpty() fails for IEnumerable

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEmpty/ArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEmpty/ArrayScenario.cs
@@ -11,7 +11,7 @@ namespace Shouldly.Tests.ShouldBeEmpty
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1 } should be empty but was [1]"; }
+            get { return "new[] { 1 } should be empty but had 1 item(s) and was [1]"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBeEmpty/ArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEmpty/ArrayScenario.cs
@@ -11,7 +11,7 @@ namespace Shouldly.Tests.ShouldBeEmpty
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1 } should be empty but had 1 item(s) and was [1]"; }
+            get { return "new[] { 1 } should be empty but had 1 item and was [1]"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly/MessageGenerators/ShouldBeEmptyMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeEmptyMessageGenerator.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Shouldly.MessageGenerators
@@ -17,15 +19,19 @@ namespace Shouldly.MessageGenerators
             const string format = @"
     {0}
             {1}
-        but was {2}";
+        but{2} was {3}";
 
             var codePart = context.CodePart;
             var expectedValue = context.Expected.Inspect();
 
             if (context.IsNegatedAssertion)
-                return String.Format(format, codePart, context.ShouldMethod.PascalToSpaced(), context.Expected == null ? "null" : "");
+                return String.Format(format, codePart, context.ShouldMethod.PascalToSpaced(), string.Empty, context.Expected == null ? "null" : "");
 
-            return String.Format(format, codePart, context.ShouldMethod.PascalToSpaced(), expectedValue);
+            return String.Format(format, codePart, context.ShouldMethod.PascalToSpaced(),
+                !(context.Expected is string) && context.Expected is IEnumerable
+                    ? string.Format(" had {0} item(s) and", context.Expected.As<IEnumerable>().Cast<object>().Count())
+                    : string.Empty,
+                expectedValue);
         }
     }
 }

--- a/src/Shouldly/MessageGenerators/ShouldBeEmptyMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeEmptyMessageGenerator.cs
@@ -27,9 +27,10 @@ namespace Shouldly.MessageGenerators
             if (context.IsNegatedAssertion)
                 return String.Format(format, codePart, context.ShouldMethod.PascalToSpaced(), string.Empty, context.Expected == null ? "null" : "");
 
+            var count = (context.Expected ?? Enumerable.Empty<object>()).As<IEnumerable>().Cast<object>().Count();
             return String.Format(format, codePart, context.ShouldMethod.PascalToSpaced(),
                 !(context.Expected is string) && context.Expected is IEnumerable
-                    ? string.Format(" had {0} item(s) and", context.Expected.As<IEnumerable>().Cast<object>().Count())
+                ? string.Format(" had {0} item{1} and", count, count == 1 ? string.Empty : "s")
                     : string.Empty,
                 expectedValue);
         }


### PR DESCRIPTION
I'm finding the count is what I really want to know, rather than the contents of the array. The contents of said array are not useful anyway when it's not a primitive type (where .ToString() shows a useful value).

This will show the number of items before the array content.

Perhaps this should be elsewhere too? Thoughts?