### PR TITLE
Implement 'ShouldBeInOrder' for IEnumerable

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
@@ -181,6 +181,15 @@ namespace Shouldly
         public static void ShouldBeEmpty<T>(this System.Collections.Generic.IEnumerable<T> actual) { }
         public static void ShouldBeEmpty<T>(this System.Collections.Generic.IEnumerable<T> actual, string customMessage) { }
         public static void ShouldBeEmpty<T>(this System.Collections.Generic.IEnumerable<T> actual, [JetBrains.Annotations.InstantHandleAttribute()] System.Func<string> customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, string customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, [JetBrains.Annotations.InstantHandleAttribute()] System.Func<string> customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, string customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, [JetBrains.Annotations.InstantHandleAttribute()] System.Func<string> customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T> customComparer) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T> customComparer, string customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T> customComparer, [JetBrains.Annotations.InstantHandleAttribute()] System.Func<string> customMessage) { }
         public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected) { }
         public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, string customMessage) { }
         public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, [JetBrains.Annotations.InstantHandleAttribute()] System.Func<string> customMessage) { }

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
@@ -596,6 +596,11 @@ namespace Shouldly
         public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string customMessage, System.Type exceptionType) { }
         public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, [JetBrains.Annotations.InstantHandleAttribute()] System.Func<string> customMessage, System.Type exceptionType) { }
     }
+    public enum SortDirection
+    {
+        Ascending = 0,
+        Descending = 1,
+    }
     [System.FlagsAttribute()]
     public enum StringCompareShould
     {

--- a/src/Shouldly.Tests/ShouldBeInOrder/DoubleArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/DoubleArrayScenario.cs
@@ -17,16 +17,18 @@ _descendingTarget.ShouldBeInOrder("Some additional context"),
 
 errorWithSource:
 @"_descendingTarget
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+1.4
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[1.5d, 1.4d, 1.3d, 1.2d, 1.1d]
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+1.4
 
 Additional Info:
     Some additional context");
@@ -40,16 +42,18 @@ _descendingTarget.ShouldBeInOrder(SortDirection.Ascending, "Some additional cont
 
 errorWithSource:
 @"_descendingTarget
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+1.4
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[1.5d, 1.4d, 1.3d, 1.2d, 1.1d]
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+1.4
 
 Additional Info:
     Some additional context");
@@ -63,16 +67,18 @@ _ascendingTarget.ShouldBeInOrder(SortDirection.Descending, "Some additional cont
 
 errorWithSource:
 @"_ascendingTarget
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+1.2
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[1.1d, 1.2d, 1.3d, 1.4d, 1.5d]
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+1.2
 
 Additional Info:
     Some additional context");
@@ -86,16 +92,18 @@ _ascendingTarget.ShouldBeInOrder(SortDirection.Descending, Comparer<double>.Defa
 
 errorWithSource:
 @"_ascendingTarget
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+1.2
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[1.1d, 1.2d, 1.3d, 1.4d, 1.5d]
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+1.2
 
 Additional Info:
     Some additional context");

--- a/src/Shouldly.Tests/ShouldBeInOrder/DoubleArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/DoubleArrayScenario.cs
@@ -1,0 +1,128 @@
+﻿using System.Collections.Generic;
+using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeInOrder
+{
+    public class DoubleArrayScenario
+    {
+        private readonly double[] _ascendingTarget = { 1.1, 1.2, 1.3, 1.4, 1.5 };
+        private readonly double[] _descendingTarget = { 1.5, 1.4, 1.3, 1.2, 1.1 };
+
+        [Fact]
+        public void ShouldFailWithDefaultDirection()
+        {
+            Verify.ShouldFail(() =>
+_descendingTarget.ShouldBeInOrder("Some additional context"),
+
+errorWithSource:
+@"_descendingTarget
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[1.5d, 1.4d, 1.3d, 1.2d, 1.1d]
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenAscendingIsSpecified()
+        {
+            Verify.ShouldFail(() =>
+_descendingTarget.ShouldBeInOrder(SortDirection.Ascending, "Some additional context"),
+
+errorWithSource:
+@"_descendingTarget
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[1.5d, 1.4d, 1.3d, 1.2d, 1.1d]
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenDescendingIsSpecified()
+        {
+            Verify.ShouldFail(() =>
+_ascendingTarget.ShouldBeInOrder(SortDirection.Descending, "Some additional context"),
+
+errorWithSource:
+@"_ascendingTarget
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[1.1d, 1.2d, 1.3d, 1.4d, 1.5d]
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenDescendingIsSpecifiedAndComparerIsGiven()
+        {
+            Verify.ShouldFail(() =>
+_ascendingTarget.ShouldBeInOrder(SortDirection.Descending, Comparer<double>.Default, "Some additional context"),
+
+errorWithSource:
+@"_ascendingTarget
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[1.1d, 1.2d, 1.3d, 1.4d, 1.5d]
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPassWithDefaultDirection()
+        {
+            _ascendingTarget.ShouldBeInOrder();
+        }
+
+        [Fact]
+        public void ShouldPassWhenAscendingIsSpecified()
+        {
+            _ascendingTarget.ShouldBeInOrder(SortDirection.Ascending);
+        }
+
+        [Fact]
+        public void ShouldPassWhenDescendingIsSpecified()
+        {
+            _descendingTarget.ShouldBeInOrder(SortDirection.Descending);
+        }
+
+        [Fact]
+        public void ShouldPassWhenDescendingIsSpecifiedAndComparerIsGiven()
+        {
+            _descendingTarget.ShouldBeInOrder(SortDirection.Descending, Comparer<double>.Default);
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeInOrder/EmptyArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/EmptyArrayScenario.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeInOrder
+{
+    public class EmptyArrayScenario
+    {
+        [Fact]
+        public void ShouldPass()
+        {
+            new int[0].ShouldBeInOrder();
+        }
+
+        [Fact]
+        public void ShouldPassWhenSortDirectionIsGiven()
+        {
+            new int[0].ShouldBeInOrder(SortDirection.Descending);
+        }
+
+        [Fact]
+        public void ShouldPassWhenSortDirectionAndCustomComparerAreGiven()
+        {
+            new int[0].ShouldBeInOrder(SortDirection.Ascending, Comparer<int>.Default);
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeInOrder/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/IntegerArrayScenario.cs
@@ -1,0 +1,128 @@
+﻿using System.Collections.Generic;
+using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeInOrder
+{
+    public class IntegerArrayScenario
+    {
+        private readonly int[] _ascendingTarget = { 1, 2, 3, 4, 5 };
+        private readonly int[] _descendingTarget = { 5, 4, 3, 2, 1 };
+
+        [Fact]
+        public void ShouldFailWithDefaultDirection()
+        {
+            Verify.ShouldFail(() =>
+_descendingTarget.ShouldBeInOrder("Some additional context"),
+
+errorWithSource:
+@"_descendingTarget
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[5, 4, 3, 2, 1]
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenAscendingIsSpecified()
+        {
+            Verify.ShouldFail(() =>
+_descendingTarget.ShouldBeInOrder(SortDirection.Ascending, "Some additional context"),
+
+errorWithSource:
+@"_descendingTarget
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[5, 4, 3, 2, 1]
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenDescendingIsSpecified()
+        {
+            Verify.ShouldFail(() =>
+_ascendingTarget.ShouldBeInOrder(SortDirection.Descending, "Some additional context"),
+
+errorWithSource:
+@"_ascendingTarget
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[1, 2, 3, 4, 5]
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenDescendingIsSpecifiedAndComparerIsGiven()
+        {
+            Verify.ShouldFail(() =>
+_ascendingTarget.ShouldBeInOrder(SortDirection.Descending, Comparer<int>.Default, "Some additional context"),
+
+errorWithSource:
+@"_ascendingTarget
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[1, 2, 3, 4, 5]
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPassWithDefaultDirection()
+        {
+            _ascendingTarget.ShouldBeInOrder();
+        }
+
+        [Fact]
+        public void ShouldPassWhenAscendingIsSpecified()
+        {
+            _ascendingTarget.ShouldBeInOrder(SortDirection.Ascending);
+        }
+
+        [Fact]
+        public void ShouldPassWhenDescendingIsSpecified()
+        {
+            _descendingTarget.ShouldBeInOrder(SortDirection.Descending);
+        }
+
+        [Fact]
+        public void ShouldPassWhenDescendingIsSpecifiedAndComparerIsGiven()
+        {
+            _descendingTarget.ShouldBeInOrder(SortDirection.Descending, Comparer<int>.Default);
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeInOrder/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/IntegerArrayScenario.cs
@@ -17,16 +17,18 @@ _descendingTarget.ShouldBeInOrder("Some additional context"),
 
 errorWithSource:
 @"_descendingTarget
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+4
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[5, 4, 3, 2, 1]
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+4
 
 Additional Info:
     Some additional context");
@@ -40,16 +42,18 @@ _descendingTarget.ShouldBeInOrder(SortDirection.Ascending, "Some additional cont
 
 errorWithSource:
 @"_descendingTarget
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+4
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[5, 4, 3, 2, 1]
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+4
 
 Additional Info:
     Some additional context");
@@ -63,16 +67,18 @@ _ascendingTarget.ShouldBeInOrder(SortDirection.Descending, "Some additional cont
 
 errorWithSource:
 @"_ascendingTarget
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+2
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[1, 2, 3, 4, 5]
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+2
 
 Additional Info:
     Some additional context");
@@ -86,16 +92,18 @@ _ascendingTarget.ShouldBeInOrder(SortDirection.Descending, Comparer<int>.Default
 
 errorWithSource:
 @"_ascendingTarget
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+2
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[1, 2, 3, 4, 5]
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+2
 
 Additional Info:
     Some additional context");

--- a/src/Shouldly.Tests/ShouldBeInOrder/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/StringArrayScenario.cs
@@ -1,0 +1,128 @@
+﻿using System.Collections.Generic;
+using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeInOrder
+{
+    public class StringArrayScenario
+    {
+        private readonly string[] _ascendingTarget = { "a", "b", "c", "d", "e" };
+        private readonly string[] _descendingTarget = { "e", "d", "c", "b", "a" };
+
+        [Fact]
+        public void ShouldFailWithDefaultDirection()
+        {
+            Verify.ShouldFail(() =>
+_descendingTarget.ShouldBeInOrder("Some additional context"),
+
+errorWithSource:
+@"_descendingTarget
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[""e"", ""d"", ""c"", ""b"", ""a""]
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenAscendingIsSpecified()
+        {
+            Verify.ShouldFail(() =>
+_descendingTarget.ShouldBeInOrder(SortDirection.Ascending, "Some additional context"),
+
+errorWithSource:
+@"_descendingTarget
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[""e"", ""d"", ""c"", ""b"", ""a""]
+    should be in ascending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenDescendingIsSpecified()
+        {
+            Verify.ShouldFail(() =>
+_ascendingTarget.ShouldBeInOrder(SortDirection.Descending, "Some additional context"),
+
+errorWithSource:
+@"_ascendingTarget
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[""a"", ""b"", ""c"", ""d"", ""e""]
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenDescendingIsSpecifiedAndComparerIsGiven()
+        {
+            Verify.ShouldFail(() =>
+_ascendingTarget.ShouldBeInOrder(SortDirection.Descending, Comparer<string>.Default, "Some additional context"),
+
+errorWithSource:
+@"_ascendingTarget
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[""a"", ""b"", ""c"", ""d"", ""e""]
+    should be in descending order
+    but item at index 1 was not.
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPassWithDefaultDirection()
+        {
+            _ascendingTarget.ShouldBeInOrder();
+        }
+
+        [Fact]
+        public void ShouldPassWhenAscendingIsSpecified()
+        {
+            _ascendingTarget.ShouldBeInOrder(SortDirection.Ascending);
+        }
+
+        [Fact]
+        public void ShouldPassWhenDescendingIsSpecified()
+        {
+            _descendingTarget.ShouldBeInOrder(SortDirection.Descending);
+        }
+
+        [Fact]
+        public void ShouldPassWhenDescendingIsSpecifiedAndComparerIsGiven()
+        {
+            _descendingTarget.ShouldBeInOrder(SortDirection.Descending, Comparer<string>.Default);
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeInOrder/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/StringArrayScenario.cs
@@ -17,16 +17,18 @@ _descendingTarget.ShouldBeInOrder("Some additional context"),
 
 errorWithSource:
 @"_descendingTarget
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+d
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[""e"", ""d"", ""c"", ""b"", ""a""]
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+d
 
 Additional Info:
     Some additional context");
@@ -40,16 +42,18 @@ _descendingTarget.ShouldBeInOrder(SortDirection.Ascending, "Some additional cont
 
 errorWithSource:
 @"_descendingTarget
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+d
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[""e"", ""d"", ""c"", ""b"", ""a""]
-    should be in ascending order
-    but item at index 1 was not.
+    should be in ascending order but was not.
+    The first out-of-order item was found at index 1:
+d
 
 Additional Info:
     Some additional context");
@@ -63,16 +67,18 @@ _ascendingTarget.ShouldBeInOrder(SortDirection.Descending, "Some additional cont
 
 errorWithSource:
 @"_ascendingTarget
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+b
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[""a"", ""b"", ""c"", ""d"", ""e""]
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+b
 
 Additional Info:
     Some additional context");
@@ -86,16 +92,18 @@ _ascendingTarget.ShouldBeInOrder(SortDirection.Descending, Comparer<string>.Defa
 
 errorWithSource:
 @"_ascendingTarget
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+b
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
 @"[""a"", ""b"", ""c"", ""d"", ""e""]
-    should be in descending order
-    but item at index 1 was not.
+    should be in descending order but was not.
+    The first out-of-order item was found at index 1:
+b
 
 Additional Info:
     Some additional context");

--- a/src/Shouldly.Tests/ShouldBeInOrder/UnitArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/UnitArrayScenario.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeInOrder
+{
+    public class UnitArrayScenario
+    {
+        [Fact]
+        public void ShouldPass()
+        {
+            new[] { 5 }.ShouldBeInOrder();
+        }
+
+        [Fact]
+        public void ShouldPassWhenSortDirectionIsGiven()
+        {
+            new[] { 5 }.ShouldBeInOrder(SortDirection.Descending);
+        }
+
+        [Fact]
+        public void ShouldPassWhenSortDirectionAndCustomComparerAreGiven()
+        {
+            new[] { 5 }.ShouldBeInOrder(SortDirection.Ascending, Comparer<int>.Default);
+        }
+    }
+}

--- a/src/Shouldly/Internals/IShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/IShouldlyAssertionContext.cs
@@ -18,9 +18,9 @@ namespace Shouldly
         TimeSpan? Timeout { get; set; }
         bool IgnoreOrder { get; set; }
 
-        // For now, this property cannot just check to see if "Actual != null". The term is overloaded. 
+        // For now, this property cannot just check to see if "Actual != null". The term is overloaded.
         // In some cases it means the "Actual" value is not relevant (eg: "dictionary.ContainsKey(key)") and in some
-        // cases it means that the value is relevant, but during execution we got a null. (eg: Foo.ShouldBe(bar) where 
+        // cases it means that the value is relevant, but during execution we got a null. (eg: Foo.ShouldBe(bar) where
         // Foo is null). So for now, it is a flag needs to be set externally to determine whether or not the "Actual" value
         // is relevant.
         bool HasRelevantActual { get; set; }
@@ -32,5 +32,8 @@ namespace Shouldly
         bool CodePartMatchesActual { get; }
         Expression Filter { get; set; }
         int? MatchCount { get; set; }
+        SortDirection SortDirection { get; set; }
+        int OutOfOrderIndex { get; set; }
+        object OutOfOrderObject { get; set; }
     }
 }

--- a/src/Shouldly/Internals/ShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/ShouldlyAssertionContext.cs
@@ -21,9 +21,9 @@ namespace Shouldly
 
         public bool IgnoreOrder { get; set; }
 
-        // For now, this property cannot just check to see if "Actual != null". The term is overloaded. 
+        // For now, this property cannot just check to see if "Actual != null". The term is overloaded.
         // In some cases it means the "Actual" value is not relevant (eg: "dictionary.ContainsKey(key)") and in some
-        // cases it means that the value is relevant, but during execution we got a null. (eg: Foo.ShouldBe(bar) where 
+        // cases it means that the value is relevant, but during execution we got a null. (eg: Foo.ShouldBe(bar) where
         // Foo is null). So for now, it is a flag needs to be set externally to determine whether or not the "Actual" value
         // is relevant.
         public bool HasRelevantActual { get; set; }
@@ -33,6 +33,9 @@ namespace Shouldly
         public string CustomMessage { get; set; }
         public Expression Filter { get; set; }
         public int? MatchCount { get; set; }
+        public SortDirection SortDirection { get; set; }
+        public int OutOfOrderIndex { get; set; }
+        public object OutOfOrderObject { get; set; }
 
 #if StackTrace
         internal ShouldlyAssertionContext(

--- a/src/Shouldly/MessageGenerators/ShouldBeInOrderMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeInOrderMessageGenerator.cs
@@ -1,0 +1,18 @@
+namespace Shouldly.MessageGenerators
+{
+    internal class ShouldBeInOrderMessageGenerator : ShouldlyMessageGenerator
+    {
+        public override bool CanProcess(IShouldlyAssertionContext context)
+        {
+            return context.ShouldMethod == "ShouldBeInOrder";
+        }
+
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
+        {
+            return
+$@"{context.CodePart}
+    should be in {context.Expected.ToString().ToLower()} order
+    but item at index {context.Key} was not.";
+        }
+    }
+}

--- a/src/Shouldly/MessageGenerators/ShouldBeInOrderMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeInOrderMessageGenerator.cs
@@ -11,8 +11,9 @@ namespace Shouldly.MessageGenerators
         {
             return
 $@"{context.CodePart}
-    should be in {context.Expected.ToString().ToLower()} order
-    but item at index {context.Key} was not.";
+    should be in {context.SortDirection.ToString().ToLower()} order but was not.
+    The first out-of-order item was found at index {context.OutOfOrderIndex}:
+{context.OutOfOrderObject}";
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -332,7 +332,7 @@ namespace Shouldly
                     && isOutOfOrder(previousItem, currentItem))
                 {
                     throw new ShouldAssertException(
-                        new ExpectedActualKeyShouldlyMessage(expectedSortDirection, actual, currentIndex, customMessage).ToString());
+                        new ExpectedOrderShouldlyMessage(actual, expectedSortDirection, currentIndex, currentItem, customMessage).ToString());
                 }
 
                 previousItem = currentItem;

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -116,6 +116,22 @@ namespace Shouldly
         }
     }
 
+    internal class ExpectedOrderShouldlyMessage : ShouldlyMessage
+    {
+        public ExpectedOrderShouldlyMessage(object actual, SortDirection expectedDirection, int outOfOrderIndex, object outOfOrderObject,
+            [InstantHandle] Func<string> customMessage,
+            [CallerMemberName] string shouldlyMethod = null)
+        {
+            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, actual: actual)
+            {
+                SortDirection = expectedDirection,
+                OutOfOrderIndex = outOfOrderIndex,
+                OutOfOrderObject = outOfOrderObject
+            };
+            if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
+        }
+    }
+
     internal class ShouldlyThrowMessage : ShouldlyMessage
     {
         public ShouldlyThrowMessage(object expected, string exceptionMessage, Func<string> customMessage,

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -56,7 +56,7 @@ namespace Shouldly
 
     internal class ExpectedActualWithCaseSensitivityShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualWithCaseSensitivityShouldlyMessage(object expected, object actual, 
+        public ExpectedActualWithCaseSensitivityShouldlyMessage(object expected, object actual,
             Case? caseSensitivity,
             [InstantHandle] Func<string> customMessage,
             [CallerMemberName] string shouldlyMethod = null)
@@ -229,14 +229,14 @@ namespace Shouldly
             new DictionaryShouldContainKeyAndValueMessageGenerator(),
             new DictionaryShouldOrNotContainKeyMessageGenerator(),
             new DictionaryShouldNotContainValueForKeyMessageGenerator(),
-            new ShouldBeginEndWithMessageGenerator(), 
-            new ShouldBeWithinRangeMessageGenerator(), 
+            new ShouldBeginEndWithMessageGenerator(),
+            new ShouldBeWithinRangeMessageGenerator(),
             new ShouldContainWithinRangeMessageGenerator(),
-            new ShouldBeUniqueMessageGenerator(), 
-            new ShouldBeEnumerableCaseSensitiveMessageGenerator(), 
-            new ShouldContainMessageGenerator(), 
-            new ShouldContainPredicateMessageGenerator(), 
-            new ShouldBeIgnoringOrderMessageGenerator(), 
+            new ShouldBeUniqueMessageGenerator(),
+            new ShouldBeEnumerableCaseSensitiveMessageGenerator(),
+            new ShouldContainMessageGenerator(),
+            new ShouldContainPredicateMessageGenerator(),
+            new ShouldBeIgnoringOrderMessageGenerator(),
             new ShouldSatisfyAllConditionsMessageGenerator(),
             new ShouldBeSubsetOfMessageGenerator(),
             new ShouldHaveSingleItemMessageGenerator(),
@@ -248,7 +248,8 @@ namespace Shouldly
             new ShouldBeMessageGenerator(),
             new ShouldBePositiveMessageGenerator(),
             new ShouldBeNegativeMessageGenerator(),
-            new ShouldBeTypeMessageGenerator()
+            new ShouldBeTypeMessageGenerator(),
+            new ShouldBeInOrderMessageGenerator()
         };
 
         protected IShouldlyAssertionContext ShouldlyAssertionContext { get; set; }

--- a/src/Shouldly/SortDirection.cs
+++ b/src/Shouldly/SortDirection.cs
@@ -1,0 +1,8 @@
+﻿namespace Shouldly
+{
+    public enum SortDirection
+    {
+        Ascending = 0,
+        Descending = 1
+    }
+}


### PR DESCRIPTION
I added an enum, `SortDirection`, as well as overloads of the method with and without a custom `IComparer<T>` passed in. `ApprovePublicAPI` was also updated to include the new methods.

I tried to follow the pattern that the other extensions use, including custom error messages that are clear and concise. Let me know if I missed anything.
This should address issue #280.