### PR TITLE
Compare Custom classes that don't implement IComparable (#364)

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
@@ -348,6 +348,9 @@ namespace Shouldly
             where T : System.IComparable<> { }
         public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, string customMessage)
             where T : System.IComparable<> { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, [JetBrains.Annotations.InstantHandleAttribute()] System.Func<string> customMessage)
             where T : System.IComparable<> { }
         public static void ShouldBeInRange<T>(this T actual, T from, T to)
@@ -360,12 +363,18 @@ namespace Shouldly
             where T : System.IComparable<> { }
         public static void ShouldBeLessThan<T>(this T actual, T expected, string customMessage)
             where T : System.IComparable<> { }
+        public static void ShouldBeLessThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
+        public static void ShouldBeLessThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
+        public static void ShouldBeLessThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldBeLessThan<T>(this T actual, T expected, [JetBrains.Annotations.InstantHandleAttribute()] System.Func<string> customMessage)
             where T : System.IComparable<> { }
         public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected)
             where T : System.IComparable<> { }
         public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, string customMessage)
             where T : System.IComparable<> { }
+        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
+        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
+        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, [JetBrains.Annotations.InstantHandleAttribute()] System.Func<string> customMessage)
             where T : System.IComparable<> { }
         public static void ShouldBeNegative(this decimal actual) { }

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
@@ -337,6 +337,9 @@ namespace Shouldly
         public static void ShouldBeAssignableTo(this object actual, System.Type expected, [JetBrains.Annotations.InstantHandleAttribute()] System.Func<string> customMessage) { }
         public static void ShouldBeGreaterThan<T>(this T actual, T expected)
             where T : System.IComparable<> { }
+        public static void ShouldBeGreaterThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
+        public static void ShouldBeGreaterThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
+        public static void ShouldBeGreaterThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldBeGreaterThan<T>(this T actual, T expected, string customMessage)
             where T : System.IComparable<> { }
         public static void ShouldBeGreaterThan<T>(this T actual, T expected, [JetBrains.Annotations.InstantHandleAttribute()] System.Func<string> customMessage)

--- a/src/Shouldly.Tests/ShouldBeGreaterOrEqualTo/CustomObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeGreaterOrEqualTo/CustomObjectScenario.cs
@@ -1,4 +1,5 @@
-﻿using Shouldly.Tests.TestHelpers;
+﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBeGreaterOrEqualTo
@@ -6,7 +7,37 @@ namespace Shouldly.Tests.ShouldBeGreaterOrEqualTo
     public class CustomObjectScenario
     {
         [Fact]
-        public void CompareCustom()
+        public void CustomObjectScenarioShouldFail()
+        {
+            var customA = new Custom { Val = 1 };
+            var customB = new Custom { Val = 2 };
+            var comparer = new CustomComparer<Custom>();
+            Verify.ShouldFail(() =>
+customA.ShouldBeGreaterThanOrEqualTo(customB, comparer, "Some additional context"),
+
+errorWithSource:
+@"customA
+    should be greater than or equal to
+Shouldly.Tests.TestHelpers.Custom (000000)
+    but was
+Shouldly.Tests.TestHelpers.Custom (000000)
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Shouldly.Tests.TestHelpers.Custom (000000)
+    should be greater than or equal to
+Shouldly.Tests.TestHelpers.Custom (000000)
+    but was not
+
+Additional Info:
+    Some additional context"
+);
+        }
+
+        [Fact]
+        public void ShouldPass()
         {
             var customA = new Custom { Val = 1 };
             var customB = new Custom { Val = 1 };

--- a/src/Shouldly.Tests/ShouldBeGreaterOrEqualTo/CustomObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeGreaterOrEqualTo/CustomObjectScenario.cs
@@ -1,17 +1,17 @@
 ﻿using Shouldly.Tests.TestHelpers;
 using Xunit;
 
-namespace Shouldly.Tests.ShouldBeGreaterThan
+namespace Shouldly.Tests.ShouldBeGreaterOrEqualTo
 {
     public class CustomObjectScenario
     {
         [Fact]
         public void CompareCustom()
         {
-            var customA = new Custom { Val = 2 };
+            var customA = new Custom { Val = 1 };
             var customB = new Custom { Val = 1 };
             var comparer = new CustomComparer<Custom>();
-            customA.ShouldBeGreaterThan(customB, comparer);
+            customA.ShouldBeGreaterThanOrEqualTo(customB, comparer);
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeGreaterThan/CustomObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeGreaterThan/CustomObjectScenario.cs
@@ -1,12 +1,44 @@
-﻿using Shouldly.Tests.TestHelpers;
+﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBeGreaterThan
 {
     public class CustomObjectScenario
     {
+
         [Fact]
-        public void CompareCustom()
+        public void CustomObjectScenarioShouldFail()
+        {
+            var customA = new Custom { Val = 1 };
+            var customB = new Custom { Val = 2 };
+            var comparer = new CustomComparer<Custom>();
+            Verify.ShouldFail(() =>
+customA.ShouldBeGreaterThan(customB, comparer, "Some additional context"),
+
+errorWithSource:
+@"customA
+    should be greater than
+Shouldly.Tests.TestHelpers.Custom (000000)
+    but was
+Shouldly.Tests.TestHelpers.Custom (000000)
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Shouldly.Tests.TestHelpers.Custom (000000)
+    should be greater than
+Shouldly.Tests.TestHelpers.Custom (000000)
+    but was not
+
+Additional Info:
+    Some additional context"
+);
+        }
+
+        [Fact]
+        public void ShouldPass()
         {
             var customA = new Custom { Val = 2 };
             var customB = new Custom { Val = 1 };

--- a/src/Shouldly.Tests/ShouldBeGreaterThan/CustomObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeGreaterThan/CustomObjectScenario.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeGreaterThan
+{
+    public class CustomObjectScenario
+    {
+        [Fact]
+        public void CompareCustom()
+        {
+            var customA = new Custom { Val = 2 };
+            var customB = new Custom { Val = 1 };
+            var comparer = new CustomComparer<Custom>();
+            customA.ShouldBeGreaterThan(customB, comparer);
+        }
+
+        public class CustomComparer<T> : IComparer<T>
+        {
+            public int Compare(T x, T y)
+            {
+                Custom x1 = x as Custom;
+                Custom x2 = y as Custom;
+                return x1.Val > x2.Val ? 1 : -1;
+            }
+        }
+
+        class Custom
+        {
+            public int Val { get; set; }
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeLessThan/CustomObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeLessThan/CustomObjectScenario.cs
@@ -1,4 +1,5 @@
-﻿using Shouldly.Tests.TestHelpers;
+﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBeLessThan
@@ -6,7 +7,37 @@ namespace Shouldly.Tests.ShouldBeLessThan
     public class CustomObjectScenario
     {
         [Fact]
-        public void CompareCustom()
+        public void CustomObjectScenarioShouldFail()
+        {
+            var customA = new Custom { Val = 1 };
+            var customB = new Custom { Val = 1 };
+            var comparer = new CustomComparer<Custom>();
+            Verify.ShouldFail(() =>
+customA.ShouldBeLessThan(customB, comparer, "Some additional context"),
+
+errorWithSource:
+@"customA
+    should be less than
+Shouldly.Tests.TestHelpers.Custom (000000)
+    but was
+Shouldly.Tests.TestHelpers.Custom (000000)
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Shouldly.Tests.TestHelpers.Custom (000000)
+    should be less than
+Shouldly.Tests.TestHelpers.Custom (000000)
+    but was not
+
+Additional Info:
+    Some additional context"
+);
+        }
+
+        [Fact]
+        public void ShouldPass()
         {
             var customA = new Custom { Val = 2 };
             var customB = new Custom { Val = 1 };

--- a/src/Shouldly.Tests/ShouldBeLessThan/CustomObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeLessThan/CustomObjectScenario.cs
@@ -1,7 +1,7 @@
 ﻿using Shouldly.Tests.TestHelpers;
 using Xunit;
 
-namespace Shouldly.Tests.ShouldBeGreaterThan
+namespace Shouldly.Tests.ShouldBeLessThan
 {
     public class CustomObjectScenario
     {
@@ -11,7 +11,7 @@ namespace Shouldly.Tests.ShouldBeGreaterThan
             var customA = new Custom { Val = 2 };
             var customB = new Custom { Val = 1 };
             var comparer = new CustomComparer<Custom>();
-            customA.ShouldBeGreaterThan(customB, comparer);
+            customB.ShouldBeLessThan(customA, comparer);
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeLessThanOrEqualTo/CustomObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeLessThanOrEqualTo/CustomObjectScenario.cs
@@ -1,17 +1,17 @@
 ﻿using Shouldly.Tests.TestHelpers;
 using Xunit;
 
-namespace Shouldly.Tests.ShouldBeGreaterThan
+namespace Shouldly.Tests.ShouldBeLessThanOrEqualTo
 {
     public class CustomObjectScenario
     {
         [Fact]
         public void CompareCustom()
         {
-            var customA = new Custom { Val = 2 };
+            var customA = new Custom { Val = 1 };
             var customB = new Custom { Val = 1 };
             var comparer = new CustomComparer<Custom>();
-            customA.ShouldBeGreaterThan(customB, comparer);
+            customA.ShouldBeLessThanOrEqualTo(customB, comparer);
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeLessThanOrEqualTo/CustomObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeLessThanOrEqualTo/CustomObjectScenario.cs
@@ -1,4 +1,5 @@
-﻿using Shouldly.Tests.TestHelpers;
+﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBeLessThanOrEqualTo
@@ -6,11 +7,41 @@ namespace Shouldly.Tests.ShouldBeLessThanOrEqualTo
     public class CustomObjectScenario
     {
         [Fact]
-        public void CompareCustom()
+        public void CustomObjectScenarioShouldFail()
         {
-            var customA = new Custom { Val = 1 };
+            var customA = new Custom { Val = 2 };
             var customB = new Custom { Val = 1 };
             var comparer = new CustomComparer<Custom>();
+            Verify.ShouldFail(() =>
+customA.ShouldBeLessThanOrEqualTo(customB, comparer, "Some additional context"),
+
+errorWithSource:
+@"customA
+    should be less than or equal to
+Shouldly.Tests.TestHelpers.Custom (000000)
+    but was
+Shouldly.Tests.TestHelpers.Custom (000000)
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Shouldly.Tests.TestHelpers.Custom (000000)
+    should be less than or equal to
+Shouldly.Tests.TestHelpers.Custom (000000)
+    but was not
+
+Additional Info:
+    Some additional context"
+);
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            CustomAB customA = new CustomA { Val = 1 };
+            CustomAB customB = new CustomB { Val = 1 };
+            var comparer = new CustomComparer<CustomAB>();
             customA.ShouldBeLessThanOrEqualTo(customB, comparer);
         }
     }

--- a/src/Shouldly.Tests/ShouldBeLessThanOrEqualTo/CustomObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeLessThanOrEqualTo/CustomObjectScenario.cs
@@ -39,9 +39,9 @@ Additional Info:
         [Fact]
         public void ShouldPass()
         {
-            CustomAB customA = new CustomA { Val = 1 };
-            CustomAB customB = new CustomB { Val = 1 };
-            var comparer = new CustomComparer<CustomAB>();
+            Custom customA = new Custom { Val = 1 };
+            Custom customB = new Custom { Val = 1 };
+            var comparer = new CustomComparer<Custom>();
             customA.ShouldBeLessThanOrEqualTo(customB, comparer);
         }
     }

--- a/src/Shouldly.Tests/TestHelpers/CustomComparerClass.cs
+++ b/src/Shouldly.Tests/TestHelpers/CustomComparerClass.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+
+namespace Shouldly.Tests.TestHelpers
+{
+    internal class CustomComparer<T> : IComparer<T>
+    {
+        public int Compare(T x, T y)
+        {
+            Custom x1 = x as Custom;
+            Custom x2 = y as Custom;
+            if (x1.Val == x2.Val)
+                return 0;
+            return x1.Val > x2.Val ? 1 : -1;
+        }
+    }
+
+    internal class Custom
+    {
+        public int Val { get; set; }
+    }
+}

--- a/src/Shouldly/Internals/Is.cs
+++ b/src/Shouldly/Internals/Is.cs
@@ -284,11 +284,20 @@ namespace Shouldly
             return Compare(comparable, expected) > 0;
         }
 
+        public static bool GreaterThan<T>(T actual, T expected, IComparer<T> comparer)
+        {
+            return Compare(actual, expected, comparer) > 0;
+        }
+
         public static bool LessThan<T>(IComparable<T> comparable, T expected)
         {
             return Compare(comparable, expected) < 0;
         }
 
+        static decimal Compare<T>(T actual, T expected, IComparer<T> comparer)
+        {
+            return comparer.Compare(actual, expected);
+        }
         static decimal Compare<T>(IComparable<T> comparable, T expected)
         {
 #if NewReflection

--- a/src/Shouldly/Internals/Is.cs
+++ b/src/Shouldly/Internals/Is.cs
@@ -274,9 +274,19 @@ namespace Shouldly
             return Compare(comparable, expected) >= 0;
         }
 
+        public static bool GreaterThanOrEqualTo<T>(T actual, T expected, IComparer<T> comparer)
+        {
+            return Compare(actual, expected, comparer) >= 0;
+        }
+
         public static bool LessThanOrEqualTo<T>(IComparable<T> comparable, T expected)
         {
             return Compare(comparable, expected) <= 0;
+        }
+
+        public static bool LessThanOrEqualTo<T>(T actual, T expected, IComparer<T> comparer)
+        {
+            return Compare(actual, expected, comparer) <= 0;
         }
 
         public static bool GreaterThan<T>(IComparable<T> comparable, T expected)
@@ -292,6 +302,11 @@ namespace Shouldly
         public static bool LessThan<T>(IComparable<T> comparable, T expected)
         {
             return Compare(comparable, expected) < 0;
+        }
+
+        public static bool LessThan<T>(T actual, T expected, IComparer<T> comparer)
+        {
+            return Compare(actual, expected, comparer) < 0;
         }
 
         static decimal Compare<T>(T actual, T expected, IComparer<T> comparer)

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeGtLtTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeGtLtTestExtensions.cs
@@ -45,6 +45,21 @@ namespace Shouldly
             ShouldBeLessThan(actual, expected, () => customMessage);
         }
 
+        public static void ShouldBeLessThan<T>(this T actual, T expected, IComparer<T> comparer)
+        {
+            ShouldBeLessThan(actual, expected, comparer, () => null);
+        }
+
+        public static void ShouldBeLessThan<T>(this T actual, T expected, IComparer<T> comparer, string customMessage)
+        {
+            ShouldBeLessThan(actual, expected, comparer, () => customMessage);
+        }
+
+        public static void ShouldBeLessThan<T>(this T actual, T expected, IComparer<T> comparer, Func<string> customMessage)
+        {
+            actual.AssertAwesomely(v => Is.LessThan(actual, expected, comparer), actual, expected, customMessage);
+        }
+
         public static void ShouldBeLessThan<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
         {
             actual.AssertAwesomely(v => Is.LessThan(v, expected), actual, expected, customMessage);
@@ -60,6 +75,21 @@ namespace Shouldly
             ShouldBeGreaterThanOrEqualTo(actual, expected, () => customMessage);
         }
 
+        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer)
+        {
+            ShouldBeGreaterThanOrEqualTo(actual, expected, comparer, () => null);
+        }
+
+        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer, string customMessage)
+        {
+            ShouldBeGreaterThanOrEqualTo(actual, expected, comparer, () => customMessage);
+        }
+
+        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer, Func<string> customMessage)
+        {
+            actual.AssertAwesomely(v => Is.GreaterThanOrEqualTo(actual, expected, comparer), actual, expected, customMessage);
+        }
+
         public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
         {
             actual.AssertAwesomely(v => Is.GreaterThanOrEqualTo(v, expected), actual, expected, customMessage);
@@ -73,6 +103,21 @@ namespace Shouldly
         public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, string customMessage) where T : IComparable<T>
         {
             ShouldBeLessThanOrEqualTo(actual, expected, () => customMessage);
+        }
+
+        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer)
+        {
+            ShouldBeLessThanOrEqualTo(actual, expected, comparer, () => null);
+        }
+
+        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer, string customMessage)
+        {
+            ShouldBeLessThanOrEqualTo(actual, expected, comparer, () => customMessage);
+        }
+
+        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer, Func<string> customMessage)
+        {
+            actual.AssertAwesomely(v => Is.LessThanOrEqualTo(actual, expected, comparer), actual, expected, customMessage);
         }
 
         public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage) where T : IComparable<T>

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeGtLtTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeGtLtTestExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using JetBrains.Annotations;
+using System.Collections.Generic;
 
 namespace Shouldly
 {
@@ -10,6 +11,20 @@ namespace Shouldly
             ShouldBeGreaterThan(actual, expected, () => null);
         }
 
+        public static void ShouldBeGreaterThan<T>(this T actual, T expected, IComparer<T> comparer)
+        {
+            ShouldBeGreaterThan(actual, expected, comparer, () => null);
+        }
+
+        public static void ShouldBeGreaterThan<T>(this T actual, T expected, IComparer<T> comparer, string customMessage)
+        {
+            ShouldBeGreaterThan(actual, expected, comparer, () => customMessage);
+        }
+
+        public static void ShouldBeGreaterThan<T>(this T actual, T expected, IComparer<T> comparer, Func<string> customMessage)
+        {
+            actual.AssertAwesomely(v => Is.GreaterThan(actual, expected, comparer), actual, expected, customMessage);
+        }
         public static void ShouldBeGreaterThan<T>(this T actual, T expected, string customMessage) where T : IComparable<T>
         {
             ShouldBeGreaterThan(actual, expected, () => customMessage);


### PR DESCRIPTION
Allow custom IComparer instances for classes that don't implement IComparable.

https://github.com/shouldly/shouldly/issues/364