### PR TITLE
Refactor ShouldBeEnumerableTestExtensions to handle additional information

### DIFF
--- a/src/Shouldly.Tests/ShouldAllBe/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldAllBe/IntegerArrayScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldAllBe
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1, 2, 3 }.ShouldAllBe(x => x < 2);
+            new[] {1, 2, 3}.ShouldAllBe(x => x < 2, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1, 2, 3 } should satisfy the condition (x < 2) but [2,3] do not"; }
+            get
+            {
+                return "new[] { 1, 2, 3 } should satisfy the condition (x < 2) but [2,3] do not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 1, 2, 3 }.ShouldAllBe(x => x < 4);
+            new[] {1, 2, 3}.ShouldAllBe(x => x < 4, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/ActualIsNullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/ActualIsNullScenario.cs
@@ -15,8 +15,8 @@ namespace Shouldly.Tests.ShouldBe.EnumerableType
         protected override string ChuckedAWobblyErrorMessage
         {
             get { return "something should be [1, 2, 3] but was null" +
-                         " Additional Info:" +
-                         " Some additional context"; }
+                         "Additional Info:" +
+                         "Some additional context"; }
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/DifferentCollectionTypeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/DifferentCollectionTypeScenario.cs
@@ -18,8 +18,8 @@ namespace Shouldly.Tests.ShouldBe.EnumerableType
         protected override string ChuckedAWobblyErrorMessage
         {
             get { return "new List<int> { 1, 2, 3 } should be [1, 3, 2] but was [1, 2, 3] difference [1, *2*, *3*]" +
-                         " Additional Info:" +
-                         " Some additional context"; }
+                         "Additional Info:" +
+                         "Some additional context"; }
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeOffsetScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeOffsetScenario.cs
@@ -16,8 +16,8 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
             get
             {
                 return String.Format("date should be within {0} of {1} but was {2}" +
-                                     " Additional Info:" +
-                                     " Some additional context",
+                                     "Additional Info:" +
+                                     "Some additional context",
                     TimeSpan.FromHours(1), new DateTimeOffset(new DateTime(2000, 6, 1, 1, 0, 1), TimeSpan.Zero),
                     new DateTimeOffset(new DateTime(2000, 6, 1), TimeSpan.Zero));
             }

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeScenario.cs
@@ -16,8 +16,8 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
             get 
             {
                 return String.Format("date should be within {0} of {1} but was {2}" +
-                                     " Additional Info:" +
-                                     " Some additional context",
+                                     "Additional Info:" +
+                                     "Some additional context",
                     TimeSpan.FromHours(1), new DateTime(2000, 6, 1, 1, 0, 1), new DateTime(2000, 6, 1)); 
             }
         }

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfDecimalScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfDecimalScenario.cs
@@ -13,9 +13,13 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "firstSet should be within 0.1 of [1.4301, 2.34, 3.45] but was [1.23, 2.34, 3.45001] difference [*1.23*, 2.34, *3.45001*]" +
-                         " Additional Info:" +
-                         " Some additional context"; }
+            get
+            {
+                return
+                    "firstSet should be within 0.1 of [1.4301, 2.34, 3.45] but was [1.23, 2.34, 3.45001] difference [*1.23*, 2.34, *3.45001*]" +
+                    "Additional Info:" +
+                    "Some additional context";
+            }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/TimeSpanScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/TimeSpanScenario.cs
@@ -16,8 +16,8 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
             get
             {
                 return "timeSpan should be within 01:00:00 of 02:06:00 but was 01:00:00" +
-                       " Additional Info:" +
-                       " Some additional context";
+                       "Additional Info:" +
+                       "Some additional context";
             }
         }
 

--- a/src/Shouldly.Tests/ShouldBeEmpty/ArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEmpty/ArrayScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldBeEmpty
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1 }.ShouldBeEmpty();
+            new[] {1}.ShouldBeEmpty(() => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1 } should be empty but had 1 item and was [1]"; }
+            get
+            {
+                return "new[] { 1 } should be empty but had 1 item and was [1]" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new int[0].ShouldBeEmpty();
+            new int[0].ShouldBeEmpty(() => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeSameAs/BasicScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSameAs/BasicScenario.cs
@@ -18,8 +18,8 @@ namespace Shouldly.Tests.ShouldBeSameAs
             {
                 //TODO maybe include GetHashCode?
                 return "zulu should be same as System.Object but was System.Object" +
-                       " Additional Info:" +
-                       " Some additional context";
+                       "Additional Info:" +
+                       "Some additional context";
             }
         }
 

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/DecimalArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/DecimalArrayScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1m }.ShouldBeSubsetOf(new[] { 2m, 3m, 4m });
+            new[] {1m}.ShouldBeSubsetOf(new[] {2m, 3m, 4m}, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1m } should be subset of  [2, 3, 4] but does not"; }
+            get
+            {
+                return "new[] { 1m } should be subset of  [2, 3, 4] but does not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 1m }.ShouldBeSubsetOf(new[] { 1m, 2m, 3m });
+            new[] {1m}.ShouldBeSubsetOf(new[] {1m, 2m, 3m}, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/FloatArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/FloatArrayScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1f }.ShouldBeSubsetOf(new[] { 2f, 3f, 4f });
+            new[] {1f}.ShouldBeSubsetOf(new[] {2f, 3f, 4f}, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1f } should be subset of  [2, 3, 4] but does not"; }
+            get
+            {
+                return "new[] { 1f } should be subset of  [2, 3, 4] but does not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 1f }.ShouldBeSubsetOf(new[] { 1f, 2f, 3f });
+            new[] {1f}.ShouldBeSubsetOf(new[] {1f, 2f, 3f}, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/IntegerArrayScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1 }.ShouldBeSubsetOf(new[] { 2, 3, 4 });
+            new[] {1}.ShouldBeSubsetOf(new[] {2, 3, 4}, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1 } should be subset of  [2, 3, 4] but does not"; }
+            get
+            {
+                return "new[] { 1 } should be subset of  [2, 3, 4] but does not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 1 }.ShouldBeSubsetOf(new[] { 1, 2, 3 });
+            new[] {1}.ShouldBeSubsetOf(new[] {1, 2, 3}, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/ObjectArrayOfIntScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/ObjectArrayOfIntScenario.cs
@@ -9,12 +9,17 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
             var arr = new object[] { 1, 2, 3 };
             var arr2 = new object[] { 1, 2 };
 
-            arr.ShouldBeSubsetOf(arr2);
+            arr.ShouldBeSubsetOf(arr2, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "arr should be subset of [1, 2] but does not"; }
+            get
+            {
+                return "arr should be subset of [1, 2] but does not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
@@ -22,7 +27,7 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
             var arr = new object[] { 1, 2, 3 };
             var arr2 = new object[] { 1, 2, 3, 4 };
 
-            arr.ShouldBeSubsetOf(arr2);
+            arr.ShouldBeSubsetOf(arr2, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/StringArrayScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { "1", "2", "3" }.ShouldBeSubsetOf(new[] { "1", "2" });
+            new[] {"1", "2", "3"}.ShouldBeSubsetOf(new[] {"1", "2"}, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { \"1\", \"2\", \"3\" } should be subset of [\"1\", \"2\"] but does not"; }
+            get
+            {
+                return "new[] { \"1\", \"2\", \"3\" } should be subset of [\"1\", \"2\"] but does not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { "1", "2", "3" }.ShouldBeSubsetOf(new[] { "1", "2", "3", "4" });
+            new[] {"1", "2", "3"}.ShouldBeSubsetOf(new[] {"1", "2", "3", "4"}, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/SuccessScenarios.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/SuccessScenarios.cs
@@ -9,13 +9,13 @@ namespace Shouldly.Tests.ShouldBeSubsetOf
         {
             var arr = new[] { 1 };
 
-            arr.ShouldBeSubsetOf(arr);
+            arr.ShouldBeSubsetOf(arr, () => "Some additional context");
         }
 
         [Test]
         public void EmptyArrayIsSubsetOfAnything()
         {
-            new int[0].ShouldBeSubsetOf(new[] { 1, 2, 3, 4 });
+            new int[0].ShouldBeSubsetOf(new[] {1, 2, 3, 4}, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeUnique/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeUnique/IntegerArrayScenario.cs
@@ -8,18 +8,20 @@ namespace Shouldly.Tests.ShouldBeUnique
         {
             get
             {
-                return "new [] { 1, 2, 2 } should be unique but [2] was duplicated";
+                return "new [] { 1, 2, 2 } should be unique but [2] was duplicated" +
+                       "Additional Info:" +
+                       "Some additional context";
             }
         }
 
         protected override void ShouldThrowAWobbly()
         {
-            new [] { 1, 2, 2 }.ShouldBeUnique();
+            new[] {1, 2, 2}.ShouldBeUnique(() => "Some additional context");
         }
 
         protected override void ShouldPass()
         {
-            new [] { 1, 2, 3 }.ShouldBeUnique();
+            new[] {1, 2, 3}.ShouldBeUnique(() => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeUnique/ObjectArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeUnique/ObjectArrayScenario.cs
@@ -8,18 +8,20 @@ namespace Shouldly.Tests.ShouldBeUnique
         {
             get
             {
-                return "new object[] { 1, 2, 3, 4, 2 } should be unique but [2] was duplicated";
+                return "new object[] { 1, 2, 3, 4, 2 } should be unique but [2] was duplicated" +
+                       "Additional Info:" +
+                       "Some additional context";
             }
         }
 
         protected override void ShouldThrowAWobbly()
         {
-            new object[] { 1, 2, 3, 4, 2 }.ShouldBeUnique();
+            new object[] {1, 2, 3, 4, 2}.ShouldBeUnique(() => "Some additional context");
         }
 
         protected override void ShouldPass()
         {
-            new object[] { 1, 2, 3, 4, 7 }.ShouldBeUnique();
+            new object[] {1, 2, 3, 4, 7}.ShouldBeUnique(() => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeUnique/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeUnique/StringArrayScenario.cs
@@ -9,18 +9,20 @@ namespace Shouldly.Tests.ShouldBeUnique
             get
             {
                 return "new string[] { \"string2\", \"string1\", \"string42\", \"string2\" } " +
-                "should be unique but [\"string2\"] was duplicated";
+                       "should be unique but [\"string2\"] was duplicated" +
+                       "Additional Info:" +
+                       "Some additional context";
             }
         }
 
         protected override void ShouldThrowAWobbly()
         {
-            new string[] { "string2", "string1", "string42", "string2" }.ShouldBeUnique();
+            new string[] {"string2", "string1", "string42", "string2"}.ShouldBeUnique(() => "Some additional context");
         }
 
         protected override void ShouldPass()
         {
-            new string[] { "string2", "string1", "string42", "string53" }.ShouldBeUnique();
+            new string[] {"string2", "string1", "string42", "string53"}.ShouldBeUnique(() => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldContain/DoubleWithToleranceScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/DoubleWithToleranceScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[]{1d, 2d, 3d}.ShouldContain(1.8, 0.1d);
+            new[] {1d, 2d, 3d}.ShouldContain(1.8, 0.1d, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[]{1d, 2d, 3d} should contain 1.8 within 0.1 but was [1, 2, 3]"; }
+            get
+            {
+                return "new[]{1d, 2d, 3d} should contain 1.8 within 0.1 but was [1, 2, 3]" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 1d, 2d, 3d }.ShouldContain(1.91d, 0.1d);
+            new[] {1d, 2d, 3d}.ShouldContain(1.91d, 0.1d, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldContain/EmptyArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/EmptyArrayScenario.cs
@@ -6,12 +6,17 @@ namespace Shouldly.Tests.ShouldContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            new int[0].ShouldContain(1);
+            new int[0].ShouldContain(1, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new int[0] should contain 1 but does not"; }
+            get
+            {
+                return "new int[0] should contain 1 but does not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldContain/FloatWithToleranceScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/FloatWithToleranceScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[]{1f, 2f, 3f}.ShouldContain(1.8f, 0.1d);
+            new[] {1f, 2f, 3f}.ShouldContain(1.8f, 0.1d, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[]{1f, 2f, 3f} should contain 1.8 within 0.1 but was [1, 2, 3]"; }
+            get
+            {
+                return "new[]{1f, 2f, 3f} should contain 1.8 within 0.1 but was [1, 2, 3]" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 1f, 2f, 3f }.ShouldContain(1.91f, 0.1d);
+            new[] {1f, 2f, 3f}.ShouldContain(1.91f, 0.1d, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldContain/IntegerScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/IntegerScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1, 2, 3, 4, 5 }.ShouldContain(6);
+            new[] { 1, 2, 3, 4, 5 }.ShouldContain(6, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return " new[] { 1, 2, 3, 4, 5 } should contain 6 but does not"; }
+            get
+            {
+                return "new[] { 1, 2, 3, 4, 5 } should contain 6 but does not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 1, 2, 3, 4, 5 }.ShouldContain(3);
+            new[] { 1, 2, 3, 4, 5 }.ShouldContain(3, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldContain/IntegerWithNegativeValuesScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/IntegerWithNegativeValuesScenario.cs
@@ -6,19 +6,24 @@ namespace Shouldly.Tests.ShouldContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 2, 3, 4, 5, 4, 123665, 11234, -1356237712831 }.ShouldContain(6);
+            new[] { 2, 3, 4, 5, 4, 123665, 11234, -1356237712831 }.ShouldContain(6, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 2, 3, 4, 5, 4, 123665, 11234, -1356237712831 } " +
-                         "should contain 6 " +
-                         "but does not"; }
+            get
+            {
+                return "new[] { 2, 3, 4, 5, 4, 123665, 11234, -1356237712831 } " +
+                       "should contain 6 " +
+                       "but does not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 2, 3, 4, 5, 4, 123665, 11234, -1356237712831 }.ShouldContain(-1356237712831);
+            new[] { 2, 3, 4, 5, 4, 123665, 11234, -1356237712831 }.ShouldContain(-1356237712831, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldContain/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/ObjectScenario.cs
@@ -11,7 +11,7 @@ namespace Shouldly.Tests.ShouldContain
             var b = new Object();
             var c = new Object();
             var d = new Object();
-            new[] { a, b, c }.ShouldContain(d);
+            new[] { a, b, c }.ShouldContain(d, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
@@ -20,8 +20,9 @@ namespace Shouldly.Tests.ShouldContain
     new[] { a, b, c }
         should contain
     System.Object
-        but does not"; }
-            
+        but does not
+    Additional Info:
+    Some additional context"; }
         }
 
         protected override void ShouldPass()
@@ -29,7 +30,7 @@ namespace Shouldly.Tests.ShouldContain
             var a = new Object();
             var b = new Object();
             var c = new Object();
-            new[] { a, b, c }.ShouldContain(b);
+            new[] { a, b, c }.ShouldContain(b, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldContain/PredicateClosureScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/PredicateClosureScenario.cs
@@ -8,7 +8,7 @@ namespace Shouldly.Tests.ShouldContain
         protected override void ShouldThrowAWobbly()
         {
             var capturedOuterVar = 4;
-            new[] { 1, 2, 3 }.ShouldContain(i => i > capturedOuterVar);
+            new[] {1, 2, 3}.ShouldContain(i => i > capturedOuterVar, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
@@ -19,7 +19,9 @@ namespace Shouldly.Tests.ShouldContain
         new[] { 1, 2, 3 }
                 should contain an element satisfying the condition
             (i > capturedOuterVar)
-                but does not";
+                but does not
+            Additional Info:
+            Some additional context";
             }
         }
     }

--- a/src/Shouldly.Tests/ShouldContain/PredicateObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/PredicateObjectScenario.cs
@@ -9,7 +9,7 @@ namespace Shouldly.Tests.ShouldContain
             var a = new object();
             var b = new object();
             var c = new object();
-            new[] { a, b, c }.ShouldContain(o => o.GetType().FullName.Equals(""));
+            new[] {a, b, c}.ShouldContain(o => o.GetType().FullName.Equals(""), () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
@@ -18,8 +18,9 @@ namespace Shouldly.Tests.ShouldContain
     new[] { a, b, c }
         should contain an element satisfying the condition
     o.GetType().FullName.Equals("""")
-        but does not"; }
-            
+        but does not
+    Additional Info:
+    Some additional context"; }
         }
 
         protected override void ShouldPass()
@@ -27,8 +28,8 @@ namespace Shouldly.Tests.ShouldContain
             var a = new object();
             var b = new object();
             var c = new object();
-            new[] { a, b, c }.ShouldContain(o => o.GetType().FullName.Equals("System.Object"));
-
+            new[] {a, b, c}.ShouldContain(o => o.GetType().FullName.Equals("System.Object"),
+                () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldContain/PredicateScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/PredicateScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1, 2, 3 }.ShouldContain(i => i > 4);
+            new[] {1, 2, 3}.ShouldContain(i => i > 4, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1, 2, 3 } should contain an element satisfying the condition (i > 4) but does not"; }
+            get
+            {
+                return "new[] { 1, 2, 3 } should contain an element satisfying the condition (i > 4) but does not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 1, 2, 3 }.ShouldContain(i => i < 3);
+            new[] {1, 2, 3}.ShouldContain(i => i < 3, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldContain/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/StringArrayScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[]{"a", "b", "c"}.ShouldContain("d");
+            new[] {"a", "b", "c"}.ShouldContain("d", () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return " new[]{\"a\", \"b\", \"c\"} should contain \"d\" but does not"; }
+            get
+            {
+                return "new[]{\"a\", \"b\", \"c\"} should contain \"d\" but does not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { "a", "b", "c" }.ShouldContain("b");
+            new[] {"a", "b", "c"}.ShouldContain("b", () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldContain/StringContainsCharScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/StringContainsCharScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            "Foo".ShouldContain('B');
+            "Foo".ShouldContain('B', () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "\"Foo\" should contain B but does not"; }
+            get
+            {
+                return "\"Foo\" should contain B but does not" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            "Foo".ShouldContain('F');
+            "Foo".ShouldContain('F', () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotBe/BoolScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBe/BoolScenario.cs
@@ -17,9 +17,12 @@ namespace Shouldly.Tests.ShouldNotBe
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "myFalseValue should not be False but was False" +
-                         " Additional Info:" +
-                         " Some additional context"; }
+            get
+            {
+                return "myFalseValue should not be False but was False" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotBe/WithTolerance/DateTimeOffsetScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBe/WithTolerance/DateTimeOffsetScenario.cs
@@ -16,8 +16,8 @@ namespace Shouldly.Tests.ShouldNotBe.WithTolerance
             get 
             {
                 return String.Format("date should not be within {0} of {1} but was {2}" +
-                                     " Additional Info:" +
-                                     " Some additional context",
+                                     "Additional Info:" +
+                                     "Some additional context",
                     TimeSpan.FromHours(1.5),
                         new DateTimeOffset(new DateTime(2000, 6, 1, 1, 0, 1), TimeSpan.Zero),
                             new DateTimeOffset(new DateTime(2000, 6, 1), TimeSpan.Zero)); 

--- a/src/Shouldly.Tests/ShouldNotBe/WithTolerance/DateTimeScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBe/WithTolerance/DateTimeScenario.cs
@@ -16,8 +16,8 @@ namespace Shouldly.Tests.ShouldNotBe.WithTolerance
             get 
             {
                 return String.Format("date should not be within {0} of {1} but was {2}" +
-                                     " Additional Info:" +
-                                     " Some additional context", 
+                                     "Additional Info:" +
+                                     "Some additional context", 
                     TimeSpan.FromHours(1.5), new DateTime(2000, 6, 1, 1, 0, 1), new DateTime(2000, 6, 1)); 
             }
         }

--- a/src/Shouldly.Tests/ShouldNotBe/WithTolerance/TimeSpanScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBe/WithTolerance/TimeSpanScenario.cs
@@ -16,8 +16,8 @@ namespace Shouldly.Tests.ShouldNotBe.WithTolerance
             get
             {
                 return "timeSpan should not be within 01:30:00 of 02:06:00 but was 01:00:00" +
-                       " Additional Info:" +
-                       " Some additional context";
+                       "Additional Info:" +
+                       "Some additional context";
             }
         }
 

--- a/src/Shouldly.Tests/ShouldNotBeEmpty/ArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBeEmpty/ArrayScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldNotBeEmpty
     {
         protected override void ShouldThrowAWobbly()
         {
-            new int[0].ShouldNotBeEmpty();
+            new int[0].ShouldNotBeEmpty(() => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new int[0] should not be empty but was "; }
+            get
+            {
+                return "new int[0] should not be empty but was " +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new []{1}.ShouldNotBeEmpty();
+            new[] {1}.ShouldNotBeEmpty(() => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotBeSameAs/BasicScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBeSameAs/BasicScenario.cs
@@ -14,8 +14,8 @@ namespace Shouldly.Tests.ShouldNotBeSameAs
         protected override string ChuckedAWobblyErrorMessage
         {
             get { return "zulu should not be same as System.Object but was System.Object" +
-                         " Additional Info:" +
-                         " Some additional context"; }
+                         "Additional Info:" +
+                         "Some additional context"; }
         }
 
         protected override void ShouldPass()

--- a/src/Shouldly.Tests/ShouldNotContain/IntegerScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/IntegerScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldNotContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1, 2, 3, 4, 5 }.ShouldNotContain(3);
+            new[] {1, 2, 3, 4, 5}.ShouldNotContain(3, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return " new[] { 1, 2, 3, 4, 5 } should not contain 3 but does"; }
+            get
+            {
+                return "new[] { 1, 2, 3, 4, 5 } should not contain 3 but does" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 1, 2, 3, 4, 5 }.ShouldNotContain(7);
+            new[] {1, 2, 3, 4, 5}.ShouldNotContain(7, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotContain/IntegerWithNegativeValuesScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/IntegerWithNegativeValuesScenario.cs
@@ -6,19 +6,24 @@ namespace Shouldly.Tests.ShouldNotContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 2, 3, 4, 5, 4, 123665, 11234, -1356237712831 }.ShouldNotContain(3);
+            new[] {2, 3, 4, 5, 4, 123665, 11234, -1356237712831}.ShouldNotContain(3, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 2, 3, 4, 5, 4, 123665, 11234, -1356237712831 } " +
-                         "should not contain 3 " +
-                         "but does"; }
+            get
+            {
+                return "new[] { 2, 3, 4, 5, 4, 123665, 11234, -1356237712831 } " +
+                       "should not contain 3 " +
+                       "but does" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 2, 3, 4, 5, 4, 123665, 11234, -1356237712831 }.ShouldNotContain(-300);
+            new[] {2, 3, 4, 5, 4, 123665, 11234, -1356237712831}.ShouldNotContain(-300, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotContain/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/ObjectScenario.cs
@@ -10,7 +10,7 @@ namespace Shouldly.Tests.ShouldNotContain
             var a = new Object();
             var b = new Object();
             var c = new Object();
-            new[] { a, b, c }.ShouldNotContain(c);
+            new[] {a, b, c}.ShouldNotContain(c, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
@@ -21,7 +21,9 @@ namespace Shouldly.Tests.ShouldNotContain
     new[] { a, b, c }
         should not contain
     System.Object
-        but does";
+        but does
+    Additional Info:
+    Some additional context";
             }
 
         }
@@ -32,7 +34,7 @@ namespace Shouldly.Tests.ShouldNotContain
             var b = new Object();
             var c = new Object();
             var d = new Object();
-            new[] { a, b, c }.ShouldNotContain(d);
+            new[] {a, b, c}.ShouldNotContain(d, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotContain/PredicateClosureScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/PredicateClosureScenario.cs
@@ -8,7 +8,7 @@ namespace Shouldly.Tests.ShouldNotContain
         protected override void ShouldThrowAWobbly()
         {
             var capturedOuterVar = 4;
-            new[] { 1, 2, 3 }.ShouldNotContain(i => i < capturedOuterVar);
+            new[] {1, 2, 3}.ShouldNotContain(i => i < capturedOuterVar, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
@@ -19,7 +19,9 @@ namespace Shouldly.Tests.ShouldNotContain
         new[] { 1, 2, 3 }
                 should not contain an element satisfying the condition
             (i < capturedOuterVar)
-                but does";
+                but does
+        Additional Info:
+        Some additional context";
             }
         }
     }

--- a/src/Shouldly.Tests/ShouldNotContain/PredicateObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/PredicateObjectScenario.cs
@@ -10,7 +10,8 @@ namespace Shouldly.Tests.ShouldNotContain
             var a = new Object();
             var b = new Object();
             var c = new Object();
-            new[] { a, b, c }.ShouldNotContain(o => o.GetType().FullName.Equals("System.Object"));
+            new[] {a, b, c}.ShouldNotContain(o => o.GetType().FullName.Equals("System.Object"),
+                () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
@@ -19,8 +20,9 @@ namespace Shouldly.Tests.ShouldNotContain
     new[] { a, b, c }
         should not contain an element satisfying the condition
     o.GetType().FullName.Equals(""System.Object"")
-        but does"; }
-            
+        but does
+    Additional Info:
+    Some additional context"; }
         }
 
         protected override void ShouldPass()
@@ -28,7 +30,7 @@ namespace Shouldly.Tests.ShouldNotContain
             var a = new Object();
             var b = new Object();
             var c = new Object();
-            new[] { a, b, c }.ShouldNotContain(o => o.GetType().FullName.Equals(""));
+            new[] {a, b, c}.ShouldNotContain(o => o.GetType().FullName.Equals(""), () => "Some additional context");
 
         }
     }

--- a/src/Shouldly.Tests/ShouldNotContain/PredicateScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/PredicateScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldNotContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[] { 1, 2, 3 }.ShouldNotContain(i => i < 4);
+            new[] {1, 2, 3}.ShouldNotContain(i => i < 4, () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "new[] { 1, 2, 3 } should not contain an element satisfying the condition (i < 4) but does"; }
+            get
+            {
+                return "new[] { 1, 2, 3 } should not contain an element satisfying the condition (i < 4) but does" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { 1, 2, 3 }.ShouldNotContain(i => i > 3);
+            new[] {1, 2, 3}.ShouldNotContain(i => i > 3, () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotContain/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/StringArrayScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldNotContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            new[]{"a", "b", "c"}.ShouldNotContain("c");
+            new[] {"a", "b", "c"}.ShouldNotContain("c", () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return " new[]{\"a\", \"b\", \"c\"} should not contain \"c\" but does"; }
+            get
+            {
+                return "new[]{\"a\", \"b\", \"c\"} should not contain \"c\" but does" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            new[] { "a", "b", "c" }.ShouldNotContain("d");
+            new[] {"a", "b", "c"}.ShouldNotContain("d", () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotContain/StringContainsCharScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/StringContainsCharScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.ShouldNotContain
     {
         protected override void ShouldThrowAWobbly()
         {
-            "Foo".ShouldNotContain('F');
+            "Foo".ShouldNotContain('F', () => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "\"Foo\" should not contain F but does"; }
+            get
+            {
+                return "\"Foo\" should not contain F but does" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            "Foo".ShouldNotContain('B');
+            "Foo".ShouldNotContain('B', () => "Some additional context");
         }
     }
 }

--- a/src/Shouldly.Tests/Strings/ShouldBeEmpty/ActualIsNull.cs
+++ b/src/Shouldly.Tests/Strings/ShouldBeEmpty/ActualIsNull.cs
@@ -6,12 +6,17 @@ namespace Shouldly.Tests.Strings.ShouldBeEmpty
     {
         protected override void ShouldThrowAWobbly()
         {
-            ((string)null).ShouldBeEmpty();
+            ((string) null).ShouldBeEmpty(() => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "((string)null) should be empty but was null"; }
+            get
+            {
+                return "((string)null) should be empty but was null" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
     }
 }

--- a/src/Shouldly.Tests/Strings/ShouldBeEmpty/ShouldBeEmptyBasicScenario.cs
+++ b/src/Shouldly.Tests/Strings/ShouldBeEmpty/ShouldBeEmptyBasicScenario.cs
@@ -6,17 +6,22 @@ namespace Shouldly.Tests.Strings.ShouldBeEmpty
     {
         protected override void ShouldThrowAWobbly()
         {
-            "a".ShouldBeEmpty();
+            "a".ShouldBeEmpty(() => "Some additional context");
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
-            get { return "\"a\" should be empty but was \"a\""; }
+            get
+            {
+                return "\"a\" should be empty but was \"a\"" +
+                       "Additional Info:" +
+                       "Some additional context";
+            }
         }
 
         protected override void ShouldPass()
         {
-            "".ShouldBeEmpty();
+            "".ShouldBeEmpty(() => "Some additional context");
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -12,63 +12,163 @@ namespace Shouldly
     {
         public static void ShouldContain<T>(this IEnumerable<T> actual, T expected)
         {
+            ShouldContain(actual, expected, () => null);
+        }
+
+        public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, string customMessage)
+        {
+            ShouldContain(actual, expected, () => customMessage);
+        }
+
+        public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, Func<string> customMessage)
+        {
             if (!actual.Contains(expected))
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage()).ToString());
         }
 
         public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected)
         {
+            ShouldNotContain(actual, expected, () => null);
+        }
+
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, string customMessage)
+        {
+            ShouldNotContain(actual, expected, () => customMessage);
+        }
+
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, Func<string> customMessage)
+        {
             if (actual.Contains(expected))
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage()).ToString());
         }
 
         public static void ShouldContain<T>(this IEnumerable<T> actual, Expression<Func<T, bool>> elementPredicate)
         {
+            ShouldContain(actual, elementPredicate, () => null);
+        }
+
+        public static void ShouldContain<T>(this IEnumerable<T> actual, Expression<Func<T, bool>> elementPredicate, string customMessage)
+        {
+            ShouldContain(actual, elementPredicate, () => customMessage);
+        }
+
+        public static void ShouldContain<T>(this IEnumerable<T> actual, Expression<Func<T, bool>> elementPredicate, Func<string> customMessage)
+        {
             var condition = elementPredicate.Compile();
             if (!actual.Any(condition))
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(elementPredicate.Body).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(elementPredicate.Body, customMessage()).ToString());
         }
 
         public static void ShouldNotContain<T>(this IEnumerable<T> actual, Expression<Func<T, bool>> elementPredicate)
         {
+            ShouldNotContain(actual, elementPredicate, () => null);
+        }
+
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, Expression<Func<T, bool>> elementPredicate, string customMessage)
+        {
+            ShouldNotContain(actual, elementPredicate, () => customMessage);
+        }
+
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, Expression<Func<T, bool>> elementPredicate, Func<string> customMessage)
+        {
             var condition = elementPredicate.Compile();
             if (actual.Any(condition))
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(elementPredicate.Body).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(elementPredicate.Body, customMessage()).ToString());
         }
 
         public static void ShouldAllBe<T>(this IEnumerable<T> actual, Expression<Func<T, bool>> elementPredicate)
         {
+            ShouldAllBe(actual, elementPredicate, () => null);
+        }
+
+        public static void ShouldAllBe<T>(this IEnumerable<T> actual, Expression<Func<T, bool>> elementPredicate, string customMessage)
+        {
+            ShouldAllBe(actual, elementPredicate, () => customMessage);
+        }
+
+        public static void ShouldAllBe<T>(this IEnumerable<T> actual, Expression<Func<T, bool>> elementPredicate, Func<string> customMessage)
+        {
             var condition = elementPredicate.Compile();
             var actualResults = actual.Where(part => !condition(part));
             if (actualResults.Any())
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(elementPredicate.Body, actualResults).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(elementPredicate.Body, actualResults, customMessage()).ToString());
         }
 
         public static void ShouldBeEmpty<T>(this IEnumerable<T> actual)
         {
+            ShouldBeEmpty(actual, () => null);
+        }
+
+        public static void ShouldBeEmpty<T>(this IEnumerable<T> actual, string customMessage)
+        {
+            ShouldBeEmpty(actual, () => customMessage);
+        }
+
+        public static void ShouldBeEmpty<T>(this IEnumerable<T> actual, Func<string> customMessage)
+        {
             if (actual == null || (actual != null && actual.Count() != 0))
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage()).ToString());
         }
 
         public static void ShouldNotBeEmpty<T>(this IEnumerable<T> actual)
         {
+            ShouldNotBeEmpty(actual, () => null);
+        }
+
+        public static void ShouldNotBeEmpty<T>(this IEnumerable<T> actual, string customMessage)
+        {
+            ShouldNotBeEmpty(actual, () => customMessage);
+        }
+
+        public static void ShouldNotBeEmpty<T>(this IEnumerable<T> actual, Func<string> customMessage)
+        {
             if (actual == null || actual != null && !actual.Any())
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage()).ToString());
         }
 
         public static void ShouldContain(this IEnumerable<float> actual, float expected, double tolerance)
         {
+            ShouldContain(actual, expected, tolerance, () => null);
+        }
+
+        public static void ShouldContain(this IEnumerable<float> actual, float expected, double tolerance, string customMessage)
+        {
+            ShouldContain(actual, expected, tolerance, () => customMessage);
+        }
+
+        public static void ShouldContain(this IEnumerable<float> actual, float expected, double tolerance, Func<string> customMessage)
+        {
             if (!actual.Any(a => Math.Abs(expected - a) < tolerance))
-                throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance).ToString());
+                throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance, customMessage()).ToString());
         }
 
         public static void ShouldContain(this IEnumerable<double> actual, double expected, double tolerance)
         {
+            ShouldContain(actual, expected, () => null);
+        }
+
+        public static void ShouldContain(this IEnumerable<double> actual, double expected, double tolerance, string customMessage)
+        {
+            ShouldContain(actual, expected, () => customMessage);
+        }
+
+        public static void ShouldContain(this IEnumerable<double> actual, double expected, double tolerance, Func<string> customMessage)
+        {
             if (!actual.Any(a => Math.Abs(expected - a) < tolerance))
-                throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance).ToString());
+                throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance, customMessage()).ToString());
         }
 
         public static void ShouldBeSubsetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected)
+        {
+            ShouldBeSubsetOf(actual, expected, () => null);
+        }
+
+        public static void ShouldBeSubsetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected, string customMessage)
+        {
+            ShouldBeSubsetOf(actual, expected, () => customMessage);
+        }
+
+        public static void ShouldBeSubsetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected, Func<string> customMessage)
         {
             if (actual.Equals(expected))
                 return;
@@ -85,14 +185,24 @@ namespace Shouldly
                 }
                 return false;
             }))
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(expected).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(expected, customMessage()).ToString());
         }
 
         public static void ShouldBeUnique<T>(this IEnumerable<T> actual)
         {
+            ShouldBeUnique(actual, () => null);
+        }
+
+        public static void ShouldBeUnique<T>(this IEnumerable<T> actual, string customMessage)
+        {
+            ShouldBeUnique(actual, () => customMessage);
+        }
+
+        public static void ShouldBeUnique<T>(this IEnumerable<T> actual, Func<string> customMessage)
+        {
             var duplicates = GetDuplicates(actual);
             if (duplicates.Any())
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(new List<T>(), duplicates).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(new List<T>(), duplicates, customMessage()).ToString());
         }
 
         static List<object> GetDuplicates<T>(IEnumerable<T> items)


### PR DESCRIPTION
This PR is a part of https://github.com/shouldly/shouldly/pull/195 and contains refactoring for `ShouldBeEnumerableTestExtensions` methods to handle additional information.

Let me know in case of any issues :)