### PR TITLE
Extend core extensions with custom message

### DIFF
--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/ActualIsNullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/ActualIsNullScenario.cs
@@ -9,12 +9,14 @@ namespace Shouldly.Tests.ShouldBe.EnumerableType
         {
             IEnumerable<int> something = null;
             // ReSharper disable once ExpressionIsAlwaysNull
-            something.ShouldBe(new[] { 1, 2, 3 });
+            something.ShouldBe(new[] { 1, 2, 3 }, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "something should be [1, 2, 3] but was null"; }
+            get { return "something should be [1, 2, 3] but was null" +
+                         " Additional Info:" +
+                         " Some additional context"; }
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/DifferentCollectionTypeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/DifferentCollectionTypeScenario.cs
@@ -7,17 +7,19 @@ namespace Shouldly.Tests.ShouldBe.EnumerableType
     {
         protected override void ShouldPass()
         {
-            new List<int> { 1, 2, 3 }.ShouldBe(new[] { 1, 2, 3 });
+            new List<int> { 1, 2, 3 }.ShouldBe(new[] { 1, 2, 3 }, false, () => "Some additional context");
         }
 
         protected override void ShouldThrowAWobbly()
         {
-            new List<int> { 1, 2, 3 }.ShouldBe(new[] { 1, 3, 2 });
+            new List<int> { 1, 2, 3 }.ShouldBe(new[] { 1, 3, 2 }, false, "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new List<int> { 1, 2, 3 } should be [1, 3, 2] but was [1, 2, 3] difference [1, *2*, *3*]"; }
+            get { return "new List<int> { 1, 2, 3 } should be [1, 3, 2] but was [1, 2, 3] difference [1, *2*, *3*]" +
+                         " Additional Info:" +
+                         " Some additional context"; }
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/EnumerableOfComplexTypeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/EnumerableOfComplexTypeScenario.cs
@@ -10,7 +10,7 @@ namespace Shouldly.Tests.ShouldBe.EnumerableType
 
         protected override void ShouldThrowAWobbly()
         {
-            _aEnumerable.ShouldBe(_bArray);
+            _aEnumerable.ShouldBe(_bArray, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
@@ -18,12 +18,14 @@ namespace Shouldly.Tests.ShouldBe.EnumerableType
             get { return "_aEnumerable " +
                          "should be [Name(Joeyjojoshabadoo Jr) Enabled(True)] " +
                          "but was [Name(Joe) Enabled(True)] " +
-                         "difference [*Name(Joe) Enabled(True)*]"; }
+                         "difference [*Name(Joe) Enabled(True)*] " +
+                         "Additional Info: " +
+                         "Some additional context"; }
         }
 
         protected override void ShouldPass()
         {
-            _aEnumerable.ShouldBe(_aEnumerable);
+            _aEnumerable.ShouldBe(_aEnumerable, () => "Some additonal context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfDecimalScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfDecimalScenario.cs
@@ -8,19 +8,21 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
         {
             var firstSet = new[] { 1.23m, 2.34m, 3.45001m };
             var secondSet = new[] { 1.4301m, 2.34m, 3.45m };
-            firstSet.ShouldBe(secondSet, 0.1m);
+            firstSet.ShouldBe(secondSet, 0.1m, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "firstSet should be within 0.1 of [1.4301, 2.34, 3.45] but was [1.23, 2.34, 3.45001] difference [*1.23*, 2.34, *3.45001*]"; }
+            get { return "firstSet should be within 0.1 of [1.4301, 2.34, 3.45] but was [1.23, 2.34, 3.45001] difference [*1.23*, 2.34, *3.45001*]" +
+                         " Additional Info:" +
+                         " Some additional context"; }
         }
 
         protected override void ShouldPass()
         {
             var firstSet = new[] { 1.23m, 2.34m, 3.45001m };
             var secondSet = new[] { 1.2301m, 2.34m, 3.45m };
-            firstSet.ShouldBe(secondSet, 0.01m);
+            firstSet.ShouldBe(secondSet, 0.01m, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeSameAs/BasicScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSameAs/BasicScenario.cs
@@ -9,7 +9,7 @@ namespace Shouldly.Tests.ShouldBeSameAs
             var zulu = new object();
             var tutsie = new object();
 
-            zulu.ShouldBeSameAs(tutsie);
+            zulu.ShouldBeSameAs(tutsie, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
@@ -17,7 +17,9 @@ namespace Shouldly.Tests.ShouldBeSameAs
             get
             {
                 //TODO maybe include GetHashCode?
-                return "zulu should be same as System.Object but was System.Object";
+                return "zulu should be same as System.Object but was System.Object" +
+                       " Additional Info:" +
+                       " Some additional context";
             }
         }
 
@@ -25,7 +27,7 @@ namespace Shouldly.Tests.ShouldBeSameAs
         {
             var zulu = new object();
 
-            zulu.ShouldBeSameAs(zulu);
+            zulu.ShouldBeSameAs(zulu, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotBe/BoolScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBe/BoolScenario.cs
@@ -6,18 +6,20 @@ namespace Shouldly.Tests.ShouldNotBe
     {
         protected override void ShouldPass()
         {
-            false.ShouldNotBe(true);
+            false.ShouldNotBe(true, () => "Some additional context");
         }
 
         protected override void ShouldThrowAWobbly()
         {
             const bool myFalseValue = false;
-            myFalseValue.ShouldNotBe(false);
+            myFalseValue.ShouldNotBe(false, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "myFalseValue should not be False but was False"; }
+            get { return "myFalseValue should not be False but was False" +
+                         " Additional Info:" +
+                         " Some additional context"; }
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotBeSameAs/BasicScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBeSameAs/BasicScenario.cs
@@ -8,12 +8,14 @@ namespace Shouldly.Tests.ShouldNotBeSameAs
         {
             var zulu = new object();
 
-            zulu.ShouldNotBeSameAs(zulu);
+            zulu.ShouldNotBeSameAs(zulu, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "zulu should not be same as System.Object but was System.Object"; }
+            get { return "zulu should not be same as System.Object but was System.Object" +
+                         " Additional Info:" +
+                         " Some additional context"; }
         }
 
         protected override void ShouldPass()
@@ -21,7 +23,7 @@ namespace Shouldly.Tests.ShouldNotBeSameAs
             var zulu = new object();
             var tutsie = new object();
 
-            zulu.ShouldNotBeSameAs(tutsie);
+            zulu.ShouldNotBeSameAs(tutsie, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly/Internals/ShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/ShouldlyAssertionContext.cs
@@ -31,6 +31,7 @@ namespace Shouldly
         public bool HasRelevantKey { get; set; }
 
         public bool IsNegatedAssertion { get { return ShouldMethod.Contains("Not"); } }
+        public string CustomMessage { get; set; }
 
         internal ShouldlyAssertionContext(object expected, object actual = null)
         {

--- a/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
+++ b/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
@@ -4,8 +4,11 @@ namespace Shouldly
 {
     internal static class ShouldlyCoreExtensions
     {
-        internal static void AssertAwesomely<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected)
+        internal static void AssertAwesomely<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected, Func<string> customMessage = null)
         {
+            if (customMessage == null)
+                customMessage = () => null;
+
             try
             {
                 if (specifiedConstraint(actual)) return;
@@ -15,11 +18,14 @@ namespace Shouldly
                 throw new ShouldAssertException(ex.Message, ex);
             }
 
-            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(originalExpected, originalActual).ToString());
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(originalExpected, originalActual, customMessage()).ToString());
         }
 
-        internal static void AssertAwesomelyIgnoringOrder<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected)
+        internal static void AssertAwesomelyIgnoringOrder<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected,  Func<string> customMessage = null)
         {
+            if (customMessage == null)
+                customMessage = () => null;
+
             try
             {
                 if (specifiedConstraint(actual)) return;
@@ -29,11 +35,14 @@ namespace Shouldly
                 throw new ShouldAssertException(ex.Message, ex);
             }
 
-            throw new ShouldAssertException(new ExpectedActualIgnoreOrderShouldlyMessage(originalExpected, originalActual).ToString());
+            throw new ShouldAssertException(new ExpectedActualIgnoreOrderShouldlyMessage(originalExpected, originalActual, customMessage()).ToString());
         }
 
-        internal static void AssertAwesomely<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected, object tolerance)
+        internal static void AssertAwesomely<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected, object tolerance, Func<string> customMessage = null )
         {
+            if (customMessage == null)
+                customMessage = () => null;
+
             try
             {
                 if (specifiedConstraint(actual)) return;
@@ -43,7 +52,7 @@ namespace Shouldly
                 throw new ShouldAssertException(ex.Message, ex);
             }
 
-            throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(originalExpected, originalActual, tolerance).ToString());
+            throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(originalExpected, originalActual, tolerance, customMessage()).ToString());
         }
     }
 }

--- a/src/Shouldly/MessageGenerators/ShouldBeWithinRangeMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeWithinRangeMessageGenerator.cs
@@ -9,7 +9,7 @@ namespace Shouldly.MessageGenerators
         {
             return context.ShouldMethod.StartsWith("Should")
                    && !context.ShouldMethod.Contains("Contain")
-                   && context.UnderlyingShouldMethod.GetParameters().Last().Name == "tolerance";
+                   && context.UnderlyingShouldMethod.GetParameters().Any(p => p.Name == "tolerance");
         }
 
         public override string GenerateErrorMessage(ShouldlyAssertionContext context)

--- a/src/Shouldly/MessageGenerators/ShouldContainWithinRangeMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldContainWithinRangeMessageGenerator.cs
@@ -8,7 +8,7 @@ namespace Shouldly.MessageGenerators
         {
             return context.ShouldMethod.StartsWith("Should")
                    && context.ShouldMethod.Contains("Contain")
-                   && context.UnderlyingShouldMethod.GetParameters().Last().Name == "tolerance";
+                   && context.UnderlyingShouldMethod.GetParameters().Any(p => p.Name == "tolerance");
         }
 
         public override string GenerateErrorMessage(ShouldlyAssertionContext context)

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ShouldBeTestExtensions.cs
@@ -11,61 +11,100 @@ namespace Shouldly
     {
         public static void ShouldBe<T>(this T actual, T expected)
         {
-            ShouldBe(actual, expected, (Func<string>)null);
+            ShouldBe(actual, expected, () => null);
         }
-        public static void ShouldBe<T>(this T actual, T expected, Func<string> message)
+        public static void ShouldBe<T>(this T actual, T expected, string customMessage)
+        {
+            ShouldBe(actual, expected, () => customMessage);
+        }
+        public static void ShouldBe<T>(this T actual, T expected, Func<string> customMessage)
         {
             if (ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName) || typeof(T) == typeof(string))
-                actual.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<T>()), actual, expected);
-            else 
-                actual.AssertAwesomely(v => Is.Equal(v, expected), actual, expected);
-        }
-        public static void ShouldBe<T>(this T actual, T expected, string message)
-        {
-            if (ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName) || typeof(T) == typeof(string))
-                actual.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<T>()), actual, expected);
-            else 
-                actual.AssertAwesomely(v => Is.Equal(v, expected), actual, expected);
+                actual.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<T>()), actual, expected, customMessage);
+            else
+                actual.AssertAwesomely(v => Is.Equal(v, expected), actual, expected, customMessage);
         }
 
         [ContractAnnotation("actual:null,expected:null => halt")]
         public static void ShouldNotBe<T>(this T actual, T expected)
         {
-            actual.AssertAwesomely(v => !Is.Equal(v, expected), actual, expected);
+            ShouldNotBe(actual, expected, () => null);
+        }
+        [ContractAnnotation("actual:null,expected:null => halt")]
+        public static void ShouldNotBe<T>(this T actual, T expected, string customMessage)
+        {
+            ShouldNotBe(actual, expected, () => customMessage);
+        }
+        [ContractAnnotation("actual:null,expected:null => halt")]
+        public static void ShouldNotBe<T>(this T actual, T expected, Func<string> customMessage )
+        {
+            actual.AssertAwesomely(v => !Is.Equal(v, expected), actual, expected, customMessage);
         }
 
         public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool ignoreOrder = false)
         {
+            ShouldBe(actual, expected, ignoreOrder, () => null);
+        }
+        public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool ignoreOrder, string customMessage)
+        {
+            ShouldBe(actual, expected, ignoreOrder, () => customMessage);
+        }
+        public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool ignoreOrder, Func<string> customMessage)
+        {
             if (!ignoreOrder && ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName))
             {
-                actual.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<IEnumerable<T>>()), actual, expected);
+                actual.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<IEnumerable<T>>()), actual, expected, customMessage);
             }
             else
             {
                 if (ignoreOrder)
                 {
-                    actual.AssertAwesomelyIgnoringOrder(v => Is.EqualIgnoreOrder(v, expected), actual, expected);
+                    actual.AssertAwesomelyIgnoringOrder(v => Is.EqualIgnoreOrder(v, expected), actual, expected, customMessage);
                 }
                 else
                 {
-                    actual.AssertAwesomely(v => Is.Equal(v, expected), actual, expected);
+                    actual.AssertAwesomely(v => Is.Equal(v, expected), actual, expected, customMessage);
                 }
             }
         }
 
         public static void ShouldBe(this IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance)
         {
-            actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance);
+            ShouldBe(actual, expected, tolerance, () => null);
+        }
+        public static void ShouldBe(this IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance, string customMessage)
+        {
+            ShouldBe(actual, expected, tolerance, () => customMessage);
+        }
+        public static void ShouldBe(this IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance, Func<string> customMessage)
+        {
+            actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
 
         public static void ShouldBeSameAs(this object actual, object expected)
         {
-            actual.AssertAwesomely(v => Is.Same(v, expected), actual, expected);
+            ShouldBeSameAs(actual, expected, () => null);
+        }
+        public static void ShouldBeSameAs(this object actual, object expected, string customMessage)
+        {
+            ShouldBeSameAs(actual, expected, () => customMessage);
+        }
+        public static void ShouldBeSameAs(this object actual, object expected, Func<string> customMessage)
+        {
+            actual.AssertAwesomely(v => Is.Same(v, expected), actual, expected, customMessage);
         }
 
         public static void ShouldNotBeSameAs(this object actual, object expected)
         {
-            actual.AssertAwesomely(v => !Is.Same(v, expected), actual, expected);
+            ShouldNotBeSameAs(actual, expected, () => null);
+        }
+        public static void ShouldNotBeSameAs(this object actual, object expected, string customMessage)
+        {
+            ShouldNotBeSameAs(actual, expected, () => customMessage);
+        }
+        public static void ShouldNotBeSameAs(this object actual, object expected, Func<string> customMessage)
+        {
+            actual.AssertAwesomely(v => !Is.Same(v, expected), actual, expected, customMessage);
         }
     }
 }

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -9,49 +9,54 @@ namespace Shouldly
 {
     internal class ExpectedShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedShouldlyMessage(object expected)
+        public ExpectedShouldlyMessage(object expected, string customMessage = null)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(expected);
+            ShouldlyAssertionContext.CustomMessage = customMessage;
         }
     }
 
     internal class ExpectedActualShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualShouldlyMessage(object expected, object actual)
+        public ExpectedActualShouldlyMessage(object expected, object actual, string customMessage = null)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(expected, actual);
             ShouldlyAssertionContext.HasRelevantActual = true;
+            ShouldlyAssertionContext.CustomMessage = customMessage;
         }
     }
 
     internal class ExpectedActualToleranceShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualToleranceShouldlyMessage(object expected, object actual, object tolerance)
+        public ExpectedActualToleranceShouldlyMessage(object expected, object actual, object tolerance, string customMessage = null)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(expected, actual);
             ShouldlyAssertionContext.Tolerance = tolerance;
             ShouldlyAssertionContext.HasRelevantActual = true;
+            ShouldlyAssertionContext.CustomMessage = customMessage;
         }
     }
 
     internal class ExpectedActualIgnoreOrderShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualIgnoreOrderShouldlyMessage(object expected, object actual)
+        public ExpectedActualIgnoreOrderShouldlyMessage(object expected, object actual, string customMessage = null)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(expected, actual);
             ShouldlyAssertionContext.IgnoreOrder = true;
             ShouldlyAssertionContext.HasRelevantActual = true;
+            ShouldlyAssertionContext.CustomMessage = customMessage;
         }
     }
 
     internal class ExpectedActualKeyShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualKeyShouldlyMessage(object expected, object actual, object key)
+        public ExpectedActualKeyShouldlyMessage(object expected, object actual, object key, string customMessage = null)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(expected, actual);
             ShouldlyAssertionContext.Key = key;
             ShouldlyAssertionContext.HasRelevantActual = true;
             ShouldlyAssertionContext.HasRelevantKey = true;
+            ShouldlyAssertionContext.CustomMessage = customMessage;
         }
     }
 
@@ -86,7 +91,14 @@ namespace Shouldly
 
         public override string ToString()
         {
-            return GenerateShouldMessage();
+            var message = GenerateShouldMessage();
+            if (_shouldlyAssertionContext.CustomMessage != null)
+            {
+                message += string.Format(@"
+    Additional Info:
+    {0}", _shouldlyAssertionContext.CustomMessage);
+            }
+            return message;
         }
 
         private string GenerateShouldMessage()


### PR DESCRIPTION
Added ability to specify customMessage in AssertAwesomely methods.
Added customMessage overloads for ShouldBeTestExtensions.
Updated tests for ShouldBeTestExtensions - not all of them (there's a lot), but enough to cover the different methods.
