### PR TITLE
Added InstantHandle attribute to all customMessage delegates

### DIFF
--- a/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
+++ b/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
@@ -1,10 +1,11 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
     internal static class ShouldlyCoreExtensions
     {
-        internal static void AssertAwesomely<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected, Func<string> customMessage = null)
+        internal static void AssertAwesomely<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected, [InstantHandle] Func<string> customMessage = null)
         {
             if (customMessage == null)
                 customMessage = () => null;
@@ -38,7 +39,7 @@ namespace Shouldly
             throw new ShouldAssertException(new ExpectedActualIgnoreOrderShouldlyMessage(originalExpected, originalActual, customMessage).ToString());
         }
 
-        internal static void AssertAwesomely<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected, object tolerance, Func<string> customMessage = null )
+        internal static void AssertAwesomely<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected, object tolerance, [InstantHandle] Func<string> customMessage = null)
         {
             if (customMessage == null)
                 customMessage = () => null;
@@ -55,7 +56,7 @@ namespace Shouldly
             throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(originalExpected, originalActual, tolerance, customMessage).ToString());
         }
 
-        internal static void AssertAwesomely<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected, Case caseSensitivity, Func<string> customMessage = null)
+        internal static void AssertAwesomely<T>(this T actual, Func<T, bool> specifiedConstraint, object originalActual, object originalExpected, Case caseSensitivity, [InstantHandle] Func<string> customMessage = null)
         {
             if (customMessage == null)
                 customMessage = () => null;

--- a/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
+++ b/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Dynamic;
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -23,7 +24,7 @@ namespace Shouldly
             HaveProperty(dynamicTestObject, propertyName, message);
         }
 
-        public static void HaveProperty(dynamic dynamicTestObject, string propertyName, Func<string> customMessage)
+        public static void HaveProperty(dynamic dynamicTestObject, string propertyName, [InstantHandle] Func<string> customMessage)
         {
             if (dynamicTestObject is IDynamicMetaObjectProvider)
             {

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowExtensions.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowExtensions.cs
@@ -16,7 +16,7 @@ namespace Shouldly
         {
             return Throw<TException>(actual, () => customMessage);
         }
-        public static TException Throw<TException>([InstantHandle] Action actual, Func<string> customMessage) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Action actual, [InstantHandle] Func<string> customMessage) where TException : Exception
         {
             try
             {
@@ -42,7 +42,7 @@ namespace Shouldly
         {
             NotThrow(action, () => customMessage);
         }
-        public static void NotThrow([InstantHandle] Action action, Func<string> customMessage)
+        public static void NotThrow([InstantHandle] Action action, [InstantHandle] Func<string> customMessage)
         {
             try
             {
@@ -62,7 +62,7 @@ namespace Shouldly
         {
             return NotThrow(action, () => customMessage);
         }
-        public static T NotThrow<T>([InstantHandle] Func<T> action, Func<string> customMessage)
+        public static T NotThrow<T>([InstantHandle] Func<T> action, [InstantHandle] Func<string> customMessage)
         {
             try
             {

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsyncExtensions.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsyncExtensions.cs
@@ -1,6 +1,7 @@
 ﻿#if net40
 using System;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -15,7 +16,7 @@ namespace Shouldly
             return ThrowAsync<TException>(task, () => customMessage);
         }
 
-        public static Task<TException> ThrowAsync<TException>(Task task, Func<string> customMessage)
+        public static Task<TException> ThrowAsync<TException>(Task task, [InstantHandle] Func<string> customMessage)
             where TException : Exception
         {
             return ThrowAsync<TException>(() => task, customMessage);
@@ -28,7 +29,7 @@ namespace Shouldly
         {
             return ThrowAsync<TException>(actual, () => customMessage);
         }
-        public static Task<TException> ThrowAsync<TException>(Func<Task> actual, Func<string> customMessage) where TException : Exception
+        public static Task<TException> ThrowAsync<TException>(Func<Task> actual, [InstantHandle] Func<string> customMessage) where TException : Exception
         {
             return actual().ContinueWith(t =>
             {

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskExtensions.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskExtensions.cs
@@ -17,7 +17,7 @@ namespace Shouldly
         {
             return Throw<TException>(actual, () => customMessage);
         }
-        public static TException Throw<TException>(Task actual, Func<string> customMessage) where TException : Exception
+        public static TException Throw<TException>(Task actual, [InstantHandle] Func<string> customMessage) where TException : Exception
         {
             return Throw<TException>(() => actual, customMessage);
         }
@@ -31,7 +31,7 @@ namespace Shouldly
         {
             return Throw<TException>(actual, () => customMessage);
         }
-        public static TException Throw<TException>([InstantHandle] Func<Task> actual, Func<string> customMessage) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Func<Task> actual, [InstantHandle] Func<string> customMessage) where TException : Exception
         {
             return Throw<TException>(actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
         }
@@ -48,7 +48,7 @@ namespace Shouldly
             return Throw<TException>(actual, timeoutAfter, () => customMessage);
         }
 
-        public static TException Throw<TException>(Task actual, TimeSpan timeoutAfter, Func<string> customMessage)
+        public static TException Throw<TException>(Task actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
             where TException : Exception
         {
             return Throw<TException>(() => actual, timeoutAfter, customMessage);            
@@ -65,7 +65,7 @@ namespace Shouldly
         {
             return Throw<TException>(actual, timeoutAfter, () => customMessage);
         }
-        public static TException Throw<TException>([InstantHandle] Func<Task> actual, TimeSpan timeoutAfter, Func<string> customMessage) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage) where TException : Exception
         {
             try
             {
@@ -99,7 +99,7 @@ namespace Shouldly
         {
             NotThrow(action, () => customMessage);
         }
-        public static void NotThrow(Task action, Func<string> customMessage)
+        public static void NotThrow(Task action, [InstantHandle] Func<string> customMessage)
         {
             NotThrow(() => action, customMessage);
         }
@@ -113,7 +113,7 @@ namespace Shouldly
         {
             return NotThrow(action, () => customMessage);
         }
-        public static T NotThrow<T>(Task<T> action, Func<string> customMessage)
+        public static T NotThrow<T>(Task<T> action, [InstantHandle] Func<string> customMessage)
         {
             return NotThrow(() => action, customMessage);
         }
@@ -127,7 +127,7 @@ namespace Shouldly
         {
             NotThrow(action, () => customMessage);
         }
-        public static void NotThrow([InstantHandle] Func<Task> action, Func<string> customMessage)
+        public static void NotThrow([InstantHandle] Func<Task> action, [InstantHandle] Func<string> customMessage)
         {
             NotThrow(action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
         }
@@ -141,7 +141,7 @@ namespace Shouldly
         {
             NotThrow(action, timeoutAfter, () => customMessage);
         }
-        public static void NotThrow(Task action, TimeSpan timeoutAfter, Func<string> customMessage)
+        public static void NotThrow(Task action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
         {
             NotThrow(() => action, timeoutAfter, customMessage);
         }
@@ -155,7 +155,7 @@ namespace Shouldly
         {
             NotThrow(action, timeoutAfter, () => customMessage);
         }
-        public static void NotThrow([InstantHandle] Func<Task> action, TimeSpan timeoutAfter, Func<string> customMessage)
+        public static void NotThrow([InstantHandle] Func<Task> action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
         {
             try
             {
@@ -184,7 +184,7 @@ namespace Shouldly
         {
             return NotThrow(action, () => customMessage);            
         }
-        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, Func<string> customMessage)
+        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, [InstantHandle] Func<string> customMessage)
         {
             return NotThrow(action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
         }
@@ -198,7 +198,7 @@ namespace Shouldly
         {
             return NotThrow(action, timeoutAfter, () => customMessage);
         }
-        public static T NotThrow<T>(Task<T> action, TimeSpan timeoutAfter, Func<string> customMessage)
+        public static T NotThrow<T>(Task<T> action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
         {
             return NotThrow(() => action, timeoutAfter, customMessage);
         }
@@ -212,7 +212,7 @@ namespace Shouldly
         {
             return NotThrow(action, timeoutAfter, () => customMessage);
         }
-        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, TimeSpan timeoutAfter, Func<string> customMessage)
+        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
         {
             try
             {
@@ -239,7 +239,7 @@ namespace Shouldly
             }
         }
 
-        private static void RunAndWait(Func<Task> actual, TimeSpan timeoutAfter, Func<string> customMessage)
+        private static void RunAndWait(Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
         {
             // Drop the sync context so continuations will not post to it, causing a deadlock
             if (SynchronizationContext.Current != null)
@@ -253,7 +253,7 @@ namespace Shouldly
             }
         }
 
-        private static TException HandleAggregateException<TException>(AggregateException e, Func<string> customMessage) where TException : Exception
+        private static TException HandleAggregateException<TException>(AggregateException e, [InstantHandle] Func<string> customMessage) where TException : Exception
         {
             var innerException = e.InnerException;
             if (innerException is TException)

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/DateTimeShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/DateTimeShouldBeTestExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -14,7 +15,7 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this DateTime actual, DateTime expected, TimeSpan tolerance, Func<string> customMessage)
+        public static void ShouldBe(this DateTime actual, DateTime expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -29,7 +30,7 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, Func<string> customMessage)
+        public static void ShouldBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -44,7 +45,7 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, Func<string> customMessage)
+        public static void ShouldBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -59,7 +60,7 @@ namespace Shouldly
             ShouldNotBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldNotBe(this DateTime actual, DateTime expected, TimeSpan tolerance, Func<string> customMessage)
+        public static void ShouldNotBe(this DateTime actual, DateTime expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => !Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -73,8 +74,8 @@ namespace Shouldly
         {
             ShouldNotBe(actual, expected, tolerance, () => customMessage);
         }
-        
-        public static void ShouldNotBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, Func<string> customMessage)
+
+        public static void ShouldNotBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => !Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -89,7 +90,7 @@ namespace Shouldly
             ShouldNotBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldNotBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, Func<string> customMessage)
+        public static void ShouldNotBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => !Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         } 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
@@ -17,7 +17,7 @@ namespace Shouldly
         {
             ShouldBe(actual, expected, () => customMessage);
         }
-        public static void ShouldBe<T>(this T actual, T expected, Func<string> customMessage)
+        public static void ShouldBe<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage)
         {
             if (ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName) || typeof(T) == typeof(string))
                 actual.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<T>()), actual, expected, customMessage);
@@ -36,7 +36,7 @@ namespace Shouldly
             ShouldNotBe(actual, expected, () => customMessage);
         }
         [ContractAnnotation("actual:null,expected:null => halt")]
-        public static void ShouldNotBe<T>(this T actual, T expected, Func<string> customMessage )
+        public static void ShouldNotBe<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => !Is.Equal(v, expected), actual, expected, customMessage);
         }
@@ -49,7 +49,7 @@ namespace Shouldly
         {
             ShouldBe(actual, expected, ignoreOrder, () => customMessage);
         }
-        public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool ignoreOrder, Func<string> customMessage)
+        public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool ignoreOrder, [InstantHandle] Func<string> customMessage)
         {
             if (!ignoreOrder && ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName))
             {
@@ -76,7 +76,7 @@ namespace Shouldly
         {
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
-        public static void ShouldBe(this IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance, Func<string> customMessage)
+        public static void ShouldBe(this IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -89,7 +89,7 @@ namespace Shouldly
         {
             ShouldBeSameAs(actual, expected, () => customMessage);
         }
-        public static void ShouldBeSameAs(this object actual, object expected, Func<string> customMessage)
+        public static void ShouldBeSameAs(this object actual, object expected, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.Same(v, expected), actual, expected, customMessage);
         }
@@ -102,7 +102,7 @@ namespace Shouldly
         {
             ShouldNotBeSameAs(actual, expected, () => customMessage);
         }
-        public static void ShouldNotBeSameAs(this object actual, object expected, Func<string> customMessage)
+        public static void ShouldNotBeSameAs(this object actual, object expected, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => !Is.Same(v, expected), actual, expected, customMessage);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/NumericShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/NumericShouldBeTestExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -15,7 +16,7 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this float actual, float expected, double tolerance, Func<string> customMessage)
+        public static void ShouldBe(this float actual, float expected, double tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -30,7 +31,7 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this IEnumerable<double> actual, IEnumerable<double> expected, double tolerance, Func<string> customMessage)
+        public static void ShouldBe(this IEnumerable<double> actual, IEnumerable<double> expected, double tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -45,7 +46,7 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this IEnumerable<float> actual, IEnumerable<float> expected, double tolerance, Func<string> customMessage)
+        public static void ShouldBe(this IEnumerable<float> actual, IEnumerable<float> expected, double tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -60,7 +61,7 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this double actual, double expected, double tolerance, Func<string> customMessage)
+        public static void ShouldBe(this double actual, double expected, double tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -75,7 +76,7 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, Func<string> customMessage)
+        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         } 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringContainsTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringContainsTestExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -17,7 +18,7 @@ namespace Shouldly
             ShouldContainWithoutWhitespace(actual, expected, () => customMessage);
         }
 
-        public static void ShouldContainWithoutWhitespace(this string actual, object expected, Func<string> customMessage)
+        public static void ShouldContainWithoutWhitespace(this string actual, object expected, [InstantHandle] Func<string> customMessage)
         {
             var strippedActual = actual.Quotify().StripWhitespace();
             var strippedExpected = (expected ?? "NULL").ToString().Quotify().StripWhitespace();
@@ -45,12 +46,12 @@ namespace Shouldly
             ShouldContain(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldContain(this string actual, string expected, Func<string> customMessage)
+        public static void ShouldContain(this string actual, string expected, [InstantHandle] Func<string> customMessage)
         {
             ShouldContain(actual, expected, customMessage, Case.Insensitive);
         }
 
-        public static void ShouldContain(this string actual, string expected, Func<string> customMessage, Case caseSensitivity)
+        public static void ShouldContain(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity)
         {
             actual.AssertAwesomely(
                 v => (caseSensitivity == Case.Sensitive) ? Is.StringContainingUsingCaseSensitivity(v, expected) : Is.StringContainingIgnoreCase(v, expected), 
@@ -80,12 +81,12 @@ namespace Shouldly
             ShouldNotContain(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldNotContain(this string actual, string expected, Func<string> customMessage)
+        public static void ShouldNotContain(this string actual, string expected, [InstantHandle] Func<string> customMessage)
         {
             ShouldNotContain(actual, expected, customMessage, Case.Insensitive);
         }
 
-        public static void ShouldNotContain(this string actual, string expected, Func<string> customMessage, Case caseSensitivity)
+        public static void ShouldNotContain(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity)
         {
             actual.AssertAwesomely(v =>
             {
@@ -104,7 +105,7 @@ namespace Shouldly
             ShouldMatch(actual, regexPattern, () => customMessage);
         }
 
-        public static void ShouldMatch(this string actual, string regexPattern, Func<string> customMessage)
+        public static void ShouldMatch(this string actual, string regexPattern, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.StringMatchingRegex(v, regexPattern), actual, regexPattern, customMessage);
         } 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringNullOrEmptyTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringNullOrEmptyTestExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -14,7 +15,7 @@ namespace Shouldly
             ShouldBeNullOrEmpty(actual, () => customMessage);
         }
 
-        public static void ShouldBeNullOrEmpty(this string actual, Func<string> customMessage)
+        public static void ShouldBeNullOrEmpty(this string actual, [InstantHandle] Func<string> customMessage)
         {
             if (!string.IsNullOrEmpty(actual))
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
@@ -30,7 +31,7 @@ namespace Shouldly
             ShouldNotBeNullOrEmpty(actual, () => customMessage);
         }
 
-        public static void ShouldNotBeNullOrEmpty(this string actual, Func<string> customMessage)
+        public static void ShouldNotBeNullOrEmpty(this string actual, [InstantHandle] Func<string> customMessage)
         {
             if (string.IsNullOrEmpty(actual))
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringShouldBeTestExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -20,7 +21,7 @@ namespace Shouldly
             ShouldBe(actual, expected, caseSensitivity, () => customMessage);
         }
 
-        public static void ShouldBe(this string actual, string expected, Case caseSensitivity, Func<string> customMessage)
+        public static void ShouldBe(this string actual, string expected, Case caseSensitivity, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => (caseSensitivity == Case.Sensitive)
                 ? Is.Equal(v, expected)

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringStartEndTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringStartEndTestExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -20,7 +21,7 @@ namespace Shouldly
             ShouldStartWith(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldStartWith(this string actual, string expected, Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldStartWith(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
         {
             actual.AssertAwesomely(v => Is.StringStartingWithUsingCaseSensitivity(v, expected, caseSensitivity), actual, expected, customMessage);
         }
@@ -41,7 +42,7 @@ namespace Shouldly
             ShouldEndWith(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldEndWith(this string actual, string expected, Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldEndWith(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
         {
             actual.AssertAwesomely(v => Is.EndsWithUsingCaseSensitivity(v, expected, caseSensitivity), actual, expected, customMessage);
         }
@@ -61,7 +62,7 @@ public static void ShouldNotStartWith(this string actual, string expected, Case 
             ShouldNotStartWith(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldNotStartWith(this string actual, string expected, Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldNotStartWith(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
         {
             actual.AssertAwesomely(v => !Is.StringStartingWithUsingCaseSensitivity(v, expected, caseSensitivity), actual, expected, customMessage);
         }
@@ -81,7 +82,7 @@ public static void ShouldNotEndWith(this string actual, string expected, Case ca
             ShouldNotEndWith(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldNotEndWith(this string actual, string expected, Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldNotEndWith(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
         {
             actual.AssertAwesomely(v => !Is.EndsWithUsingCaseSensitivity(v, expected, caseSensitivity), actual, expected, customMessage);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using JetBrains.Annotations;
 
 namespace Shouldly 
 {
@@ -18,7 +19,7 @@ namespace Shouldly
             ShouldContainKey(dictionary, key, () => customMessage);
         }
 
-        public static void ShouldContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, Func<string> customMessage)
+        public static void ShouldContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, [InstantHandle] Func<string> customMessage)
         {
             if (!dictionary.ContainsKey(key))
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(key, customMessage).ToString());
@@ -34,7 +35,7 @@ namespace Shouldly
             ShouldNotContainKey(dictionary, key, () => customMessage);
         }
 
-        public static void ShouldNotContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, Func<string> customMessage)
+        public static void ShouldNotContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, [InstantHandle] Func<string> customMessage)
         {
             if (dictionary.ContainsKey(key))
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(key, customMessage).ToString());
@@ -50,7 +51,7 @@ namespace Shouldly
             ShouldContainKeyAndValue(dictionary, key, val, () => customMessage);
         }
 
-        public static void ShouldContainKeyAndValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, Func<string> customMessage)
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, [InstantHandle] Func<string> customMessage)
         {
             if (!dictionary.ContainsKey(key))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(val, key, customMessage).ToString());
@@ -69,7 +70,7 @@ namespace Shouldly
             ShouldNotContainValueForKey(dictionary, key, val, () => customMessage);
         }
 
-        public static void ShouldNotContainValueForKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, Func<string> customMessage)
+        public static void ShouldNotContainValueForKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, [InstantHandle] Func<string> customMessage)
         {
             if (!dictionary.ContainsKey(key))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(val, key, customMessage).ToString());

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -21,7 +21,7 @@ namespace Shouldly
             ShouldContain(actual, expected, () => customMessage);
         }
 
-        public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, Func<string> customMessage)
+        public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, [InstantHandle] Func<string> customMessage)
         {
             if (!actual.Contains(expected))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
@@ -37,7 +37,7 @@ namespace Shouldly
             ShouldNotContain(actual, expected, () => customMessage);
         }
 
-        public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, Func<string> customMessage)
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, [InstantHandle] Func<string> customMessage)
         {
             if (actual.Contains(expected))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
@@ -53,7 +53,7 @@ namespace Shouldly
             ShouldContain(actual, elementPredicate, () => customMessage);
         }
 
-        public static void ShouldContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, Func<string> customMessage)
+        public static void ShouldContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, [InstantHandle] Func<string> customMessage)
         {
             var condition = elementPredicate.Compile();
             if (!actual.Any(condition))
@@ -70,7 +70,7 @@ namespace Shouldly
             ShouldNotContain(actual, elementPredicate, () => customMessage);
         }
 
-        public static void ShouldNotContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, Func<string> customMessage)
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, [InstantHandle] Func<string> customMessage)
         {
             var condition = elementPredicate.Compile();
             if (actual.Any(condition))
@@ -87,7 +87,7 @@ namespace Shouldly
             ShouldAllBe(actual, elementPredicate, () => customMessage);
         }
 
-        public static void ShouldAllBe<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, Func<string> customMessage)
+        public static void ShouldAllBe<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, [InstantHandle] Func<string> customMessage)
         {
             var condition = elementPredicate.Compile();
             var actualResults = actual.Where(part => !condition(part));
@@ -105,7 +105,7 @@ namespace Shouldly
             ShouldBeEmpty(actual, () => customMessage);
         }
 
-        public static void ShouldBeEmpty<T>(this IEnumerable<T> actual, Func<string> customMessage)
+        public static void ShouldBeEmpty<T>(this IEnumerable<T> actual, [InstantHandle] Func<string> customMessage)
         {
             if (actual == null || (actual != null && actual.Count() != 0))
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
@@ -121,7 +121,7 @@ namespace Shouldly
             ShouldNotBeEmpty(actual, () => customMessage);
         }
 
-        public static void ShouldNotBeEmpty<T>(this IEnumerable<T> actual, Func<string> customMessage)
+        public static void ShouldNotBeEmpty<T>(this IEnumerable<T> actual, [InstantHandle] Func<string> customMessage)
         {
             if (actual == null || actual != null && !actual.Any())
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
@@ -137,7 +137,7 @@ namespace Shouldly
             ShouldContain(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldContain(this IEnumerable<float> actual, float expected, double tolerance, Func<string> customMessage)
+        public static void ShouldContain(this IEnumerable<float> actual, float expected, double tolerance, [InstantHandle] Func<string> customMessage)
         {
             if (!actual.Any(a => Math.Abs(expected - a) < tolerance))
                 throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance, customMessage).ToString());
@@ -153,7 +153,7 @@ namespace Shouldly
             ShouldContain(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldContain(this IEnumerable<double> actual, double expected, double tolerance, Func<string> customMessage)
+        public static void ShouldContain(this IEnumerable<double> actual, double expected, double tolerance, [InstantHandle] Func<string> customMessage)
         {
             if (!actual.Any(a => Math.Abs(expected - a) < tolerance))
                 throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance, customMessage).ToString());
@@ -169,7 +169,7 @@ namespace Shouldly
             ShouldBeSubsetOf(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeSubsetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected, Func<string> customMessage)
+        public static void ShouldBeSubsetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected, [InstantHandle] Func<string> customMessage)
         {
             if (actual.Equals(expected))
                 return;
@@ -189,7 +189,7 @@ namespace Shouldly
             ShouldBeUnique(actual, () => customMessage);
         }
 
-        public static void ShouldBeUnique<T>(this IEnumerable<T> actual, Func<string> customMessage)
+        public static void ShouldBeUnique<T>(this IEnumerable<T> actual, [InstantHandle] Func<string> customMessage)
         {
             var duplicates = GetDuplicates(actual);
             if (duplicates.Any())

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeGtLtTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeGtLtTestExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -14,7 +15,7 @@ namespace Shouldly
             ShouldBeGreaterThan(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected, Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldBeGreaterThan<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
         {
             actual.AssertAwesomely(v => Is.GreaterThan(v, expected), actual, expected, customMessage);
         }
@@ -29,7 +30,7 @@ namespace Shouldly
             ShouldBeLessThan(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeLessThan<T>(this T actual, T expected, Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldBeLessThan<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
         {
             actual.AssertAwesomely(v => Is.LessThan(v, expected), actual, expected, customMessage);
         }
@@ -44,7 +45,7 @@ namespace Shouldly
             ShouldBeGreaterThanOrEqualTo(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
         {
             actual.AssertAwesomely(v => Is.GreaterThanOrEqualTo(v, expected), actual, expected, customMessage);
         }
@@ -59,7 +60,7 @@ namespace Shouldly
             ShouldBeLessThanOrEqualTo(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
         {
             actual.AssertAwesomely(v => Is.LessThanOrEqualTo(v, expected), actual, expected, customMessage);
         } 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeRangeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeRangeTestExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -13,7 +14,7 @@ namespace Shouldly
         {
             ShouldBeOneOf(actual, expected, () => customMessage);
         }
-        public static void ShouldBeOneOf<T>(this T actual, T[] expected, Func<string> customMessage)
+        public static void ShouldBeOneOf<T>(this T actual, T[] expected, [InstantHandle] Func<string> customMessage)
         {
             if (!expected.Contains(actual))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
@@ -27,7 +28,7 @@ namespace Shouldly
         {
             ShouldNotBeOneOf(actual, expected, () => customMessage);
         }
-        public static void ShouldNotBeOneOf<T>(this T actual, T[] expected, Func<string> customMessage)
+        public static void ShouldNotBeOneOf<T>(this T actual, T[] expected, [InstantHandle] Func<string> customMessage)
         {
             if (expected.Contains(actual))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
@@ -41,7 +42,7 @@ namespace Shouldly
         {
             ShouldBeInRange(actual, from, to, () => customMessage);
         }
-        public static void ShouldBeInRange<T>(this T actual, T from, T to, Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldBeInRange<T>(this T actual, T from, T to, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
         {
             actual.AssertAwesomely(v => Is.InRange<T>(v, @from, to), actual, new { @from, to }, customMessage);
         }
@@ -54,7 +55,7 @@ namespace Shouldly
         {
             ShouldNotBeInRange(actual, from, to, () => customMessage);
         }
-        public static void ShouldNotBeInRange<T>(this T actual, T from, T to, Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldNotBeInRange<T>(this T actual, T from, T to, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
         {
             actual.AssertAwesomely(v => !Is.InRange<T>(v, @from, to), actual, new { @from, to }, customMessage);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeTypeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeTypeTestExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -14,7 +15,7 @@ namespace Shouldly
             return ShouldBeAssignableTo<T>(actual, () => customMessage);
         }
 
-        public static T ShouldBeAssignableTo<T>(this object actual, Func<string> customMessage)
+        public static T ShouldBeAssignableTo<T>(this object actual, [InstantHandle] Func<string> customMessage)
         {
             ShouldBeAssignableTo(actual, typeof(T), customMessage);
             return (T)actual;
@@ -30,7 +31,7 @@ namespace Shouldly
             ShouldBeAssignableTo(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeAssignableTo(this object actual, Type expected, Func<string> customMessage)
+        public static void ShouldBeAssignableTo(this object actual, Type expected, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => Is.InstanceOf(v, expected), actual == null ? null : actual.GetType(), expected, customMessage);
         }
@@ -45,7 +46,7 @@ namespace Shouldly
             return ShouldBeOfType<T>(actual, () => customMessage);
         }
 
-        public static T ShouldBeOfType<T>(this object actual, Func<string> customMessage)
+        public static T ShouldBeOfType<T>(this object actual, [InstantHandle] Func<string> customMessage)
         {
             ShouldBeOfType(actual, typeof(T), customMessage);
             return (T)actual;
@@ -61,7 +62,7 @@ namespace Shouldly
             ShouldBeOfType(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeOfType(this object actual, Type expected, Func<string> customMessage)
+        public static void ShouldBeOfType(this object actual, Type expected, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => v != null && v.GetType() == expected, actual == null ? null : actual.GetType(),
                 expected, customMessage);
@@ -77,7 +78,7 @@ namespace Shouldly
             ShouldNotBeAssignableTo<T>(actual, () => customMessage);
         }
 
-        public static void ShouldNotBeAssignableTo<T>(this object actual, Func<string> customMessage)
+        public static void ShouldNotBeAssignableTo<T>(this object actual, [InstantHandle] Func<string> customMessage)
         {
             ShouldNotBeAssignableTo(actual, typeof(T), customMessage);
         }
@@ -92,7 +93,7 @@ namespace Shouldly
             ShouldNotBeAssignableTo(actual, expected, () => customMessage);
         }
 
-        public static void ShouldNotBeAssignableTo(this object actual, Type expected, Func<string> customMessage)
+        public static void ShouldNotBeAssignableTo(this object actual, Type expected, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => !Is.InstanceOf(v, expected), actual, expected);
         }
@@ -107,7 +108,7 @@ namespace Shouldly
             ShouldNotBeOfType<T>(actual, () => customMessage);
         }
 
-        public static void ShouldNotBeOfType<T>(this object actual, Func<string> customMessage)
+        public static void ShouldNotBeOfType<T>(this object actual, [InstantHandle] Func<string> customMessage)
         {
             ShouldNotBeOfType(actual, typeof(T), customMessage);
         }
@@ -122,7 +123,7 @@ namespace Shouldly
             ShouldNotBeOfType(actual, expected, () => customMessage);
         }
 
-        public static void ShouldNotBeOfType(this object actual, Type expected, Func<string> customMessage)
+        public static void ShouldNotBeOfType(this object actual, Type expected, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => v == null || v.GetType() != expected, actual, expected, customMessage);
         } 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldCompleteInExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldCompleteInExtensions.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using System.Threading;
 using System;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -19,7 +20,7 @@ namespace Shouldly
         {
             CompleteIn(action, timeout, () => customMessage);
         }
-        public static void CompleteIn(Action action, TimeSpan timeout, Func<string> customMessage)
+        public static void CompleteIn(Action action, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
         {
             var actual = Task.Factory.StartNew(action, CancellationToken.None, TaskCreationOptions.None,
                         TaskScheduler.Default);
@@ -35,7 +36,7 @@ namespace Shouldly
         {
             return CompleteIn(function, timeout, () => customMessage);
         }
-        public static T CompleteIn<T>(Func<T> function, TimeSpan timeout, Func<string> customMessage)
+        public static T CompleteIn<T>(Func<T> function, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
         {
             var actual = Task.Factory.StartNew(function, CancellationToken.None, TaskCreationOptions.None,
                         TaskScheduler.Default);
@@ -52,7 +53,7 @@ namespace Shouldly
         {
             CompleteIn(actual, timeout, () => customMessage);
         }
-        public static void CompleteIn(Func<Task> actual, TimeSpan timeout, Func<string> customMessage)
+        public static void CompleteIn(Func<Task> actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
         {
             CompleteIn(actual(), timeout, customMessage, "Task");
         }
@@ -66,7 +67,7 @@ namespace Shouldly
         {
             return CompleteIn(actual, timeout, () => customMessage);
         }
-        public static T CompleteIn<T>(Func<Task<T>> actual, TimeSpan timeout, Func<string> customMessage)
+        public static T CompleteIn<T>(Func<Task<T>> actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
         {
             return CompleteIn(actual(), timeout, customMessage, "Task");
         }
@@ -80,7 +81,7 @@ namespace Shouldly
         {
             CompleteIn(actual, timeout, () => customMessage);
         }
-        public static void CompleteIn(Task actual, TimeSpan timeout, Func<string> customMessage)
+        public static void CompleteIn(Task actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
         {
             CompleteIn(actual, timeout, customMessage, "Task");
         }
@@ -96,18 +97,18 @@ namespace Shouldly
             CompleteIn(actual, timeout, () => customMessage);
             return actual.Result;
         }
-        public static T CompleteIn<T>(Task<T> actual, TimeSpan timeout, Func<string> customMessage)
+        public static T CompleteIn<T>(Task<T> actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
         {
             return CompleteIn(actual, timeout, customMessage, "Task");
         }
 
-        private static T CompleteIn<T>(Task<T> actual, TimeSpan timeout, Func<string> customMessage, string what)
+        private static T CompleteIn<T>(Task<T> actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage, string what)
         {
             CompleteIn((Task)actual, timeout, customMessage, what);
             return actual.Result;
         }
 
-        private static void CompleteIn(Task actual, TimeSpan timeout, Func<string> customMessage, string what)
+        private static void CompleteIn(Task actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage, string what)
         {
             try
             {

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAllConditionsTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAllConditionsTestExtensions.cs
@@ -19,7 +19,7 @@ namespace Shouldly
         {
             ShouldSatisfyAllConditions(actual, () => customMessage, conditions);
         }
-        public static void ShouldSatisfyAllConditions(this object actual, Func<string> customMessage, [InstantHandle] params Action[] conditions)
+        public static void ShouldSatisfyAllConditions(this object actual, [InstantHandle] Func<string> customMessage, [InstantHandle] params Action[] conditions)
         {
             var errorMessages = new List<Exception>();
             foreach (var action in conditions) 

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using JetBrains.Annotations;
 using Shouldly.DifferenceHighlighting;
 using Shouldly.MessageGenerators;
 
@@ -9,7 +10,7 @@ namespace Shouldly
 {
     internal class ExpectedShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedShouldlyMessage(object expected, Func<string> customMessage)
+        public ExpectedShouldlyMessage(object expected, [InstantHandle] Func<string> customMessage)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(expected);
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
@@ -18,7 +19,7 @@ namespace Shouldly
 
     internal class ExpectedActualShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualShouldlyMessage(object expected, object actual, Func<string> customMessage)
+        public ExpectedActualShouldlyMessage(object expected, object actual, [InstantHandle] Func<string> customMessage)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(expected, actual)
             {
@@ -30,7 +31,7 @@ namespace Shouldly
 
     internal class ExpectedActualWithCaseSensitivityShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualWithCaseSensitivityShouldlyMessage(object expected, object actual, Case caseSensitivity, Func<string> customMessage)
+        public ExpectedActualWithCaseSensitivityShouldlyMessage(object expected, object actual, Case caseSensitivity, [InstantHandle] Func<string> customMessage)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(expected, actual)
             {
@@ -43,7 +44,7 @@ namespace Shouldly
 
     internal class ExpectedActualToleranceShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualToleranceShouldlyMessage(object expected, object actual, object tolerance, Func<string> customMessage)
+        public ExpectedActualToleranceShouldlyMessage(object expected, object actual, object tolerance, [InstantHandle] Func<string> customMessage)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(expected, actual)
             {
@@ -56,7 +57,7 @@ namespace Shouldly
 
     internal class ExpectedActualIgnoreOrderShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualIgnoreOrderShouldlyMessage(object expected, object actual, Func<string> customMessage)
+        public ExpectedActualIgnoreOrderShouldlyMessage(object expected, object actual, [InstantHandle] Func<string> customMessage)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(expected, actual);
             ShouldlyAssertionContext.IgnoreOrder = true;
@@ -67,7 +68,7 @@ namespace Shouldly
 
     internal class ExpectedActualKeyShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualKeyShouldlyMessage(object expected, object actual, object key, Func<string> customMessage)
+        public ExpectedActualKeyShouldlyMessage(object expected, object actual, object key, [InstantHandle] Func<string> customMessage)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(expected, actual)
             {
@@ -82,7 +83,7 @@ namespace Shouldly
 #if net40
     internal class CompleteInShouldlyMessage : ShouldlyMessage
     {
-        public CompleteInShouldlyMessage(string what, TimeSpan timeout, Func<string> customMessage)
+        public CompleteInShouldlyMessage(string what, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(what)
             {
@@ -94,7 +95,7 @@ namespace Shouldly
 
     internal class ShouldlyThrowShouldlyMessage : ShouldlyMessage
     {
-        public ShouldlyThrowShouldlyMessage(Type exception, Func<string> customMessage)
+        public ShouldlyThrowShouldlyMessage(Type exception, [InstantHandle] Func<string> customMessage)
         {
             ShouldlyAssertionContext = new ShouldThrowAssertionContext(exception);
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();


### PR DESCRIPTION
I've added an `[InstantHandle]` attribute to all `Func<string> customMessage` parameters as per recent conversation.