### PR TITLE
Register new diff tools: Devart Code Compare and Perforce P4Merge

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
@@ -658,7 +658,11 @@ namespace Shouldly.Configuration
         [JetBrains.Annotations.UsedImplicitlyAttribute()]
         public readonly Shouldly.Configuration.DiffTool BeyondCompare4;
         [JetBrains.Annotations.UsedImplicitlyAttribute()]
+        public readonly Shouldly.Configuration.DiffTool CodeCompare;
+        [JetBrains.Annotations.UsedImplicitlyAttribute()]
         public readonly Shouldly.Configuration.DiffTool KDiff3;
+        [JetBrains.Annotations.UsedImplicitlyAttribute()]
+        public readonly Shouldly.Configuration.DiffTool P4Merge;
         public KnownDiffTools() { }
         public static Shouldly.Configuration.KnownDiffTools Instance { get; }
     }

--- a/src/Shouldly/Configuration/KnownDiffTools.cs
+++ b/src/Shouldly/Configuration/KnownDiffTools.cs
@@ -43,7 +43,7 @@ namespace Shouldly.Configuration
             if (!approvedExists)
                 File.AppendAllText(approved, string.Empty);
 
-                return $"\"{approved}\" \"{approved}\" \"{received}\" \"{approved}\"";
+            return $"\"{approved}\" \"{approved}\" \"{received}\" \"{approved}\"";
         }
     }
 }

--- a/src/Shouldly/Configuration/KnownDiffTools.cs
+++ b/src/Shouldly/Configuration/KnownDiffTools.cs
@@ -1,4 +1,5 @@
 #if ShouldMatchApproved
+using System.IO;
 using JetBrains.Annotations;
 
 namespace Shouldly.Configuration
@@ -34,16 +35,17 @@ namespace Shouldly.Configuration
 
         static string CodeCompareArgs(string received, string approved, bool approvedExists)
         {
-            return approvedExists
-                ? $"/MF=\"{received}\" /TF=\"{approved}\" /RF=\"{approved}\""
-                : $"/MF=\"{received}\" /TF=\"\" /RF=\"{approved}\"";
+            return $"/BF=\"{approved}\" /TF=\"{approved}\" /MF=\"{received}\" /RF=\"{approved}\"";
         }
 
         static string P4MergeArgs(string received, string approved, bool approvedExists)
         {
-            return approvedExists
-                ? $"\"{approved}\" \"{approved}\" \"{received}\" \"{approved}\""
-                : $"\"\" \"\" \"{received}\" \"{approved}\"";
+            if (!approvedExists)
+                using (var file = File.Create(approved))
+                {
+                }
+
+                return $"\"{approved}\" \"{approved}\" \"{received}\" \"{approved}\"";
         }
     }
 }

--- a/src/Shouldly/Configuration/KnownDiffTools.cs
+++ b/src/Shouldly/Configuration/KnownDiffTools.cs
@@ -11,6 +11,10 @@ namespace Shouldly.Configuration
         public readonly DiffTool BeyondCompare3 = new DiffTool("Beyond Compare 3", @"Beyond Compare 3\BCompare.exe", BeyondCompareArgs);
         [UsedImplicitly]
         public readonly DiffTool BeyondCompare4 = new DiffTool("Beyond Compare 4", @"Beyond Compare 4\BCompare.exe", BeyondCompareArgs);
+        [UsedImplicitly]
+        public readonly DiffTool CodeCompare = new DiffTool("Code Compare", @"Devart\Code Compare\CodeMerge.exe", CodeCompareArgs);
+        [UsedImplicitly]
+        public readonly DiffTool P4Merge = new DiffTool("P4Merge", @"Perforce\p4merge.exe", P4MergeArgs);
 
         public static KnownDiffTools Instance { get; } = new KnownDiffTools();
 
@@ -26,6 +30,20 @@ namespace Shouldly.Configuration
             return approvedExists
                 ? $"\"{received}\" \"{approved}\" -o \"{approved}\""
                 : $"\"{received}\" -o \"{approved}\"";
+        }
+
+        static string CodeCompareArgs(string received, string approved, bool approvedExists)
+        {
+            return approvedExists
+                ? $"/MF=\"{received}\" /TF=\"{approved}\" /RF=\"{approved}\""
+                : $"/MF=\"{received}\" /TF=\"\" /RF=\"{approved}\"";
+        }
+
+        static string P4MergeArgs(string received, string approved, bool approvedExists)
+        {
+            return approvedExists
+                ? $"\"{approved}\" \"{approved}\" \"{received}\" \"{approved}\""
+                : $"\"\" \"\" \"{received}\" \"{approved}\"";
         }
     }
 }

--- a/src/Shouldly/Configuration/KnownDiffTools.cs
+++ b/src/Shouldly/Configuration/KnownDiffTools.cs
@@ -41,9 +41,7 @@ namespace Shouldly.Configuration
         static string P4MergeArgs(string received, string approved, bool approvedExists)
         {
             if (!approvedExists)
-                using (var file = File.Create(approved))
-                {
-                }
+                File.AppendAllText(approved, string.Empty);
 
                 return $"\"{approved}\" \"{approved}\" \"{received}\" \"{approved}\"";
         }

--- a/src/TestDiffTools/Program.cs
+++ b/src/TestDiffTools/Program.cs
@@ -65,8 +65,11 @@ namespace TestDiffTools
                 ShouldlyConfiguration.DiffTools.RegisterDiffTool(selectedDiffTool.DiffTool);
                 var stacktrace = new StackTrace(true);
 
-                var approved = Path.Combine(Path.GetDirectoryName(stacktrace.GetFrame(0).GetFileName()),
-                    "Main.approved.txt");
+                var currentFrame = stacktrace.GetFrame(0);
+                var approved = Path.Combine(
+                    Path.GetDirectoryName(currentFrame.GetFileName()),
+                    $"{Path.GetFileNameWithoutExtension(currentFrame.GetFileName())}.{currentFrame.GetMethod().Name}.approved.txt");
+
                 switch (selectedOption)
                 {
                     case 1:


### PR DESCRIPTION
These are two tools I currently use.

I tested them out with the build script, and I think they're pulling up correctly - the approved interface shows up as the "Base" and "Theirs" versions of the files, and the received interface shows up as the "Mine" version. Changes are saved to the approved file.