### PR TITLE
#242 Bugs/exception with null dictionary keys

### DIFF
--- a/src/Shouldly.Tests/Dictionaries/ShouldContainKeyAndValue/ValueIsNull.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldContainKeyAndValue/ValueIsNull.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Shouldly.Tests.TestHelpers;
+
+namespace Shouldly.Tests.Dictionaries.ShouldContainKeyAndValue
+{
+    public class ValueIsNull : ShouldlyShouldTestScenario
+    {
+        readonly Dictionary<MyThing, MyThing> _dictionary = new Dictionary<MyThing, MyThing>
+        {
+            {ThingKey, ThingValue}
+        };
+
+        private static readonly MyThing ThingKey = new MyThing();
+        private static readonly MyThing ThingValue = null;
+
+        protected override void ShouldThrowAWobbly()
+        {
+            _dictionary.ShouldContainKeyAndValue(ThingKey, new MyThing(), "Some additional context");
+        }
+
+        protected override string ChuckedAWobblyErrorMessage
+        {
+            get
+            {
+                return
+                    "Dictionary \"_dictionary\" should contain key \"Shouldly.Tests.TestHelpers.MyThing\" with value \"Shouldly.Tests.TestHelpers.MyThing\" but value was null " +
+                    "Additional Info: " +
+                    "Some additional context";
+            }
+        }
+
+        protected override void ShouldPass()
+        {
+            _dictionary.ShouldContainKeyAndValue(ThingKey, ThingValue);
+        }
+    }
+}

--- a/src/Shouldly.Tests/Dictionaries/ShouldNotContainValueForKey/ValueIsNull.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldNotContainValueForKey/ValueIsNull.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Shouldly.Tests.TestHelpers;
+
+namespace Shouldly.Tests.Dictionaries.ShouldNotContainValueForKey
+{
+    public class ValueIsNull : ShouldlyShouldTestScenario
+    {
+        readonly Dictionary<MyThing, MyThing> _dictionary = new Dictionary<MyThing, MyThing>
+        {
+            {ThingKey, ThingValue}
+        };
+
+        private static readonly MyThing ThingKey = new MyThing();
+        private static readonly MyThing ThingValue = null;
+
+        protected override void ShouldThrowAWobbly()
+        {
+            _dictionary.ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context");
+        }
+
+        protected override string ChuckedAWobblyErrorMessage
+        {
+            get
+            {
+                return
+                    "Dictionary \"_dictionary\" should not contain key \"Shouldly.Tests.TestHelpers.MyThing\" with value null but does " +
+                    "Additional Info: " +
+                    "Some additional context";
+            }
+        }
+
+        protected override void ShouldPass()
+        {
+            _dictionary.ShouldNotContainValueForKey(ThingKey, new MyThing());
+        }
+    }
+}

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -78,6 +78,8 @@
     <Compile Include="Dictionaries\ShouldContainKeyAndValue\GuidScenario.cs" />
     <Compile Include="Dictionaries\ShouldContainKeyAndValue\OnlyKeyMatches.cs" />
     <Compile Include="Dictionaries\ShouldContainKeyAndValue\OnlyValueMatches.cs" />
+    <Compile Include="Dictionaries\ShouldContainKeyAndValue\ValueIsNull.cs" />
+    <Compile Include="Dictionaries\ShouldNotContainValueForKey\ValueIsNull.cs" />
     <Compile Include="DynamicShould\HavePropertyNonDynamicScenario.cs" />
     <Compile Include="DynamicShould\MultiLineHavePropertyScenario_MaximumLines.cs" />
     <Compile Include="DynamicShould\MultiLineHavePropertyScenario.cs" />

--- a/src/Shouldly/MessageGenerators/DictionaryShouldContainKeyAndValueMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryShouldContainKeyAndValueMessageGenerator.cs
@@ -29,7 +29,10 @@ namespace Shouldly.MessageGenerators
 
             if (context.HasRelevantKey)
             {
-                var valueString = string.Format("but value was \"{0}\"", actualValue.Trim('"'));
+                var actualValueString = context.Actual == null
+                    ? actualValue
+                    : string.Format("\"{0}\"", actualValue.Trim('"'));
+                var valueString = string.Format("but value was {0}", actualValueString);
                 return String.Format(format, codePart, keyValue.Trim('"'), expectedValue.Trim('"'), valueString);
             }
             else

--- a/src/Shouldly/MessageGenerators/DictionaryShouldNotContainValueForKeyMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryShouldNotContainValueForKeyMessageGenerator.cs
@@ -19,7 +19,7 @@ namespace Shouldly.MessageGenerators
     should not contain key
         ""{1}""
     with value
-        ""{2}""
+        {2}
     {3}";
 
             var codePart = context.CodePart;
@@ -27,14 +27,18 @@ namespace Shouldly.MessageGenerators
             var actualValue = context.Actual.ToStringAwesomely();
             var keyValue = context.Key.ToStringAwesomely();
 
+            var expectedValueString = context.Expected == null
+                ? expectedValue
+                : string.Format("\"{0}\"", expectedValue.Trim('"'));            
+
             if (context.HasRelevantKey)
             {
                 var valueString = "but does";
-                return String.Format(format, codePart, keyValue.Trim('"'), expectedValue.Trim('"'), valueString);
+                return String.Format(format, codePart, keyValue.Trim('"'), expectedValueString, valueString);
             }
             else
             {
-                return String.Format(format, codePart, actualValue.Trim('"'), expectedValue.Trim('"'), "but the key does not exist");
+                return String.Format(format, codePart, actualValue.Trim('"'), expectedValueString, "but the key does not exist");
             }
         }
     }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
@@ -56,7 +56,7 @@ namespace Shouldly
             if (!dictionary.ContainsKey(key))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(val, key, customMessage).ToString());
 
-            if (!dictionary[key].Equals(val))
+            if (!Equals(dictionary[key], val))
                 throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary[key], key, customMessage).ToString());
         }
 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
@@ -75,7 +75,7 @@ namespace Shouldly
             if (!dictionary.ContainsKey(key))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(val, key, customMessage).ToString());
 
-            if (dictionary[key].Equals(val))
+            if (Equals(dictionary[key], val))
                 throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary[key], key, customMessage).ToString());
         }
     }


### PR DESCRIPTION
This is a fix for issue #242 where the dictionary checks can throw NullReferenceExceptions.

I've changed the equality checks from doing `dictionary[key].Equals(value)` to a null-safe `Equals(dictionary[key],value)`. This fixes the main issue.

In addition to this I've altered the associated message generators such that they now report null values as `null` rather than `"null"`.