### PR TITLE
Adding VisitTypeBinary override for ExpressionStringBuilder - Resolves #389

### DIFF
--- a/src/Shouldly.Tests/ShouldAllBe/TypeBinaryExpressionScenario.cs
+++ b/src/Shouldly.Tests/ShouldAllBe/TypeBinaryExpressionScenario.cs
@@ -1,0 +1,46 @@
+﻿using Shouldly.Tests.Strings;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldAllBe
+{       
+    public class TypeBinaryExpressionScenario
+    {
+        [Fact]
+        public void TypeBinaryExpressionScenarioShouldFail()
+        {
+            List<object> objects = new List<object> { "1", 1 };
+                        
+            Verify.ShouldFail(() => 
+objects.ShouldAllBe(x => x is string, "Some additional context"),
+
+errorWithSource:
+@"objects
+    should satisfy the condition
+(x Is String)
+    but
+[1]
+    do not
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[""1"", 1]
+    should satisfy the condition
+(x Is String)
+    but
+[1]
+    do not
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            new[] { "1", "2", "3" }.ShouldAllBe(x => x is string);
+        }
+    }
+}

--- a/src/Shouldly/App_Packages/ExpressionStringBuilder.0.10.0/ExpressionStringBuilder.cs
+++ b/src/Shouldly/App_Packages/ExpressionStringBuilder.0.10.0/ExpressionStringBuilder.cs
@@ -67,6 +67,12 @@ namespace ExpressionToString
             return node;
         }
 
+        protected override Expression VisitTypeBinary(TypeBinaryExpression node)
+        {
+            Out(node.ToString());
+            return node;
+        }
+
         protected override Expression VisitParameter(ParameterExpression node)
         {
             Out(node.Name);


### PR DESCRIPTION
Threw together this PR for #389 . Seems like we were yet to override ```VisitTypeBinary()``` in the ```ExpressionVisitor``` class, so it was not returning the full expression.