### PR TITLE
Fix for #327 Mono NullReferenceException

### DIFF
--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldCompleteInExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldCompleteInExtensions.cs
@@ -138,7 +138,9 @@ namespace Shouldly
         {
             MethodInfo preserveStackTrace = typeof(Exception).GetMethod("InternalPreserveStackTrace",
               BindingFlags.Instance | BindingFlags.NonPublic);
-            preserveStackTrace.Invoke(exception, null);
+
+            if (preserveStackTrace != null)
+                preserveStackTrace.Invoke(exception, null);
         }
     }
 }


### PR DESCRIPTION
`preserveStackTrace` is null when running under Mono, so `.Invoke` fails. After this fix, `Should.Throw<>` behaves as expected.