### PR TITLE
Message generator for ShouldBeSubsetOf

### DIFF
--- a/src/Shouldly.Tests/ShouldBeSubsetOf/DecimalArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/DecimalArrayScenario.cs
@@ -11,7 +11,7 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1m, 2m, 5m } should be subset of  [2, 3, 4] but [1, 5] do not"; }
+            get { return "new[] { 1m, 2m, 5m } should be subset of  [2, 3, 4] but [1, 5] are outside subset"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/DecimalArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/DecimalArrayScenario.cs
@@ -6,12 +6,12 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1m }.ShouldBeSubsetOf(new[] { 2m, 3m, 4m });
+            new[] { 1m, 2m, 5m }.ShouldBeSubsetOf(new[] { 2m, 3m, 4m });
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1m } should be subset of  [2, 3, 4] but does not"; }
+            get { return "new[] { 1m, 2m, 5m } should be subset of  [2, 3, 4] but [1, 5] do not"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/FloatArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/FloatArrayScenario.cs
@@ -6,12 +6,12 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1f }.ShouldBeSubsetOf(new[] { 2f, 3f, 4f });
+            new[] { 1f, 2f, 5f }.ShouldBeSubsetOf(new[] { 2f, 3f, 4f });
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1f } should be subset of  [2, 3, 4] but does not"; }
+            get { return "new[] { 1f, 2f, 5f } should be subset of  [2, 3, 4] but [1, 5] do not"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/FloatArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/FloatArrayScenario.cs
@@ -11,7 +11,7 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1f, 2f, 5f } should be subset of  [2, 3, 4] but [1, 5] do not"; }
+            get { return "new[] { 1f, 2f, 5f } should be subset of  [2, 3, 4] but [1, 5] are outside subset"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/IntegerArrayScenario.cs
@@ -6,12 +6,12 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1 }.ShouldBeSubsetOf(new[] { 2, 3, 4 });
+            new[] { 1, 2, 5 }.ShouldBeSubsetOf(new[] { 2, 3, 4 });
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1 } should be subset of  [2, 3, 4] but does not"; }
+            get { return "new[] { 1, 2, 5 } should be subset of  [2, 3, 4] but [1, 5] do not"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/IntegerArrayScenario.cs
@@ -11,7 +11,7 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1, 2, 5 } should be subset of  [2, 3, 4] but [1, 5] do not"; }
+            get { return "new[] { 1, 2, 5 } should be subset of  [2, 3, 4] but [1, 5] are outside subset"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/ObjectArrayOfIntScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/ObjectArrayOfIntScenario.cs
@@ -14,7 +14,7 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "arr should be subset of [1, 2] but [3] do not"; }
+            get { return "arr should be subset of [1, 2] but [3] is outside subset"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/ObjectArrayOfIntScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/ObjectArrayOfIntScenario.cs
@@ -14,7 +14,7 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "arr should be subset of [1, 2] but does not"; }
+            get { return "arr should be subset of [1, 2] but [3] do not"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/StringArrayScenario.cs
@@ -11,7 +11,7 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { \"1\", \"2\", \"3\" } should be subset of [\"1\", \"2\"] but does not"; }
+            get { return "new[] { \"1\", \"2\", \"3\" } should be subset of [\"1\", \"2\"] but [\"3\"] do not"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/StringArrayScenario.cs
@@ -11,7 +11,7 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { \"1\", \"2\", \"3\" } should be subset of [\"1\", \"2\"] but [\"3\"] do not"; }
+            get { return "new[] { \"1\", \"2\", \"3\" } should be subset of [\"1\", \"2\"] but [\"3\"] is outside subset"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldContain/PredicateClosureScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/PredicateClosureScenario.cs
@@ -1,4 +1,5 @@
-﻿using Shouldly.Tests.TestHelpers;
+﻿#if net40
+using Shouldly.Tests.TestHelpers;
 
 namespace Shouldly.Tests.ShouldContain
 {
@@ -23,3 +24,4 @@ namespace Shouldly.Tests.ShouldContain
         }
     }
 }
+#endif

--- a/src/Shouldly.Tests/ShouldNotContain/PredicateClosureScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/PredicateClosureScenario.cs
@@ -1,4 +1,5 @@
-﻿using Shouldly.Tests.TestHelpers;
+﻿#if net40
+using Shouldly.Tests.TestHelpers;
 
 namespace Shouldly.Tests.ShouldNotContain
 {
@@ -23,3 +24,4 @@ namespace Shouldly.Tests.ShouldNotContain
         }
     }
 }
+#endif

--- a/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
+++ b/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
@@ -1,0 +1,47 @@
+﻿using NUnit.Framework;
+#if net40
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Shouldly.Tests.ShouldThrowAsync
+{  
+    [TestFixture]
+    public class FuncOfTaskScenarioAsync
+    {
+       
+        [Test]
+        public void ShouldThrowAWobbly()
+        {
+            try
+            {
+               
+                Should.ThrowAsync<InvalidOperationException>(() =>
+                {
+                    var task = Task.Factory.StartNew(() => { var a = 1 + 1; Console.WriteLine(a); },
+                        CancellationToken.None, TaskCreationOptions.None,
+                        TaskScheduler.Default);
+                    return task;
+                }).Wait();
+            }
+            catch (AggregateException e)
+            {
+                var inner = e.Flatten().InnerException;
+                inner.ShouldBeOfType<ShouldAssertException>();
+            }
+        }
+
+        [Test]
+        public void ShouldPass()
+        {
+            Should.ThrowAsync<InvalidOperationException>(() =>
+            {
+                var task = Task.Factory.StartNew(() => { throw new InvalidOperationException(); },
+                    CancellationToken.None, TaskCreationOptions.None,
+                    TaskScheduler.Default);
+                return task;
+            }).Wait();
+        }
+    }
+}
+#endif

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="ShouldSatisfyAllConditions\MultipleConditionsScenario.cs" />
     <Compile Include="ShouldSatisfyAllConditions\MultipleConditionsScenario_MultiLine2.cs" />
     <Compile Include="ShouldSatisfyAllConditions\MultipleConditionsScenario_MultiLine.cs" />
+    <Compile Include="ShouldThrowAsync\FuncOfTaskScenarioAsync.cs" />
     <Compile Include="ShouldThrow\ActionDelegateScenario.cs" />
     <Compile Include="ShouldThrow\ActionDelegateThrowsDifferentExceptionScenario.cs" />
     <Compile Include="ShouldThrow\FuncOfTaskOfStringThrowsDifferentExceptionScenario.cs" />

--- a/src/Shouldly.Tests/TestHelpers/TestShouldlyAssertionContext.cs
+++ b/src/Shouldly.Tests/TestHelpers/TestShouldlyAssertionContext.cs
@@ -22,6 +22,8 @@ namespace Shouldly.Tests.TestHelpers
         public bool HasRelevantActual { get; set; }
         public bool HasRelevantKey { get; set; }
 
+        public bool IsNegatedAssertion { get { return ShouldMethod.Contains("Not"); } }
+
         internal TestShouldlyAssertionContext(object expected, object actual = null)
         {
             Expected = expected;

--- a/src/Shouldly/App_Packages/ExpressionStringBuilder.0.9.1/ExpressionStringBuilder.cs
+++ b/src/Shouldly/App_Packages/ExpressionStringBuilder.0.9.1/ExpressionStringBuilder.cs
@@ -1,4 +1,4 @@
-﻿#if NET40
+﻿#if net40
 using System;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/Shouldly/App_Packages/ExpressionStringBuilder.0.9.1/ExpressionStringBuilder.cs
+++ b/src/Shouldly/App_Packages/ExpressionStringBuilder.0.9.1/ExpressionStringBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if NET40
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
@@ -277,3 +278,4 @@ namespace ExpressionToString
         }
     }
 }
+#endif

--- a/src/Shouldly/Internals/IShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/IShouldlyAssertionContext.cs
@@ -25,5 +25,7 @@ namespace Shouldly
         // is relevant.
         bool HasRelevantActual { get; set; }
         bool HasRelevantKey { get; set; }
+
+        bool IsNegatedAssertion { get; }
     }
 }

--- a/src/Shouldly/Internals/StringHelpers.cs
+++ b/src/Shouldly/Internals/StringHelpers.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
-using ExpressionToString;
 
 namespace Shouldly
 {
@@ -61,10 +60,12 @@ namespace Shouldly
                 return info.GetValue(constant.Value).ToStringAwesomely();
             }
 
+#if net40
             if (value is BinaryExpression)
             {
-                return ExpressionStringBuilder.ToString(value.As<BinaryExpression>());
+                return ExpressionToString.ExpressionStringBuilder.ToString(value.As<BinaryExpression>());
             }
+#endif
 
             return value == null ? "null" : value.ToString();
         }

--- a/src/Shouldly/MessageGenerators/DictionaryShouldContainKeyAndValueMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryShouldContainKeyAndValueMessageGenerator.cs
@@ -6,12 +6,12 @@ namespace Shouldly.MessageGenerators
     internal class DictionaryShouldContainKeyAndValueMessageGenerator : ShouldlyMessageGenerator
     {
         private static readonly Regex Validator = new Regex("ShouldContainKeyAndValue", RegexOptions.Compiled);
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return Validator.IsMatch(context.ShouldMethod);
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             const string format = @"
     Dictionary

--- a/src/Shouldly/MessageGenerators/DictionaryShouldNotContainValueForKeyMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryShouldNotContainValueForKeyMessageGenerator.cs
@@ -6,12 +6,12 @@ namespace Shouldly.MessageGenerators
     internal class DictionaryShouldNotContainValueForKeyMessageGenerator : ShouldlyMessageGenerator
     {
         private static readonly Regex Validator = new Regex("ShouldNotContainValueForKey", RegexOptions.Compiled);
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return Validator.IsMatch(context.ShouldMethod);
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             const string format = @"
     Dictionary

--- a/src/Shouldly/MessageGenerators/DictionaryShouldOrNotContainKeyMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryShouldOrNotContainKeyMessageGenerator.cs
@@ -6,12 +6,12 @@ namespace Shouldly.MessageGenerators
     internal class DictionaryShouldOrNotContainKeyMessageGenerator : ShouldlyMessageGenerator
     {
         private static readonly Regex Validator = new Regex("Should(Not)?ContainKey", RegexOptions.Compiled);
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return Validator.IsMatch(context.ShouldMethod) && !context.HasRelevantActual;
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             const string format = @"
     Dictionary

--- a/src/Shouldly/MessageGenerators/DynamicShouldMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DynamicShouldMessageGenerator.cs
@@ -10,12 +10,12 @@ namespace Shouldly.MessageGenerators
     {
         private static readonly Regex Validator = new Regex("HaveProperty", RegexOptions.Compiled);
         private static readonly Regex DynamicObjectNameExtractor = new Regex(@"DynamicShould.HaveProperty\((?<dynamicObjectName>.*),(?<propertyName>.*)\)", RegexOptions.Compiled);
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return Validator.IsMatch(context.ShouldMethod);
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             const string format =  @"
     Dynamic object

--- a/src/Shouldly/MessageGenerators/ShouldAllBeMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldAllBeMessageGenerator.cs
@@ -7,12 +7,12 @@ namespace Shouldly.MessageGenerators
     {
         private static readonly Regex Validator = new Regex("ShouldAllBe", RegexOptions.Compiled);
 
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return Validator.IsMatch(context.ShouldMethod);
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             const string format = @"{0} should satisfy the condition {1} but {2} do not";
 

--- a/src/Shouldly/MessageGenerators/ShouldBeEmptyMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeEmptyMessageGenerator.cs
@@ -9,12 +9,12 @@ namespace Shouldly.MessageGenerators
     {
         private static readonly Regex Validator = new Regex("Should(Not)?BeEmpty", RegexOptions.Compiled);
 
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return Validator.IsMatch(context.ShouldMethod) && !context.HasRelevantActual;
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             const string format = @"
     {0}

--- a/src/Shouldly/MessageGenerators/ShouldBeIgnoringOrderMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeIgnoringOrderMessageGenerator.cs
@@ -7,12 +7,12 @@ namespace Shouldly.MessageGenerators
 {
     internal class ShouldBeIgnoringOrderMessageGenerator : ShouldlyMessageGenerator
     {
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return context.IgnoreOrder;
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             var expected = ((IEnumerable)context.Expected).Cast<object>().ToArray();
             var actual = ((IEnumerable)context.Actual).Cast<object>().ToArray();

--- a/src/Shouldly/MessageGenerators/ShouldBeNullOrEmptyMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeNullOrEmptyMessageGenerator.cs
@@ -6,12 +6,12 @@ namespace Shouldly.MessageGenerators
     internal class ShouldBeNullOrEmptyMessageGenerator : ShouldlyMessageGenerator
     {
         private static readonly Regex Validator = new Regex("Should(Not)?BeNullOrEmpty", RegexOptions.Compiled);
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return Validator.IsMatch(context.ShouldMethod) && !context.HasRelevantActual;
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             const string format = @"
     {0}

--- a/src/Shouldly/MessageGenerators/ShouldBeSubsetOfMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeSubsetOfMessageGenerator.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Collections;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Shouldly.MessageGenerators
 {
@@ -6,19 +8,21 @@ namespace Shouldly.MessageGenerators
     {
         private static readonly Regex Validator = new Regex("ShouldBeSubsetOf", RegexOptions.Compiled);
 
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return Validator.IsMatch(context.ShouldMethod);
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
-            const string format = @"{0} should be subset of {1} but {2} do not";
+            const string format = @"{0} should be subset of {1} but {2} {3} outside subset";
 
             var codePart = context.CodePart;
             var expectedValue = context.Expected.ToStringAwesomely();
 
-            return string.Format(format, codePart, expectedValue, context.Actual.ToStringAwesomely());
+            var count = (context.Actual ?? Enumerable.Empty<object>()).As<IEnumerable>().Cast<object>().Count();
+
+            return string.Format(format, codePart, expectedValue, context.Actual.ToStringAwesomely(), count > 1 ? "are" : "is");
         }
     }
 }

--- a/src/Shouldly/MessageGenerators/ShouldBeSubsetOfMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeSubsetOfMessageGenerator.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.RegularExpressions;
+
+namespace Shouldly.MessageGenerators
+{
+    internal class ShouldBeSubsetOfMessageGenerator : ShouldlyMessageGenerator
+    {
+        private static readonly Regex Validator = new Regex("ShouldBeSubsetOf", RegexOptions.Compiled);
+
+        public override bool CanProcess(ShouldlyAssertionContext context)
+        {
+            return Validator.IsMatch(context.ShouldMethod);
+        }
+
+        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        {
+            const string format = @"{0} should be subset of {1} but {2} do not";
+
+            var codePart = context.CodePart;
+            var expectedValue = context.Expected.ToStringAwesomely();
+
+            return string.Format(format, codePart, expectedValue, context.Actual.ToStringAwesomely());
+        }
+    }
+}

--- a/src/Shouldly/MessageGenerators/ShouldBeUniqueMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeUniqueMessageGenerator.cs
@@ -7,12 +7,12 @@ namespace Shouldly.MessageGenerators
     {
         private static readonly Regex Validator = new Regex("ShouldBeUnique", RegexOptions.Compiled);
 
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return Validator.IsMatch(context.ShouldMethod) && context.HasRelevantActual;
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             const string format = @"
     {0}

--- a/src/Shouldly/MessageGenerators/ShouldBeWithinRangeMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeWithinRangeMessageGenerator.cs
@@ -5,14 +5,14 @@ namespace Shouldly.MessageGenerators
 {
     internal class ShouldBeWithinRangeMessageGenerator : ShouldlyMessageGenerator
     {
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return context.ShouldMethod.StartsWith("Should")
                    && !context.ShouldMethod.Contains("Contain")
                    && context.UnderlyingShouldMethod.GetParameters().Last().Name == "tolerance";
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             const string format = @"
         {0}

--- a/src/Shouldly/MessageGenerators/ShouldContainMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldContainMessageGenerator.cs
@@ -4,14 +4,14 @@ namespace Shouldly.MessageGenerators
 {
     internal class ShouldContainMessageGenerator : ShouldlyMessageGenerator
     {
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return context.ShouldMethod.StartsWith("Should")
                    && context.ShouldMethod.Contains("Contain")
                    && !(context.Expected is Expression);
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             var codePart = context.CodePart;
             const string format = @"

--- a/src/Shouldly/MessageGenerators/ShouldContainPredicateMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldContainPredicateMessageGenerator.cs
@@ -4,14 +4,14 @@ namespace Shouldly.MessageGenerators
 {
     internal class ShouldContainPredicateMessageGenerator : ShouldlyMessageGenerator
     {
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return context.ShouldMethod.StartsWith("Should")
                    && context.ShouldMethod.Contains("Contain")
                    && context.Expected is Expression;
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             var codePart = context.CodePart;
             const string format = @"

--- a/src/Shouldly/MessageGenerators/ShouldContainWithinRangeMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldContainWithinRangeMessageGenerator.cs
@@ -4,14 +4,14 @@ namespace Shouldly.MessageGenerators
 {
     internal class ShouldContainWithinRangeMessageGenerator : ShouldlyMessageGenerator
     {
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return context.ShouldMethod.StartsWith("Should")
                    && context.ShouldMethod.Contains("Contain")
                    && context.UnderlyingShouldMethod.GetParameters().Last().Name == "tolerance";
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             const string format = @"
         {0}

--- a/src/Shouldly/MessageGenerators/ShouldSatisfyAllConditionsMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldSatisfyAllConditionsMessageGenerator.cs
@@ -7,12 +7,12 @@ namespace Shouldly.MessageGenerators
     {
         private static readonly Regex Validator = new Regex("ShouldSatisfyAllConditions", RegexOptions.Compiled);
 
-        public override bool CanProcess(ShouldlyAssertionContext context)
+        public override bool CanProcess(IShouldlyAssertionContext context)
         {
             return Validator.IsMatch(context.ShouldMethod) && !context.HasRelevantActual;
         }
 
-        public override string GenerateErrorMessage(ShouldlyAssertionContext context)
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             const string format = @"
         {0} should satisfy all the conditions specified, but does not.

--- a/src/Shouldly/MessageGenerators/ShouldlyMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldlyMessageGenerator.cs
@@ -2,7 +2,7 @@ namespace Shouldly.MessageGenerators
 {
     internal abstract class ShouldlyMessageGenerator
     {
-        public abstract bool CanProcess(ShouldlyAssertionContext context);
-        public abstract string GenerateErrorMessage(ShouldlyAssertionContext context);
+        public abstract bool CanProcess(IShouldlyAssertionContext context);
+        public abstract string GenerateErrorMessage(IShouldlyAssertionContext context);
     }
 }

--- a/src/Shouldly/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldBeEnumerableTestExtensions.cs
@@ -73,19 +73,10 @@ namespace Shouldly
             if (actual.Equals(expected))
                 return;
 
-            List<T> actualList = actual.ToList();
-            List<T> expectedList = expected.ToList();
+            var missing = actual.Except(expected);
 
-            if (!actualList.TrueForAll(element =>
-            {
-                if (expectedList.Contains(element))
-                {
-                    expectedList.Remove(element);
-                    return true;
-                }
-                return false;
-            }))
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(expected).ToString());
+            if (missing.Any())
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, missing).ToString());
         }
 
         public static void ShouldBeUnique<T>(this IEnumerable<T> actual)

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -69,6 +69,7 @@
     <Compile Include="MessageGenerators\DictionaryShouldOrNotContainKeyMessageGenerator.cs" />
     <Compile Include="MessageGenerators\DynamicShouldMessageGenerator.cs" />
     <Compile Include="MessageGenerators\ShouldAllBeMessageGenerator.cs" />
+    <Compile Include="MessageGenerators\ShouldBeSubsetOfMessageGenerator.cs" />
     <Compile Include="MessageGenerators\ShouldContainMessageGenerator.cs" />
     <Compile Include="MessageGenerators\ShouldContainPredicateMessageGenerator.cs" />
     <Compile Include="MessageGenerators\ShouldSatisfyAllConditionsMessageGenerator.cs" />

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -77,12 +77,12 @@ namespace Shouldly
             new ShouldSatisfyAllConditionsMessageGenerator(),
             new ShouldBeSubsetOfMessageGenerator()
         };
-        private ShouldlyAssertionContext _shouldlyAssertionContext;
+        private IShouldlyAssertionContext _shouldlyAssertionContext;
 
-        protected ShouldlyAssertionContext ShouldlyAssertionContext
+        protected IShouldlyAssertionContext ShouldlyAssertionContext
         {
             get { return _shouldlyAssertionContext; }
-            set { _shouldlyAssertionContext = value; }
+            set { _shouldlyAssertionContext = value.As<IShouldlyAssertionContext>(); }
         }
 
         public override string ToString()

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -82,7 +82,7 @@ namespace Shouldly
         protected IShouldlyAssertionContext ShouldlyAssertionContext
         {
             get { return _shouldlyAssertionContext; }
-            set { _shouldlyAssertionContext = value.As<IShouldlyAssertionContext>(); }
+            set { _shouldlyAssertionContext = value; }
         }
 
         public override string ToString()

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -75,6 +75,7 @@ namespace Shouldly
             new ShouldContainPredicateMessageGenerator(), 
             new ShouldBeIgnoringOrderMessageGenerator(), 
             new ShouldSatisfyAllConditionsMessageGenerator(),
+            new ShouldBeSubsetOfMessageGenerator()
         };
         private ShouldlyAssertionContext _shouldlyAssertionContext;
 

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -122,7 +122,7 @@ namespace Shouldly
             return string.Format(format, codePart, _shouldlyAssertionContext.ShouldMethod.PascalToSpaced(), _shouldlyAssertionContext.Expected is BinaryExpression ? elementSatifyingTheConditionString : "", _shouldlyAssertionContext.Expected.ToStringAwesomely(), isNegatedAssertion ? "" : " not");
         }
 
-        private string CreateActualVsExpectedMessage(ShouldlyAssertionContext context)
+        private static string CreateActualVsExpectedMessage(IShouldlyAssertionContext context)
         {
             var codePart = context.CodePart;
             string message = string.Format(@"


### PR DESCRIPTION
I added a class called `ShouldBeSubsetOfMessageGenerator` to handle the formatting of the error message.

`ShouldBeSubsetOf<T>` now uses `Except` to determine which elements are missing.

Let me know if you want me to modify anything.

Fix #158 