### PR TITLE
Addition of Should.Throw and Should.ThrowAsync methods

### DIFF
--- a/src/Shouldly.Shared/ShouldStaticClasses/ShouldThrow.cs
+++ b/src/Shouldly.Shared/ShouldStaticClasses/ShouldThrow.cs
@@ -41,6 +41,39 @@ namespace Shouldly
             throw new ShouldAssertException(new ShouldlyThrowMessage(typeof(TException), customMessage, shouldlyMethod).ToString());
         }
 
+        /*** Should.Throw(Action) ***/
+        public static Exception Throw([InstantHandle] Action actual, Type exceptionType)
+        {
+            return Throw(actual, () => null, exceptionType);
+        }
+        public static Exception Throw([InstantHandle] Action actual, string customMessage, Type exceptionType)
+        {
+            return Throw(actual, () => customMessage, exceptionType);
+        }
+        public static Exception Throw([InstantHandle] Action actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        {
+            return ThrowInternal(actual, customMessage, exceptionType);
+        }
+        internal static Exception ThrowInternal([InstantHandle] Action actual, [InstantHandle] Func<string> customMessage, Type exceptionType,
+            [CallerMemberName] string shouldlyMethod = null)
+        {
+            try
+            {
+                actual();
+            }
+            catch (Exception e)
+            {
+                if (e.GetType() == exceptionType)
+                {
+                    return e;
+                }
+
+                throw new ShouldAssertException(new ShouldlyThrowMessage(exceptionType, e.GetType(), customMessage, shouldlyMethod).ToString(), e);
+            }
+
+            throw new ShouldAssertException(new ShouldlyThrowMessage(exceptionType, customMessage, shouldlyMethod).ToString());
+        }
+
         /*** Should.NotThrow(Action) ***/
         public static void NotThrow([InstantHandle] Action action)
         {

--- a/src/Shouldly.Shared/ShouldStaticClasses/ShouldThrowTaskAsync.cs
+++ b/src/Shouldly.Shared/ShouldStaticClasses/ShouldThrowTaskAsync.cs
@@ -22,6 +22,19 @@ namespace Shouldly
             return ThrowAsync<TException>(() => task, customMessage);
         }
 
+        public static Task<Exception> ThrowAsync(Task task, Type exceptionType)
+        {
+            return ThrowAsync(task, () => null, exceptionType);
+        }
+        public static Task<Exception> ThrowAsync(Task task, string customMessage, Type exceptionType)
+        {
+            return ThrowAsync(task, () => customMessage, exceptionType);
+        }
+        public static Task<Exception> ThrowAsync(Task task, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        {
+            return ThrowAsync(() => task, customMessage, exceptionType);
+        }
+
         /*** Should.ThrowAsync(Func<Task>) ***/
         public static Task<TException> ThrowAsync<TException>(Func<Task> actual) where TException : Exception
         {
@@ -49,6 +62,36 @@ namespace Shouldly
                         , new TaskCanceledException("Task is cancelled"));
 
                 throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), customMessage, stackTrace).ToString());
+            });
+        }
+
+        /*** Should.ThrowAsync(Func<Task>) ***/
+        public static Task<Exception> ThrowAsync(Func<Task> actual, Type exceptionType)
+        {
+            return ThrowAsync(actual, () => null, exceptionType);
+        }
+        public static Task<Exception> ThrowAsync(Func<Task> actual, string customMessage, Type exceptionType)
+        {
+            return ThrowAsync(actual, () => customMessage, exceptionType);
+        }
+        public static Task<Exception> ThrowAsync(Func<Task> actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        {
+            var stackTrace = new StackTrace(true);
+            return actual().ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    if (t.Exception == null)
+                        throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(exceptionType, customMessage, stackTrace).ToString());
+
+                    return HandleAggregateException(t.Exception, customMessage, exceptionType);
+                }
+
+                if (t.IsCanceled)
+                    throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(exceptionType, customMessage, stackTrace).ToString()
+                        , new TaskCanceledException("Task is cancelled"));
+
+                throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(exceptionType, customMessage, stackTrace).ToString());
             });
         }
     }

--- a/src/Shouldly.Shared/ShouldlyExtensionMethods/ShouldThrowExtensions.cs
+++ b/src/Shouldly.Shared/ShouldlyExtensionMethods/ShouldThrowExtensions.cs
@@ -22,6 +22,20 @@ namespace Shouldly
             return Should.ThrowInternal<TException>(actual, customMessage);
         }
 
+        /*** ShouldThrow(Action) ***/
+        public static Exception ShouldThrow(this Action actual, Type exceptionType)
+        {
+            return ShouldThrow(actual, () => null, exceptionType);
+        }
+        public static Exception ShouldThrow(this Action actual, string customMessage, Type exceptionType)
+        {
+            return ShouldThrow(actual, () => customMessage, exceptionType);
+        }
+        public static Exception ShouldThrow(this Action actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        {
+            return Should.ThrowInternal(actual, customMessage, exceptionType);
+        }
+
         /*** ShouldNotThrow(Action) ***/
         public static void ShouldNotThrow(this Action action)
         {

--- a/src/Shouldly.Shared/ShouldlyExtensionMethods/ShouldThrowTaskAsyncExtensions.cs
+++ b/src/Shouldly.Shared/ShouldlyExtensionMethods/ShouldThrowTaskAsyncExtensions.cs
@@ -24,6 +24,20 @@ namespace Shouldly
             return Should.ThrowAsync<TException>(task, customMessage);
         }
 
+        /*** ShouldThrowAsync(Task) ***/
+        public static Task<Exception> ShouldThrowAsync(this Task task, Type exceptionType)
+        {
+            return Should.ThrowAsync(task, exceptionType);
+        }
+        public static Task<Exception> ShouldThrowAsync(this Task task, string customMessage, Type exceptionType)
+        {
+            return Should.ThrowAsync(task, customMessage, exceptionType);
+        }
+        public static Task<Exception> ShouldThrowAsync(this Task task, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        {
+            return Should.ThrowAsync(task, customMessage, exceptionType);
+        }
+
         /*** ShouldThrowAsync(Func<Task>) ***/
         public static Task<TException> ShouldThrowAsync<TException>(this Func<Task> actual) where TException : Exception
         {
@@ -36,6 +50,20 @@ namespace Shouldly
         public static Task<TException> ShouldThrowAsync<TException>(this Func<Task> actual, [InstantHandle] Func<string> customMessage) where TException : Exception
         {
             return Should.ThrowAsync<TException>(actual, customMessage);
+        }
+
+        /*** ShouldThrowAsync(Func<Task>) ***/
+        public static Task<Exception> ShouldThrowAsync(this Func<Task> actual, Type exceptionType)
+        {
+            return Should.ThrowAsync(actual, exceptionType);
+        }
+        public static Task<Exception> ShouldThrowAsync(this Func<Task> actual, string customMessage, Type exceptionType)
+        {
+            return Should.ThrowAsync(actual, customMessage, exceptionType);
+        }
+        public static Task<Exception> ShouldThrowAsync(this Func<Task> actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        {
+            return Should.ThrowAsync(actual, customMessage, exceptionType);
         }
     }
 }

--- a/src/Shouldly.Shared/ShouldlyExtensionMethods/ShouldThrowTaskExtensions.cs
+++ b/src/Shouldly.Shared/ShouldlyExtensionMethods/ShouldThrowTaskExtensions.cs
@@ -24,6 +24,20 @@ namespace Shouldly
             return ShouldThrow<TException>(() => actual, customMessage);
         }
 
+        /*** ShouldThrow(Task) ***/
+        public static Exception ShouldThrow(this Task actual, Type exceptionType)
+        {
+            return ShouldThrow(() => actual, exceptionType);
+        }
+        public static Exception ShouldThrow(this Task actual, string customMessage, Type exceptionType)
+        {
+            return ShouldThrow(() => actual, customMessage, exceptionType);
+        }
+        public static Exception ShouldThrow(this Task actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        {
+            return ShouldThrow(() => actual, customMessage, exceptionType);
+        }
+
         /*** ShouldThrow(Func<Task>) ***/
         public static TException ShouldThrow<TException>(this Func<Task> actual) where TException : Exception
         {
@@ -36,6 +50,20 @@ namespace Shouldly
         public static TException ShouldThrow<TException>(this Func<Task> actual, [InstantHandle] Func<string> customMessage) where TException : Exception
         {
             return ShouldThrow<TException>(actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
+        }
+
+        /*** ShouldThrow(Func<Task>) ***/
+        public static Exception ShouldThrow(this Func<Task> actual, Type exceptionType)
+        {
+            return ShouldThrow(actual, () => null, exceptionType);
+        }
+        public static Exception ShouldThrow(this Func<Task> actual, string customMessage, Type exceptionType)
+        {
+            return ShouldThrow(actual, () => customMessage, exceptionType);
+        }
+        public static Exception ShouldThrow(this Func<Task> actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        {
+            return ShouldThrow(actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage, exceptionType);
         }
 
         /*** ShouldThrow(Task, TimeSpan) ***/
@@ -52,6 +80,20 @@ namespace Shouldly
             return ShouldThrow<TException>(() => actual, timeoutAfter, customMessage);
         }
 
+        /*** ShouldThrow(Task, TimeSpan) ***/
+        public static Exception ShouldThrow(this Task actual, TimeSpan timeoutAfter, Type exceptionType)
+        {
+            return ShouldThrow(() => actual, timeoutAfter, exceptionType);
+        }
+        public static Exception ShouldThrow(this Task actual, TimeSpan timeoutAfter, string customMessage, Type exceptionType)
+        {
+            return ShouldThrow(() => actual, timeoutAfter, customMessage, exceptionType);
+        }
+        public static Exception ShouldThrow(this Task actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        {
+            return ShouldThrow(() => actual, timeoutAfter, customMessage, exceptionType);
+        }
+
         /*** ShouldThrow(Func<Task>, TimeSpan) ***/
         public static TException ShouldThrow<TException>(this Func<Task> actual, TimeSpan timeoutAfter) where TException : Exception
         {
@@ -64,6 +106,20 @@ namespace Shouldly
         public static TException ShouldThrow<TException>(this Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage) where TException : Exception
         {
             return Should.ThrowInternal<TException>(actual, timeoutAfter, customMessage);
+        }
+
+        /*** ShouldThrow(Func<Task>, TimeSpan) ***/
+        public static Exception ShouldThrow(this Func<Task> actual, TimeSpan timeoutAfter, Type exceptionType)
+        {
+            return ShouldThrow(actual, timeoutAfter, () => null,exceptionType);
+        }
+        public static Exception ShouldThrow(this Func<Task> actual, TimeSpan timeoutAfter, string customMessage, Type exceptionType)
+        {
+            return ShouldThrow(actual, timeoutAfter, () => customMessage,exceptionType);
+        }
+        public static Exception ShouldThrow(this Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        {
+            return Should.ThrowInternal(actual, timeoutAfter, customMessage,exceptionType);
         }
 
         /*** ShouldNotThrow(Task) ***/

--- a/src/Shouldly.Tests.Shared/ShouldThrow/ActionDelegateScenario.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrow/ActionDelegateScenario.cs
@@ -6,7 +6,6 @@ namespace Shouldly.Tests.ShouldThrow
 {
     public class ActionDelegateScenario
     {
-
         [Fact]
         public void ActionDelegateScenarioShouldFail()
         {
@@ -34,11 +33,47 @@ Additional Info:
         }
 
         [Fact]
+        public void ActionDelegateScenarioShouldFail_ExceptionTypePassedIn()
+        {
+            Action action = () => { };
+            Verify.ShouldFail(() =>
+action.ShouldThrow("Some additional context", typeof(NotImplementedException)),
+
+errorWithSource:
+@"`action()`
+    should throw
+System.NotImplementedException
+    but did not
+
+Additional Info:
+    Some additional context",
+
+    errorWithoutSource:
+@"delegate
+    should throw
+System.NotImplementedException
+    but did not
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
         public void ShouldPass()
         {
             var action = new Action(() => { throw new NotImplementedException(); });
 
             var ex = action.ShouldThrow<NotImplementedException>();
+            ex.ShouldBeOfType<NotImplementedException>();
+            ex.ShouldNotBe(null);
+        }
+
+        [Fact]
+        public void ShouldPass_ExceptionTypePassedIn()
+        {
+            var action = new Action(() => { throw new NotImplementedException(); });
+
+            var ex = action.ShouldThrow(typeof(NotImplementedException));
             ex.ShouldBeOfType<NotImplementedException>();
             ex.ShouldNotBe(null);
         }

--- a/src/Shouldly.Tests.Shared/ShouldThrow/ActionDelegateThrowsDifferentExceptionScenario.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrow/ActionDelegateThrowsDifferentExceptionScenario.cs
@@ -32,6 +32,34 @@ System.RankException
 
 Additional Info:
     Some additional context");
-        }
+        }    
+
+    [Fact]
+    public void NestedBlockLambdaWithoutAdditionalInformationsScenarioShouldFail_ExceptionTypePassedIn()
+    {
+        Action action = () => { throw new RankException(); };
+        Verify.ShouldFail(() =>
+action.ShouldThrow("Some additional context", typeof(InvalidOperationException)),
+
+errorWithSource:
+@"`action()`
+    should throw
+System.InvalidOperationException
+    but threw
+System.RankException
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"delegate
+    should throw
+System.InvalidOperationException
+    but threw
+System.RankException
+
+Additional Info:
+    Some additional context");
     }
+}
 }

--- a/src/Shouldly.Tests.Shared/ShouldThrow/FuncOfTaskOfStringScenario.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrow/FuncOfTaskOfStringScenario.cs
@@ -39,6 +39,35 @@ Additional Info:
         }
 
         [Fact]
+        public void FuncOfTaskOfStringScenarioShouldFail_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => "Foo",
+                            CancellationToken.None, TaskCreationOptions.None,
+                            TaskScheduler.Default);
+
+            Verify.ShouldFail(() =>
+task.ShouldThrow("Some additional context", typeof(InvalidOperationException)),
+
+errorWithSource:
+@"Task `task`
+    should throw
+System.InvalidOperationException
+    but did not
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Task
+    should throw
+System.InvalidOperationException
+    but did not
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
         public void ShouldPass()
         {
             var task = Task.Factory.StartNew<string>(() => { throw new InvalidOperationException(); },
@@ -46,6 +75,19 @@ Additional Info:
                     TaskScheduler.Default);
 
             var ex = task.ShouldThrow<InvalidOperationException>();
+
+            ex.ShouldNotBe(null);
+            ex.ShouldBeOfType<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void ShouldPass_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew<string>(() => { throw new InvalidOperationException(); },
+                    CancellationToken.None, TaskCreationOptions.None,
+                    TaskScheduler.Default);
+
+            var ex = task.ShouldThrow(typeof(InvalidOperationException));
 
             ex.ShouldNotBe(null);
             ex.ShouldBeOfType<InvalidOperationException>();

--- a/src/Shouldly.Tests.Shared/ShouldThrow/FuncOfTaskOfStringThrowsDifferentExceptionScenario.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrow/FuncOfTaskOfStringThrowsDifferentExceptionScenario.cs
@@ -42,6 +42,38 @@ Additional Info:
     Some additional context");
         }
 
+[Fact]
+        public void FuncOfTaskOfStringThrowsDifferentExceptionScenarioShouldFail_ExceptionTypePassedIn()
+        {
+            var action = new Func<Task<string>>(() =>
+            {
+                throw new RankException();
+            });
+
+            Verify.ShouldFail(() =>
+action.ShouldThrow("Some additional context", typeof(InvalidOperationException)),
+
+errorWithSource:
+@"Task `action`
+    should throw
+System.InvalidOperationException
+    but threw
+System.RankException
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Task
+    should throw
+System.InvalidOperationException
+    but threw
+System.RankException
+
+Additional Info:
+    Some additional context");
+        }
+
         [Fact]
         public void ShouldPass()
         {
@@ -50,6 +82,19 @@ Additional Info:
                     TaskScheduler.Default);
 
             var ex = task.ShouldThrow<InvalidOperationException>();
+
+            ex.ShouldNotBe(null);
+            ex.ShouldBeOfType<InvalidOperationException>();
+        }
+
+[Fact]
+        public void ShouldPass_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew<string>(() => { throw new InvalidOperationException(); },
+                    CancellationToken.None, TaskCreationOptions.None,
+                    TaskScheduler.Default);
+
+            var ex = task.ShouldThrow(typeof(InvalidOperationException));
 
             ex.ShouldNotBe(null);
             ex.ShouldBeOfType<InvalidOperationException>();

--- a/src/Shouldly.Tests.Shared/ShouldThrow/FuncOfTaskScenario.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrow/FuncOfTaskScenario.cs
@@ -39,6 +39,35 @@ Additional Info:
     Some additional context");
         }
 
+[Fact]
+        public void FuncOfTaskScenarioShouldFail_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => { },
+                            CancellationToken.None, TaskCreationOptions.None,
+                            TaskScheduler.Default);
+
+            Verify.ShouldFail(() =>
+            task.ShouldThrow("Some additional context", typeof(InvalidOperationException)),
+
+errorWithSource:
+@"Task `task`
+    should throw
+System.InvalidOperationException
+    but did not
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Task
+    should throw
+System.InvalidOperationException
+    but did not
+
+Additional Info:
+    Some additional context");
+        }
+
         [Fact]
         public void ShouldPass()
         {
@@ -47,6 +76,19 @@ Additional Info:
                     TaskScheduler.Default);
 
             var ex = task.ShouldThrow<InvalidOperationException>();
+
+            ex.ShouldNotBe(null);
+            ex.ShouldBeOfType<InvalidOperationException>();
+        }
+
+[Fact]
+        public void ShouldPass_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => { throw new InvalidOperationException(); },
+                    CancellationToken.None, TaskCreationOptions.None,
+                    TaskScheduler.Default);
+
+            var ex = task.ShouldThrow(typeof(InvalidOperationException));
 
             ex.ShouldNotBe(null);
             ex.ShouldBeOfType<InvalidOperationException>();

--- a/src/Shouldly.Tests.Shared/ShouldThrow/FuncOfTaskWhichThrowsDirectlyScenario.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrow/FuncOfTaskWhichThrowsDirectlyScenario.cs
@@ -16,6 +16,14 @@ namespace Shouldly.Tests.ShouldThrow
             var task = new Func<Task>(() => { throw new InvalidOperationException(); });
             task.ShouldThrow<InvalidOperationException>();
         }
+
+[Fact]
+        public void ShouldPass_ExceptionTypePassedIn()
+        {
+            // ReSharper disable once RedundantDelegateCreation
+            var task = new Func<Task>(() => { throw new InvalidOperationException(); });
+            task.ShouldThrow(typeof(InvalidOperationException));
+        }
     }
 }
 #endif

--- a/src/Shouldly.Tests.Shared/ShouldThrow/FuncOfTaskWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrow/FuncOfTaskWithTimeoutScenario.cs
@@ -22,6 +22,18 @@ namespace Shouldly.Tests.ShouldThrow
             ex.Message.ShouldContainWithoutWhitespace(ChuckedAWobblyErrorMessage);
         }
 
+[Fact]
+        public void ShouldThrowAWobbly_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => { Thread.Sleep(5000); },
+                CancellationToken.None, TaskCreationOptions.None,
+                TaskScheduler.Default);
+
+            var ex = Should.Throw(() => task.ShouldThrow(TimeSpan.FromSeconds(0.5), "Some additional context", typeof(ShouldCompleteInException)), typeof(ShouldCompleteInException));
+
+            ex.Message.ShouldContainWithoutWhitespace(ChuckedAWobblyErrorMessage);
+        }
+
         string ChuckedAWobblyErrorMessage => @"Task
         should complete in
     00:00:00.5000000
@@ -37,6 +49,19 @@ namespace Shouldly.Tests.ShouldThrow
                 TaskScheduler.Default);
 
             var ex = task.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(2));
+
+            ex.ShouldNotBe(null);
+            ex.ShouldBeOfType<InvalidOperationException>();
+        }
+
+[Fact]
+        public void ShouldPass_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => { throw new InvalidOperationException(); },
+                CancellationToken.None, TaskCreationOptions.None,
+                TaskScheduler.Default);
+
+            var ex = task.ShouldThrow(TimeSpan.FromSeconds(2), typeof(InvalidOperationException));
 
             ex.ShouldNotBe(null);
             ex.ShouldBeOfType<InvalidOperationException>();

--- a/src/Shouldly.Tests.Shared/ShouldThrow/NestedAwaitsDoNotDeadlockScenario.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrow/NestedAwaitsDoNotDeadlockScenario.cs
@@ -28,6 +28,25 @@ namespace Shouldly.Tests.ShouldThrow
 
             task.ShouldThrow<InvalidOperationException>();
         }
+
+[Fact]
+        public void DelegateShouldDropSynchronisationContext_ExceptionTypePassedIn()
+        {
+            // The await keyword will automatically capture synchronisation context
+            // Because shouldly uses .Wait() we cannot let continuations run on the sync context without a deadlock
+            var synchronizationContext = new SynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+            SynchronizationContext.Current.ShouldNotBe(null);
+
+            var task = new Func<Task>(() =>
+            {
+                SynchronizationContext.Current.ShouldBe(null);
+
+                throw new InvalidOperationException();
+            });
+
+            task.ShouldThrow(typeof(InvalidOperationException));
+        }
     }
 }
 #endif

--- a/src/Shouldly.Tests.Shared/ShouldThrow/TaskScenario.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrow/TaskScenario.cs
@@ -39,6 +39,35 @@ Additional Info:
     Some additional context");
         }
 
+[Fact]
+        public void TaskScenarioShouldFail_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => { },
+                            CancellationToken.None, TaskCreationOptions.None,
+                            TaskScheduler.Default);
+
+            Verify.ShouldFail(() =>
+task.ShouldThrow("Some additional context", typeof(InvalidOperationException)),
+
+errorWithSource:
+@"Task `task`
+    should throw
+System.InvalidOperationException
+    but did not
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Task
+    should throw
+System.InvalidOperationException
+    but did not
+
+Additional Info:
+    Some additional context");
+        }
+
         [Fact]
         public void ShouldPass()
         {
@@ -47,6 +76,19 @@ Additional Info:
                     TaskScheduler.Default);
 
             var ex = task.ShouldThrow<InvalidOperationException>();
+
+            ex.ShouldNotBe(null);
+            ex.ShouldBeOfType<InvalidOperationException>();
+        }
+
+[Fact]
+        public void ShouldPass_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => { throw new InvalidOperationException(); },
+                    CancellationToken.None, TaskCreationOptions.None,
+                    TaskScheduler.Default);
+
+            var ex = task.ShouldThrow(typeof(InvalidOperationException));
 
             ex.ShouldNotBe(null);
             ex.ShouldBeOfType<InvalidOperationException>();

--- a/src/Shouldly.Tests.Shared/ShouldThrow/TaskThrowsDifferentExceptionScenario.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrow/TaskThrowsDifferentExceptionScenario.cs
@@ -36,12 +36,50 @@ Additional Info:
     Some additional context");
         }
 
+[Fact]
+        public void TaskThrowsDifferentExceptionScenarioShouldFail_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => { throw new RankException(); });
+            Verify.ShouldFail(() =>
+task.ShouldThrow("Some additional context", typeof(InvalidOperationException)),
+
+errorWithSource:
+@"Task `task`
+    should throw
+System.InvalidOperationException
+    but threw
+System.RankException
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Task
+    should throw
+System.InvalidOperationException
+    but threw
+System.RankException
+
+Additional Info:
+    Some additional context");
+        }
+
         [Fact]
         public void ShouldPass()
         {
             var task = Task.Factory.StartNew(() => { throw new InvalidOperationException(); });
 
             var ex = task.ShouldThrow<InvalidOperationException>();
+            ex.ShouldNotBe(null);
+            ex.ShouldBeOfType<InvalidOperationException>();
+        }
+
+[Fact]
+        public void ShouldPass_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => { throw new InvalidOperationException(); });
+
+            var ex = task.ShouldThrow(typeof(InvalidOperationException));
             ex.ShouldNotBe(null);
             ex.ShouldBeOfType<InvalidOperationException>();
         }

--- a/src/Shouldly.Tests.Shared/ShouldThrow/TaskWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrow/TaskWithTimeoutScenario.cs
@@ -21,6 +21,17 @@ namespace Shouldly.Tests.ShouldThrow
             ex.Message.ShouldContainWithoutWhitespace(ChuckedAWobblyErrorMessage);
         }
 
+[Fact]
+        public void ShouldThrowAWobbly_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => { Thread.Sleep(5000); },
+                CancellationToken.None, TaskCreationOptions.None,
+                TaskScheduler.Default);
+
+            var ex = Should.Throw(() => task.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(0.5), "Some additional context"), typeof(ShouldCompleteInException));
+            ex.Message.ShouldContainWithoutWhitespace(ChuckedAWobblyErrorMessage);
+        }
+
         string ChuckedAWobblyErrorMessage => @"
     Task
         should complete in
@@ -37,6 +48,18 @@ namespace Shouldly.Tests.ShouldThrow
                 TaskScheduler.Default);
 
             var ex = task.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(2));
+            ex.ShouldNotBe(null);
+            ex.ShouldBeOfType<InvalidOperationException>();
+        }
+
+[Fact]
+        public void ShouldPass_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => { throw new InvalidOperationException(); },
+                CancellationToken.None, TaskCreationOptions.None,
+                TaskScheduler.Default);
+
+            var ex = task.ShouldThrow(TimeSpan.FromSeconds(2), typeof(InvalidOperationException));
             ex.ShouldNotBe(null);
             ex.ShouldBeOfType<InvalidOperationException>();
         }

--- a/src/Shouldly.Tests.Shared/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
+++ b/src/Shouldly.Tests.Shared/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
@@ -33,6 +33,29 @@ namespace Shouldly.Tests.ShouldThrowAsync
             }
         }
 
+[Fact]
+        public void ShouldThrowAWobbly_ExceptionTypePassedIn()
+        {
+            try
+            {
+                Task task = Task.Factory.StartNew(() => { var a = 1 + 1; Console.WriteLine(a); },
+                        CancellationToken.None, TaskCreationOptions.None,
+                        TaskScheduler.Default);
+
+                var result = task.ShouldThrowAsync("Some additional context", typeof(InvalidOperationException));
+                result.Wait();
+            }
+            catch (AggregateException e)
+            {
+                var inner = e.Flatten().InnerException;
+                var ex = inner.ShouldBeOfType<ShouldAssertException>();
+                ex.Message.ShouldContainWithoutWhitespace(@"
+                            `task` should throw System.InvalidOperationException but did not
+                            Additional Info:
+                            Some additional context");
+            }
+        }
+
         [Fact]
         public void ShouldPass()
         {
@@ -41,6 +64,17 @@ namespace Shouldly.Tests.ShouldThrowAsync
                 TaskScheduler.Default);
 
             var result = task.ShouldThrowAsync<InvalidOperationException>();
+            result.Wait();
+        }
+
+[Fact]
+        public void ShouldPass_ExceptionTypePassedIn()
+        {
+            var task = Task.Factory.StartNew(() => { throw new InvalidOperationException(); },
+                CancellationToken.None, TaskCreationOptions.None,
+                TaskScheduler.Default);
+
+            var result = task.ShouldThrowAsync(typeof(InvalidOperationException));
             result.Wait();
         }
     }


### PR DESCRIPTION
To support passng in the Exception type as a parameter rather than as a type argument.

This enables easier use with NUnit/xUnit theory tests where different values may throw different exception types