### PR TITLE
Updates NuGet tags and fixes a typo

### DIFF
--- a/shouldly.nuspec
+++ b/shouldly.nuspec
@@ -10,7 +10,7 @@
     <iconUrl>https://raw.github.com/shouldly/shouldly/master/Icons/package_icon.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Shouldly - Assertion framework for .NET. The way asserting *Should* be</description>
-    <tags>testing unit testing TDD AAA shoulda testunit rspec</tags>
+    <tags>test unit testing TDD AAA should testunit rspec assert assertion framework</tags>
     <dependencies>
       <group targetFramework="dotnet">
         <dependency id="System.Collections" version="4.0.0" />


### PR DESCRIPTION
I was trying to get shouldly via NuGet and I couldn't find it after searching for `should`

It turns out there was a change to the code base that moved the **shouldly.nuspec** file from `src/Shouldly/` to `src/`, but used an old version of the file.

This PR restores changes from #266 (which fixed #265).
Also, you should double check if there were any other changes that might have been lost when transitioning from `src/Shouldly/` to `src/`