### PR TITLE
Should not throw message generator

### DIFF
--- a/ShouldlyConvention.Tests/ShouldlyConvention.Tests.csproj
+++ b/ShouldlyConvention.Tests/ShouldlyConvention.Tests.csproj
@@ -101,6 +101,9 @@
       <Name>Shouldly</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Shouldly.Tests/ShouldNotThrow/ActionDelegateScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/ActionDelegateScenario.cs
@@ -14,7 +14,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return "Should should not throw but threw System.InvalidOperationException with message \"Operation is not valid due to the current state of the object.\"" +
+                return "new Action(() => { throw new InvalidOperationException(); }) should not throw but threw System.InvalidOperationException with message \"Operation is not valid due to the current state of the object.\"" +
                         "Additional Info:" +
                         "Some additional context";
             }

--- a/src/Shouldly.Tests/ShouldNotThrow/ActionDelegateScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/ActionDelegateScenario.cs
@@ -7,17 +7,16 @@ namespace Shouldly.Tests.ShouldNotThrow
     {
         protected override void ShouldThrowAWobbly()
         {
-            var action = new Action(() => { throw new InvalidOperationException(); });
-            action.ShouldNotThrow("Some additional context");
+            Should.NotThrow(new Action(() => { throw new InvalidOperationException(); }), "Some additional context");            
         }
 
         protected override string ChuckedAWobblyErrorMessage
         {
             get
             {
-                return @"action should not throw System.InvalidOperationException but does
-Additional Info:
-Some additional context";
+                return @"Should should not throw but threw System.InvalidOperationException with message Operation is not valid due to the current state of the object." +
+                        "Additional Info:" +
+                        "Some additional context";
             }
         }
 

--- a/src/Shouldly.Tests/ShouldNotThrow/ActionDelegateScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/ActionDelegateScenario.cs
@@ -14,7 +14,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"Should should not throw but threw System.InvalidOperationException with message Operation is not valid due to the current state of the object." +
+                return "Should should not throw but threw System.InvalidOperationException with message \"Operation is not valid due to the current state of the object.\"" +
                         "Additional Info:" +
                         "Some additional context";
             }

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncDelegateScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncDelegateScenario.cs
@@ -15,7 +15,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return "Should should not throw but threw System.InvalidOperationException with message \"Operation is not valid due to the current state of the object.\"" +
+                return "action should not throw but threw System.InvalidOperationException with message \"Operation is not valid due to the current state of the object.\"" +
                         "Additional Info:" +
                         "Some additional context";
             }

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncDelegateScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncDelegateScenario.cs
@@ -15,7 +15,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"Should should not throw but threw System.InvalidOperationException with message Operation is not valid due to the current state of the object." +
+                return "Should should not throw but threw System.InvalidOperationException with message \"Operation is not valid due to the current state of the object.\"" +
                         "Additional Info:" +
                         "Some additional context";
             }

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncDelegateScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncDelegateScenario.cs
@@ -15,9 +15,9 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"action should not throw System.InvalidOperationException but does
-Additional Info:
-Some additional context";
+                return @"Should should not throw but threw System.InvalidOperationException with message Operation is not valid due to the current state of the object." +
+                        "Additional Info:" +
+                        "Some additional context";
             }
         }
 

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfStringScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfStringScenario.cs
@@ -21,9 +21,9 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"task should not throw System.RankException but does
-Additional Info:
-Some additional context";
+                return @"Should should not throw but threw System.RankException" +
+                        "Additional Info:" +
+                        "Some additional context";
             }
         }
 

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfStringScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfStringScenario.cs
@@ -21,9 +21,9 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"Should should not throw but threw System.RankException" +
-                        "Additional Info:" +
-                        "Some additional context";
+                return "Should should not throw but threw System.RankException with message \"Attempted to operate on an array with the incorrect number of dimensions.\"" +
+                        " Additional Info:" +
+                        " Some additional context";
             }
         }
 

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfStringScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfStringScenario.cs
@@ -21,7 +21,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return "Should should not throw but threw System.RankException with message \"Attempted to operate on an array with the incorrect number of dimensions.\"" +
+                return "task should not throw but threw System.RankException with message \"Attempted to operate on an array with the incorrect number of dimensions.\"" +
                         " Additional Info:" +
                         " Some additional context";
             }

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
@@ -21,9 +21,9 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"task should not throw System.RankException but does
-Additional Info:
-Some additional context";
+                return @"Should should not throw but threw System.RankException" +
+                        "Additional Info:" +
+                        "Some additional context";
             }
         }
 

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
@@ -21,7 +21,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"Should should not throw but threw System.RankException" +
+                return @"task should not throw but threw System.RankException" +
                         "Additional Info:" +
                         "Some additional context";
             }

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
@@ -21,7 +21,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"task should not throw but threw System.RankException" +
+                return @"task should not throw but threw System.RankException with message ""Attempted to operate on an array with the incorrect number of dimensions.""" +
                         "Additional Info:" +
                         "Some additional context";
             }

--- a/src/Shouldly.Tests/ShouldNotThrow/NestedBlockLambdaScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/NestedBlockLambdaScenario.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Shouldly.Tests.TestHelpers;
+
+namespace Shouldly.Tests.ShouldNotThrow
+{
+    public class NestedBlockLambdaScenario : ShouldlyShouldFailureTestScenario
+    {
+        protected override void ShouldThrowAWobbly()
+        {
+            Should.NotThrow(() =>
+            {
+                if (true)
+                {
+                    throw new Exception("Dummy message.");
+                }
+            }, () => "Additional info");
+        }
+
+        protected override string ChuckedAWobblyErrorMessage
+        {
+            get
+            {
+                return
+                    "() => { if (true) { throw new Exception(\"Dummy message.\"); } } should not throw but threw System.Exception Additional Info: Additional info";
+            }
+        }
+    }
+} 

--- a/src/Shouldly.Tests/ShouldNotThrow/NestedBlockLambdaScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/NestedBlockLambdaScenario.cs
@@ -24,7 +24,7 @@ namespace Shouldly.Tests.ShouldNotThrow
             get
             {
                 return
-                    "() => { if (true) { throw new Exception(\"Dummy message.\"); } } should not throw but threw System.Exception Additional Info: Additional info";
+                    "() => { if (true) { throw new Exception(\"Dummy message.\"); } } should not throw but threw System.Exception with message \"Dummy message.\" Additional Info: Additional info";
             }
         }
     }

--- a/src/Shouldly.Tests/ShouldNotThrow/NestedBlockLambdaWithoutAdditionalInformationsScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/NestedBlockLambdaWithoutAdditionalInformationsScenario.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Shouldly.Tests.TestHelpers;
+
+namespace Shouldly.Tests.ShouldNotThrow
+{
+    public class NestedBlockLambdaWithoutAdditionalInformationsScenario  : ShouldlyShouldFailureTestScenario
+    {
+        protected override void ShouldThrowAWobbly()
+        {
+            Should.NotThrow(() =>
+            {
+                if (true)
+                {
+                    throw new Exception("Dummy message.");
+                }
+            });
+        }
+
+        protected override string ChuckedAWobblyErrorMessage
+        {
+            get
+            {
+                return
+                    "() => { if (true) { throw new Exception(\"Dummy message.\"); } } should not throw but threw System.Exception";
+            }
+        }
+    }
+} 

--- a/src/Shouldly.Tests/ShouldNotThrow/NestedBlockLambdaWithoutAdditionalInformationsScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/NestedBlockLambdaWithoutAdditionalInformationsScenario.cs
@@ -24,7 +24,7 @@ namespace Shouldly.Tests.ShouldNotThrow
             get
             {
                 return
-                    "() => { if (true) { throw new Exception(\"Dummy message.\"); } } should not throw but threw System.Exception";
+                    "() => { if (true) { throw new Exception(\"Dummy message.\"); } } should not throw but threw System.Exception with message \"Dummy message.\"";
             }
         }
     }

--- a/src/Shouldly.Tests/ShouldNotThrow/TaskOfTScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/TaskOfTScenario.cs
@@ -21,9 +21,9 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"task should not throw System.RankException but does
-Additional Info:
-Some additional context";
+                return @"Should should not throw but threw System.RankException" +
+                        "Additional Info:" +
+                        "Some additional context";
             }
         }
 

--- a/src/Shouldly.Tests/ShouldNotThrow/TaskOfTScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/TaskOfTScenario.cs
@@ -21,9 +21,9 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"Should should not throw but threw System.RankException" +
-                        "Additional Info:" +
-                        "Some additional context";
+                return "Should should not throw but threw System.RankException with message \"Attempted to operate on an array with the incorrect number of dimensions.\"" +
+                        " Additional Info:" +
+                        " Some additional context";
             }
         }
 

--- a/src/Shouldly.Tests/ShouldNotThrow/TaskOfTScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/TaskOfTScenario.cs
@@ -21,7 +21,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return "Should should not throw but threw System.RankException with message \"Attempted to operate on an array with the incorrect number of dimensions.\"" +
+                return "task should not throw but threw System.RankException with message \"Attempted to operate on an array with the incorrect number of dimensions.\"" +
                         " Additional Info:" +
                         " Some additional context";
             }

--- a/src/Shouldly.Tests/ShouldNotThrow/TaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/TaskScenario.cs
@@ -21,9 +21,9 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"task should not throw System.RankException but does
-Additional Info:
-Some additional context";
+                return @"Should should not throw but threw System.RankException" +
+                        "Additional Info:" +
+                        "Some additional context";
             }
         }
 

--- a/src/Shouldly.Tests/ShouldNotThrow/TaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/TaskScenario.cs
@@ -21,7 +21,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         {
             get
             {
-                return @"Should should not throw but threw System.RankException" +
+                return @"task should not throw but threw System.RankException" +
                         "Additional Info:" +
                         "Some additional context";
             }

--- a/src/Shouldly.Tests/ShouldNotThrow/TaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/TaskScenario.cs
@@ -22,6 +22,7 @@ namespace Shouldly.Tests.ShouldNotThrow
             get
             {
                 return @"task should not throw but threw System.RankException" +
+                        @"with message ""Attempted to operate on an array with the incorrect number of dimensions."""+
                         "Additional Info:" +
                         "Some additional context";
             }

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -143,6 +143,8 @@
     <Compile Include="ShouldNotThrow\FuncOfTaskScenario.cs" />
     <Compile Include="ShouldNotThrow\FuncOfTaskWithTimeoutScenario.cs" />
     <Compile Include="ShouldNotThrow\NestedAwaitsDoNotDeadlockScenario.cs" />
+    <Compile Include="ShouldNotThrow\NestedBlockLambdaWithoutAdditionalInformationsScenario.cs" />
+    <Compile Include="ShouldNotThrow\NestedBlockLambdaScenario.cs" />
     <Compile Include="ShouldNotThrow\TaskOfTScenario.cs" />
     <Compile Include="ShouldNotThrow\TaskOfTWithTimeoutScenario.cs" />
     <Compile Include="ShouldNotThrow\TaskScenario.cs" />

--- a/src/Shouldly/Internals/ShouldNotThrowAssertionContext.cs
+++ b/src/Shouldly/Internals/ShouldNotThrowAssertionContext.cs
@@ -1,0 +1,12 @@
+﻿namespace Shouldly
+{
+    internal class ShouldNotThrowAssertionContext : ShouldlyAssertionContext
+    {
+        public string ExceptionMessage { get; private set; }
+
+        internal ShouldNotThrowAssertionContext(object expected, object actual = null, string exceptionMessage = null) : base(expected, actual)
+        {
+            ExceptionMessage = exceptionMessage;
+        }
+    }
+}

--- a/src/Shouldly/MessageGenerators/ShouldNotThrowMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldNotThrowMessageGenerator.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -17,6 +18,21 @@ namespace Shouldly.MessageGenerators
         public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             var codePart = context.CodePart;
+            // When the static method is used instead of the extension method,
+            // the default message generator will extract "Should" as CodePart.
+            if (context.DeterminedOriginatingFrame && context.CodePart == "Should")
+            {
+                var codeLines = string.Join("\n", File.ReadAllLines(context.FileName).Skip(context.LineNumber).ToArray());
+
+                var indexOf = 
+                    codeLines.IndexOf(context.ShouldMethod) +
+                    context.ShouldMethod.Length +
+                    1;
+                var indexOfComma = codeLines.IndexOf(",");
+                if (indexOf > 0 && indexOfComma > 0 && indexOfComma > indexOf)
+                    codePart = codeLines.Substring(indexOf, indexOfComma - indexOf).Trim();
+            }
+
             var expectedValue = context.Expected.ToStringAwesomely();
 
             const string format = @"{0} should not throw but threw {1}";

--- a/src/Shouldly/MessageGenerators/ShouldNotThrowMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldNotThrowMessageGenerator.cs
@@ -23,7 +23,7 @@ namespace Shouldly.MessageGenerators
             string errorMessage = string.Format(format, codePart, expectedValue);
 
             var notThrowAssertionContext = context as ShouldNotThrowAssertionContext;
-            errorMessage += (notThrowAssertionContext != null) ? string.Format(" with message {0}", notThrowAssertionContext.ExceptionMessage) : string.Empty;
+            errorMessage += (notThrowAssertionContext != null) ? string.Format(" with message \"{0}\"", notThrowAssertionContext.ExceptionMessage) : string.Empty;
 
             return errorMessage;
         }

--- a/src/Shouldly/MessageGenerators/ShouldNotThrowMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldNotThrowMessageGenerator.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Shouldly.MessageGenerators
+{
+    internal class ShouldNotThrowMessageGenerator : ShouldlyMessageGenerator
+    {
+        private static readonly Regex Validator = new Regex("NotThrow", RegexOptions.Compiled);
+
+        public override bool CanProcess(IShouldlyAssertionContext context)
+        {
+            return Validator.IsMatch(context.ShouldMethod);
+        }
+
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
+        {
+            var codePart = context.CodePart;
+            var expectedValue = context.Expected.ToStringAwesomely();
+
+            const string format = @"{0} should not throw but threw {1}";
+            string errorMessage = string.Format(format, codePart, expectedValue);
+
+            var notThrowAssertionContext = context as ShouldNotThrowAssertionContext;
+            errorMessage += (notThrowAssertionContext != null) ? string.Format(" with message {0}", notThrowAssertionContext.ExceptionMessage) : string.Empty;
+
+            return errorMessage;
+        }
+    }
+}

--- a/src/Shouldly/MessageGenerators/ShouldNotThrowMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldNotThrowMessageGenerator.cs
@@ -18,21 +18,7 @@ namespace Shouldly.MessageGenerators
         public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             var codePart = context.CodePart;
-            // When the static method is used instead of the extension method,
-            // the default message generator will extract "Should" as CodePart.
-            if (context.DeterminedOriginatingFrame && context.CodePart == "Should")
-            {
-                var codeLines = string.Join("\n", File.ReadAllLines(context.FileName).Skip(context.LineNumber).ToArray());
-
-                var indexOf = 
-                    codeLines.IndexOf(context.ShouldMethod) +
-                    context.ShouldMethod.Length +
-                    1;
-                var indexOfComma = codeLines.IndexOf(",");
-                if (indexOf > 0 && indexOfComma > 0 && indexOfComma > indexOf)
-                    codePart = codeLines.Substring(indexOf, indexOfComma - indexOf).Trim();
-            }
-
+            
             var expectedValue = context.Expected.ToStringAwesomely();
 
             const string format = @"{0} should not throw but threw {1}";

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrow.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrow.cs
@@ -52,7 +52,7 @@ namespace Shouldly
             }
             catch (Exception ex)
             {
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(ex.GetType(), customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyNotThrowMessage(ex.GetType(), ex.Message, customMessage).ToString());
             }
         }
 
@@ -73,7 +73,7 @@ namespace Shouldly
             }
             catch (Exception ex)
             {
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(ex.GetType(), customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyNotThrowMessage(ex.GetType(), ex.Message, customMessage).ToString());
             }
         }
     }

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
@@ -161,11 +161,11 @@ namespace Shouldly
             }
             catch (AggregateException ex)
             {
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(ex.InnerException.GetType(), customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyNotThrowMessage(ex.InnerException.GetType(), ex.InnerException.Message, customMessage).ToString());
             }
             catch (Exception ex)
             {
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(ex.GetType(), customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyNotThrowMessage(ex.GetType(), ex.Message, customMessage).ToString());
             }
         }
 

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
@@ -225,11 +225,11 @@ namespace Shouldly
             }
             catch (AggregateException ex)
             {
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(ex.InnerException.GetType(), customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyNotThrowMessage(ex.InnerException.GetType(), ex.InnerException.Message, customMessage).ToString());
             }
             catch (Exception ex)
             {
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(ex.GetType(), customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyNotThrowMessage(ex.GetType(), ex.Message, customMessage).ToString());
             }
         }
 
@@ -253,8 +253,7 @@ namespace Shouldly
             if (innerException is TException)
                 return (TException)innerException;
 
-            throw new ShouldAssertException(
-                new ExpectedActualShouldlyMessage(typeof(TException), innerException.GetType(), customMessage).ToString());
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(typeof(TException), innerException.GetType(), customMessage).ToString());
         }
     }
 }

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -65,6 +65,11 @@
     <Compile Include="DifferenceHighlighting\StringDifferenceHighlighter.cs" />
     <Compile Include="Internals\ShouldThrowAssertionContext.cs" />
     <Compile Include="MessageGenerators\ShouldBeNullOrWhiteSpaceMessageGenerator.cs" />
+    <Compile Include="App_Packages\ExpressionStringBuilder.0.9.1\ExpressionStringBuilder.cs" />
+    <Compile Include="App_Packages\JetBrainsAnnotations\JetBrainsAnnotations.cs" />
+    <Compile Include="Internals\ShouldNotThrowAssertionContext.cs" />
+    <Compile Include="Internals\ShouldThrowAssertionContext.cs" />
+    <Compile Include="MessageGenerators\ShouldNotThrowMessageGenerator.cs" />
     <Compile Include="ShouldlyExtensionMethods\ShouldBe\StringContainsTestExtensions.cs" />
     <Compile Include="ShouldlyExtensionMethods\ShouldBe\StringNullOrEmptyTestExtensions.cs" />
     <Compile Include="ShouldlyExtensionMethods\ShouldBe\StringNullOrWhiteSpaceTestExtensions.cs" />

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -63,10 +63,7 @@
     <Compile Include="DifferenceHighlighting\FormattedDetailedDifferenceString.cs" />
     <Compile Include="DifferenceHighlighting\DifferenceIndexConsolidator.cs" />
     <Compile Include="DifferenceHighlighting\StringDifferenceHighlighter.cs" />
-    <Compile Include="Internals\ShouldThrowAssertionContext.cs" />
     <Compile Include="MessageGenerators\ShouldBeNullOrWhiteSpaceMessageGenerator.cs" />
-    <Compile Include="App_Packages\ExpressionStringBuilder.0.9.1\ExpressionStringBuilder.cs" />
-    <Compile Include="App_Packages\JetBrainsAnnotations\JetBrainsAnnotations.cs" />
     <Compile Include="Internals\ShouldNotThrowAssertionContext.cs" />
     <Compile Include="Internals\ShouldThrowAssertionContext.cs" />
     <Compile Include="MessageGenerators\ShouldNotThrowMessageGenerator.cs" />

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -80,6 +80,15 @@ namespace Shouldly
         }
     }
 
+    internal class ExpectedShouldlyNotThrowMessage : ShouldlyMessage
+    {
+        public ExpectedShouldlyNotThrowMessage(object expected, string exceptionMessage, Func<string> customMessage)
+        {
+            ShouldlyAssertionContext = new ShouldNotThrowAssertionContext(expected, null, exceptionMessage);
+            if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
+        }
+    }
+
 #if net40
     internal class CompleteInShouldlyMessage : ShouldlyMessage
     {
@@ -125,7 +134,8 @@ namespace Shouldly
             new ShouldContainPredicateMessageGenerator(), 
             new ShouldBeIgnoringOrderMessageGenerator(), 
             new ShouldSatisfyAllConditionsMessageGenerator(),
-            new ShouldBeSubsetOfMessageGenerator()
+            new ShouldBeSubsetOfMessageGenerator(),
+            new ShouldNotThrowMessageGenerator()
         };
         private IShouldlyAssertionContext _shouldlyAssertionContext;
 


### PR DESCRIPTION
This PR will fix #220

I took the branch from @JoeMighty and started to implement the code to extract the expression passed to `Should.NotThrow`.  ~~At the moment in only works with the `Should.NotThrow(action, customMessage)` overload and only if action doesn't contain a comma (,). Also the tests proposed by @JakeGinnivan in #220 needs to be added.~~

The current code to extract the parameter counts the open and closing parenthesis and search for `,` or `)` to find the end of the parameter. I added some tests proposed by @JakeGinnivan but not all of them. Should I add more?