### PR TITLE
Trim quotes when initializing DiffTools

### DIFF
--- a/src/Shouldly.Shared/Configuration/DiffTool.cs
+++ b/src/Shouldly.Shared/Configuration/DiffTool.cs
@@ -59,8 +59,10 @@ namespace Shouldly.Configuration
             var userPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User);
             var machinePath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine);
             var values = $"{processPath};{userPath};{machinePath}";
+            
             return values.Split(';')
                 .Where(p => !string.IsNullOrEmpty(p))
+                .Select(path => path.Trim('"'))
                 .Select(path => Path.Combine(path, fileName))
                 .FirstOrDefault(File.Exists);
         }

--- a/src/Shouldly.Shared/Configuration/DiffTool.cs
+++ b/src/Shouldly.Shared/Configuration/DiffTool.cs
@@ -59,7 +59,6 @@ namespace Shouldly.Configuration
             var userPath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.User);
             var machinePath = Environment.GetEnvironmentVariable("PATH", EnvironmentVariableTarget.Machine);
             var values = $"{processPath};{userPath};{machinePath}";
-            
             return values.Split(';')
                 .Where(p => !string.IsNullOrEmpty(p))
                 .Select(path => path.Trim('"'))


### PR DESCRIPTION
This fix trims quotes when initializing DiffTools. It may not be the correct solution (depending on your view) but it fixes the most common problem.

I could strip all characters from `Path.InvalidPathChars` but I think that may cause some wierd behavior, since they are allowed in the environment variables. 