### PR TITLE
Ability to check exception type and exception message.

### DIFF
--- a/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
+++ b/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
@@ -9,7 +9,7 @@ namespace Shouldly.Tests.ShouldThrowAsync
    
     {
 
-    [Fact]
+        [Fact]
         public void ShouldThrowAWobbly()
         {
             try
@@ -32,7 +32,7 @@ namespace Shouldly.Tests.ShouldThrowAsync
             }
         }
 
-[Fact]
+        [Fact]
         public void ShouldThrowAWobbly_ExceptionTypePassedIn()
         {
             try
@@ -66,7 +66,7 @@ namespace Shouldly.Tests.ShouldThrowAsync
             result.Wait();
         }
 
-[Fact]
+        [Fact]
         public void ShouldPass_ExceptionTypePassedIn()
         {
             var task = Task.Factory.StartNew(() => { throw new InvalidOperationException(); },
@@ -74,6 +74,17 @@ namespace Shouldly.Tests.ShouldThrowAsync
                 TaskScheduler.Default);
 
             var result = task.ShouldThrowAsync(typeof(InvalidOperationException));
+            result.Wait();
+        }
+
+        [Fact]
+        public void ShouldPassWithExceptionMessage()
+        {
+            var task = Task.Factory.StartNew(() => { throw new InvalidOperationException("My Exception Message"); },
+               CancellationToken.None, TaskCreationOptions.None,
+               TaskScheduler.Default);
+
+            var result = task.ShouldThrowWithMessageAsync<InvalidOperationException>("My Exception Message");
             result.Wait();
         }
     }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowTaskAsyncExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowTaskAsyncExtensions.cs
@@ -11,6 +11,12 @@ namespace Shouldly
     public static class ShouldThrowAsyncExtensions
     {
         /*** ShouldThrowAsync(Task) ***/
+        public static Task<TException> ShouldThrowWithMessageAsync<TException>(this Task task, string expectedExceptionMessage) where TException : Exception
+        {
+            var result = Should.ThrowAsync<TException>(task);
+            result.Result.Message.ShouldBe(expectedExceptionMessage);
+            return result;
+        }
         public static Task<TException> ShouldThrowAsync<TException>(this Task task) where TException : Exception
         {
             return Should.ThrowAsync<TException>(task);


### PR DESCRIPTION
Quick extension method to save on having to do two asserts on the exception type and the exception message.  Another possibility is having ShouldThrowAsync<TException>().WithMessage(string) similar to FluentAssertions?