### PR TITLE
Object Graph Comparison - ShouldBeEquivalentTo(...)

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/EnumerableScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/EnumerableScenario.cs
@@ -1,0 +1,117 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeEquivalentTo
+{
+    public class EnumerableScenario
+    {
+        [Fact]
+        public void ShouldFailWhenListIsTooShort()
+        {
+            var subject = new[] { 1, 2, 3, 4 };
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo(new[] { 1, 2, 3, 4, 5 }, "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject [System.Int32[]]
+    Count
+
+    Expected value to be
+5
+    but was
+4
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root> [System.Int32[]]
+    Count
+
+    Expected value to be
+5
+    but was
+4
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenListIsTooLong()
+        {
+            var subject = new[] { 1, 2, 3, 4, 5, 6 };
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo(new[] { 1, 2, 3, 4, 5 }, "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject [System.Int32[]]
+    Count
+
+    Expected value to be
+5
+    but was
+6
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root> [System.Int32[]]
+    Count
+
+    Expected value to be
+5
+    but was
+6
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenListsDoNotMatch()
+        {
+            var subject = new[] { 1, 2, 6, 4, 5 };
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo(new[] { 1, 2, 3, 4, 5 }, "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject [System.Int32[]]
+    Element [2] [System.Int32]
+
+    Expected value to be
+3
+    but was
+6
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root> [System.Int32[]]
+    Element [2] [System.Int32]
+
+    Expected value to be
+3
+    but was
+6
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            var subject = new[] { 1, 2, 6, 4, 5 };
+            subject.ShouldBeEquivalentTo(new[] { 1, 2, 6, 4, 5 });
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Shouldly.Tests.ShouldBeEquivalentTo
+{
+    public class FakeObject
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public FakeObject Child { get; set; }
+        public ICollection<string> Colors { get; set; }
+        public IEnumerable Adjectives { get; set; }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/NullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/NullScenario.cs
@@ -1,0 +1,79 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeEquivalentTo
+{
+    public class NullScenario
+    {
+        [Fact]
+        public void ShouldFailWhenActualIsNull()
+        {
+            string subject = null;
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo("Hello", "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject
+
+    Expected value to be
+""Hello""
+    but was
+null
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root>
+
+    Expected value to be
+""Hello""
+    but was
+null
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenExpectedIsNull()
+        {
+            const string subject = "Hello";
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo(null, "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject
+
+    Expected value to be
+null
+    but was
+""Hello""
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root>
+
+    Expected value to be
+null
+    but was
+""Hello""
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPassWhenBothAreNull()
+        {
+            string subject = null;
+            subject.ShouldBeEquivalentTo(null);
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using Shouldly.Tests.Strings;
+using Xunit;
 
 namespace Shouldly.Tests.ShouldBeEquivalentTo
 {
@@ -9,6 +10,189 @@ namespace Shouldly.Tests.ShouldBeEquivalentTo
         {
             var subject = new FakeObject();
             var expected = subject;
+            subject.ShouldBeEquivalentTo(expected);
+        }
+
+
+
+
+        [Fact]
+        public void ShouldFailWhenIdDoesNotMatch()
+        {
+            var subject = new FakeObject { Id = 5, Name = "Bob" };
+            var expected = new FakeObject { Id = 6, Name = "Bob" };
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo(expected, "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Id [System.Int32]
+
+    Expected value to be
+6
+    but was
+5
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root> [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Id [System.Int32]
+
+    Expected value to be
+6
+    but was
+5
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenNameDoesNotMatch()
+        {
+            var subject = new FakeObject { Id = 5, Name = "Bob" };
+            var expected = new FakeObject { Id = 5, Name = "Sally" };
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo(expected, "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Name [System.String]
+
+    Expected value to be
+""Sally""
+    but was
+""Bob""
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root> [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Name [System.String]
+
+    Expected value to be
+""Sally""
+    but was
+""Bob""
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenObjectIsComplex()
+        {
+            var subject = new FakeObject
+            {
+                Id = 5,
+                Name = "Bob",
+                Adjectives = new[] { "funny", "wise" },
+                Colors = new[] { "red", "blue" },
+                Child = new FakeObject
+                {
+                    Id = 6,
+                    Name = "Sally",
+                    Adjectives = new[] { "ugly", "intelligent" },
+                    Colors = new[] { "purple", "orange" }
+                }
+            };
+
+            var expected = new FakeObject
+            {
+                Id = 5,
+                Name = "Bob",
+                Adjectives = new[] { "funny", "wise" },
+                Colors = new[] { "red", "blue" },
+                Child = new FakeObject
+                {
+                    Id = 6,
+                    Name = "Sally",
+                    Adjectives = new[] { "beautiful", "intelligent" },
+                    Colors = new[] { "purple", "orange" }
+                }
+            };
+
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo(expected, "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+        Adjectives [System.String[]]
+            Element [0] [System.String]
+
+    Expected value to be
+""beautiful""
+    but was
+""ugly""
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root> [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+        Adjectives [System.String[]]
+            Element [0] [System.String]
+
+    Expected value to be
+""beautiful""
+    but was
+""ugly""
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            const string subject = "Hello";
+            subject.ShouldBeEquivalentTo("Hello");
+        }
+
+        [Fact]
+        public void ShouldPassWhenObjectIsComplex()
+        {
+            var subject = new FakeObject
+            {
+                Id = 5,
+                Name = "Bob",
+                Adjectives = new[] { "funny", "wise" },
+                Colors = new[] { "red", "blue" },
+                Child = new FakeObject
+                {
+                    Id = 6,
+                    Name = "Sally",
+                    Adjectives = new[] { "beautiful", "intelligent" },
+                    Colors = new[] { "purple", "orange" }
+                }
+            };
+
+            var expected = new FakeObject
+            {
+                Id = 5,
+                Name = "Bob",
+                Adjectives = new[] { "funny", "wise" },
+                Colors = new[] { "red", "blue" },
+                Child = new FakeObject
+                {
+                    Id = 6,
+                    Name = "Sally",
+                    Adjectives = new[] { "beautiful", "intelligent" },
+                    Colors = new[] { "purple", "orange" }
+                }
+            };
+
             subject.ShouldBeEquivalentTo(expected);
         }
     }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -13,9 +13,6 @@ namespace Shouldly.Tests.ShouldBeEquivalentTo
             subject.ShouldBeEquivalentTo(expected);
         }
 
-
-
-
         [Fact]
         public void ShouldFailWhenIdDoesNotMatch()
         {
@@ -154,6 +151,75 @@ Additional Info:
         }
 
         [Fact]
+        public void ShouldFailWhenObjectContainsInfiniteLoop()
+        {
+            var subject = new FakeObject
+            {
+                Id = 5,
+                Name = "Bob",
+                Adjectives = new[] { "funny", "wise" },
+                Colors = new[] { "red", "blue" },
+                Child = new FakeObject
+                {
+                    Id = 6,
+                    Name = "Sally",
+                    Adjectives = new[] { "beautiful", "intelligent" },
+                    Colors = new[] { "purple", "orange" }
+                }
+            };
+            subject.Child.Child = subject;
+
+            var expected = new FakeObject
+            {
+                Id = 5,
+                Name = "Bob",
+                Adjectives = new[] { "funny", "wise" },
+                Colors = new[] { "red", "blue" },
+                Child = new FakeObject
+                {
+                    Id = 6,
+                    Name = "Sally",
+                    Adjectives = new[] { "beautiful", "dumb" },
+                    Colors = new[] { "purple", "orange" }
+                }
+            };
+            expected.Child.Child = expected;
+
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo(expected, "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+        Adjectives [System.String[]]
+            Element [1] [System.String]
+
+    Expected value to be
+""dumb""
+    but was
+""intelligent""
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root> [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+        Adjectives [System.String[]]
+            Element [1] [System.String]
+
+    Expected value to be
+""dumb""
+    but was
+""intelligent""
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
         public void ShouldPass()
         {
             const string subject = "Hello";
@@ -192,6 +258,30 @@ Additional Info:
                     Colors = new[] { "purple", "orange" }
                 }
             };
+
+            subject.ShouldBeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void ShouldPassWhenObjectContainsInfiniteLoop()
+        {
+            var subject = new FakeObject
+            {
+                Id = 5,
+                Name = "Bob",
+                Adjectives = new[] { "funny", "wise" },
+                Colors = new[] { "red", "blue" }
+            };
+            subject.Child = subject;
+
+            var expected = new FakeObject
+            {
+                Id = 5,
+                Name = "Bob",
+                Adjectives = new[] { "funny", "wise" },
+                Colors = new[] { "red", "blue" }
+            };
+            expected.Child = expected;
 
             subject.ShouldBeEquivalentTo(expected);
         }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -1,0 +1,15 @@
+﻿using Xunit;
+
+namespace Shouldly.Tests.ShouldBeEquivalentTo
+{
+    public class ObjectScenario
+    {
+        [Fact]
+        public void ShouldPassWhenReferencesAreEqual()
+        {
+            var subject = new FakeObject();
+            var expected = subject;
+            subject.ShouldBeEquivalentTo(expected);
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/StringScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/StringScenario.cs
@@ -1,0 +1,79 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeEquivalentTo
+{
+    public class StringScenario
+    {
+        [Fact]
+        public void ShouldFailWhenStringIsDifferent()
+        {
+            const string subject = "Hello";
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo("Goodbye", "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject [System.String]
+
+    Expected value to be
+""Goodbye""
+    but was
+""Hello""
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root> [System.String]
+
+    Expected value to be
+""Goodbye""
+    but was
+""Hello""
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldFailWhenCaseIsDifferent()
+        {
+            const string subject = "Hello";
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo("HELLO", "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject [System.String]
+
+    Expected value to be
+""HELLO""
+    but was
+""Hello""
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root> [System.String]
+
+    Expected value to be
+""HELLO""
+    but was
+""Hello""
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPassWhenCaseMatches()
+        {
+            const string subject = "Hello";
+            subject.ShouldBeEquivalentTo("Hello");
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.cs
@@ -1,0 +1,40 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeEquivalentTo
+{
+    public class TypeScenario
+    {
+        [Fact]
+        public void ShouldFail()
+        {
+            const string subject = "Hello";
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo(5, "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject
+
+    Expected value to be
+System.Int32
+    but was
+System.String
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root>
+
+    Expected value to be
+System.Int32
+    but was
+System.String
+
+Additional Info:
+    Some additional context");
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ValueTypeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ValueTypeScenario.cs
@@ -1,0 +1,47 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeEquivalentTo
+{
+    public class ValueTypeScenario
+    {
+        [Fact]
+        public void ShouldFail()
+        {
+            const int subject = 5;
+            Verify.ShouldFail(() =>
+subject.ShouldBeEquivalentTo(3, "Some additional context"),
+
+errorWithSource:
+@"Comparing object equivalence, at path:
+subject [System.Int32]
+
+    Expected value to be
+3
+    but was
+5
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"Comparing object equivalence, at path:
+<root> [System.Int32]
+
+    Expected value to be
+3
+    but was
+5
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            const int subject = 5;
+            subject.ShouldBeEquivalentTo(5);
+        }
+    }
+}

--- a/src/Shouldly/Internals/IShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/IShouldlyAssertionContext.cs
@@ -34,6 +34,6 @@ namespace Shouldly
         SortDirection SortDirection { get; set; }
         int OutOfOrderIndex { get; set; }
         object OutOfOrderObject { get; set; }
-        IList<string> Path { get; set; }
+        IEnumerable<string> Path { get; set; }
     }
 }

--- a/src/Shouldly/Internals/IShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/IShouldlyAssertionContext.cs
@@ -1,7 +1,6 @@
 using System;
-using System.Diagnostics;
+using System.Collections.Generic;
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace Shouldly
 {
@@ -35,5 +34,6 @@ namespace Shouldly
         SortDirection SortDirection { get; set; }
         int OutOfOrderIndex { get; set; }
         object OutOfOrderObject { get; set; }
+        IList<string> Path { get; set; }
     }
 }

--- a/src/Shouldly/Internals/ShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/ShouldlyAssertionContext.cs
@@ -37,7 +37,7 @@ namespace Shouldly
         public SortDirection SortDirection { get; set; }
         public int OutOfOrderIndex { get; set; }
         public object OutOfOrderObject { get; set; }
-        public IList<string> Path { get; set; }
+        public IEnumerable<string> Path { get; set; }
 
 #if StackTrace
         internal ShouldlyAssertionContext(

--- a/src/Shouldly/Internals/ShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/ShouldlyAssertionContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using Shouldly.Internals;
 
@@ -36,6 +37,7 @@ namespace Shouldly
         public SortDirection SortDirection { get; set; }
         public int OutOfOrderIndex { get; set; }
         public object OutOfOrderObject { get; set; }
+        public IList<string> Path { get; set; }
 
 #if StackTrace
         internal ShouldlyAssertionContext(

--- a/src/Shouldly/MessageGenerators/ShouldBeEquivalentToMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeEquivalentToMessageGenerator.cs
@@ -33,10 +33,11 @@ $@"Comparing object equivalence, at path:
 #endif
             if (context.Path != null)
             {
-                for (var i = 0; i < context.Path.Count; i++)
+                var i = 0;
+                foreach (var part in context.Path)
                 {
-                    result.Append(new string(' ', i * IndentSize));
-                    result.AppendLine(context.Path[i]);
+                    result.Append(new string(' ', i++ * IndentSize));
+                    result.AppendLine(part);
                 }
             }
 

--- a/src/Shouldly/MessageGenerators/ShouldBeEquivalentToMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeEquivalentToMessageGenerator.cs
@@ -1,0 +1,46 @@
+﻿using System.Text;
+
+namespace Shouldly.MessageGenerators
+{
+    internal class ShouldBeEquivalentToMessageGenerator : ShouldlyMessageGenerator
+    {
+        private const string DefaultRootValue = "<root>";
+        private const int IndentSize = 4;
+
+        public override bool CanProcess(IShouldlyAssertionContext context)
+        {
+            return context.ShouldMethod == "ShouldBeEquivalentTo";
+        }
+
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
+        {
+            return
+$@"Comparing object equivalence, at path:
+{FormatPath(context)}
+
+    Expected value to be
+{context.Expected.ToStringAwesomely()}
+    but was
+{context.Actual.ToStringAwesomely()}";
+        }
+
+        private static string FormatPath(IShouldlyAssertionContext context)
+        {
+#if StackTrace
+            var result = new StringBuilder(ShouldlyConfiguration.IsSourceDisabledInErrors() ? DefaultRootValue : context.CodePart);
+#else
+            var result = new StringBuilder(DefaultRootValue);
+#endif
+            if (context.Path != null)
+            {
+                for (var i = 0; i < context.Path.Count; i++)
+                {
+                    result.Append(new string(' ', i * IndentSize));
+                    result.AppendLine(context.Path[i]);
+                }
+            }
+
+            return result.ToString().TrimEnd();
+        }
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -42,7 +42,7 @@ namespace Shouldly
             }
             else
             {
-                CompareReferenceTypes(actual, expected);
+                CompareReferenceTypes(actual, expected, type, path, customMessage, shouldlyMethod);
             }
         }
 
@@ -71,10 +71,16 @@ namespace Shouldly
                 ThrowException(actual, expected, path, customMessage, shouldlyMethod);
         }
 
-        private static void CompareReferenceTypes(object actual, object expected)
+        private static void CompareReferenceTypes(object actual, object expected, Type type, IList<string> path,
+            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
         {
             if (ReferenceEquals(actual, expected))
                 return;
+
+            if (type == typeof(string))
+            {
+                CompareStrings((string)actual, (string)expected, path, customMessage, shouldlyMethod);
+            }
         }
 
         private static bool BothValuesAreNull(object actual, object expected, IList<string> path,
@@ -93,6 +99,13 @@ namespace Shouldly
             }
 
             return false;
+        }
+
+        private static void CompareStrings(string actual, string expected, IList<string> path,
+            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        {
+            if (!actual.Equals(expected, StringComparison.Ordinal))
+                ThrowException(actual, expected, path, customMessage, shouldlyMethod);
         }
 
         private static void ThrowException(object actual, object expected, IList<string> path,

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
 namespace Shouldly
@@ -18,6 +20,32 @@ namespace Shouldly
 
         public static void ShouldBeEquivalentTo(this object actual, object expected, [InstantHandle] Func<string> customMessage)
         {
+            CompareObjects(actual, expected, new List<string>(), customMessage);
+        }
+
+        private static void CompareObjects(object actual, object expected, IList<string> path,
+            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        {
+            var type = GetTypeToCompare(actual, expected, path, customMessage, shouldlyMethod);
+        }
+
+        private static Type GetTypeToCompare(object actual, object expected, IList<string> path,
+            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        {
+            var expectedType = expected.GetType();
+            var actualType = actual.GetType();
+
+            if (actualType != expectedType)
+                ThrowException(actualType, expectedType, path, customMessage, shouldlyMethod);
+
+            return actualType;
+        }
+
+        private static void ThrowException(object actual, object expected, IList<string> path,
+            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        {
+            throw new ShouldAssertException(
+                new ExpectedEquvalenceShouldlyMessage(expected, actual, path, customMessage, shouldlyMethod).ToString());
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -40,6 +40,10 @@ namespace Shouldly
             {
                 CompareValueTypes((ValueType)actual, (ValueType)expected, path, customMessage, shouldlyMethod);
             }
+            else
+            {
+                CompareReferenceTypes(actual, expected);
+            }
         }
 
         private static Type GetTypeToCompare(object actual, object expected, IList<string> path,
@@ -65,6 +69,12 @@ namespace Shouldly
         {
             if (!actual.Equals(expected))
                 ThrowException(actual, expected, path, customMessage, shouldlyMethod);
+        }
+
+        private static void CompareReferenceTypes(object actual, object expected)
+        {
+            if (ReferenceEquals(actual, expected))
+                return;
         }
 
         private static bool BothValuesAreNull(object actual, object expected, IList<string> path,

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -27,6 +27,9 @@ namespace Shouldly
         private static void CompareObjects(object actual, object expected, IList<string> path,
             [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
         {
+            if (BothValuesAreNull(actual, expected, path, customMessage, shouldlyMethod))
+                return;
+
             var type = GetTypeToCompare(actual, expected, path, customMessage, shouldlyMethod);
 
 #if NewReflection
@@ -62,6 +65,24 @@ namespace Shouldly
         {
             if (!actual.Equals(expected))
                 ThrowException(actual, expected, path, customMessage, shouldlyMethod);
+        }
+
+        private static bool BothValuesAreNull(object actual, object expected, IList<string> path,
+            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        {
+            if (expected == null)
+            {
+                if (actual == null)
+                    return true;
+
+                ThrowException(actual, expected, path, customMessage, shouldlyMethod);
+            }
+            else if (actual == null)
+            {
+                ThrowException(actual, expected, path, customMessage, shouldlyMethod);
+            }
+
+            return false;
         }
 
         private static void ThrowException(object actual, object expected, IList<string> path,

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using JetBrains.Annotations;
+
+namespace Shouldly
+{
+    [ShouldlyMethods]
+    public static class ObjectGraphTestExtensions
+    {
+        public static void ShouldBeEquivalentTo(this object actual, object expected)
+        {
+            ShouldBeEquivalentTo(actual, expected, () => null);
+        }
+
+        public static void ShouldBeEquivalentTo(this object actual, object expected, string customMessage)
+        {
+            ShouldBeEquivalentTo(actual, expected, () => customMessage);
+        }
+
+        public static void ShouldBeEquivalentTo(this object actual, object expected, [InstantHandle] Func<string> customMessage)
+        {
+        }
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -23,10 +23,11 @@ namespace Shouldly
 
         public static void ShouldBeEquivalentTo(this object actual, object expected, [InstantHandle] Func<string> customMessage)
         {
-            CompareObjects(actual, expected, new List<string>(), customMessage);
+            CompareObjects(actual, expected, new List<string>(), new Dictionary<object, IList<object>>(), customMessage);
         }
 
-        private static void CompareObjects(object actual, object expected, IList<string> path,
+        private static void CompareObjects(object actual, object expected,
+            IList<string> path, IDictionary<object, IList<object>> previousComparisons,
             [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
         {
             if (BothValuesAreNull(actual, expected, path, customMessage, shouldlyMethod))
@@ -44,8 +45,26 @@ namespace Shouldly
             }
             else
             {
-                CompareReferenceTypes(actual, expected, type, path, customMessage, shouldlyMethod);
+                CompareReferenceTypes(actual, expected, type, path, previousComparisons, customMessage, shouldlyMethod);
             }
+        }
+
+        private static bool BothValuesAreNull(object actual, object expected, IEnumerable<string> path,
+            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        {
+            if (expected == null)
+            {
+                if (actual == null)
+                    return true;
+
+                ThrowException(actual, expected, path, customMessage, shouldlyMethod);
+            }
+            else if (actual == null)
+            {
+                ThrowException(actual, expected, path, customMessage, shouldlyMethod);
+            }
+
+            return false;
         }
 
         private static Type GetTypeToCompare(object actual, object expected, IList<string> path,
@@ -73,11 +92,15 @@ namespace Shouldly
                 ThrowException(actual, expected, path, customMessage, shouldlyMethod);
         }
 
-        private static void CompareReferenceTypes(object actual, object expected, Type type, IEnumerable<string> path,
+        private static void CompareReferenceTypes(object actual, object expected, Type type,
+            IEnumerable<string> path, IDictionary<object, IList<object>> previousComparisons,
             [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
         {
-            if (ReferenceEquals(actual, expected))
+            if (ReferenceEquals(actual, expected) ||
+                previousComparisons.Contains(actual, expected))
                 return;
+
+            previousComparisons.Record(actual, expected);
 
             if (type == typeof(string))
             {
@@ -85,31 +108,13 @@ namespace Shouldly
             }
             else if (typeof(IEnumerable).IsAssignableFrom(type))
             {
-                CompareEnumerables((IEnumerable)actual, (IEnumerable)expected, path, customMessage, shouldlyMethod);
+                CompareEnumerables((IEnumerable)actual, (IEnumerable)expected, path, previousComparisons, customMessage, shouldlyMethod);
             }
             else
             {
                 var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-                CompareProperties(actual, expected, properties, path, customMessage, shouldlyMethod);
+                CompareProperties(actual, expected, properties, path, previousComparisons, customMessage, shouldlyMethod);
             }
-        }
-
-        private static bool BothValuesAreNull(object actual, object expected, IEnumerable<string> path,
-            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
-        {
-            if (expected == null)
-            {
-                if (actual == null)
-                    return true;
-
-                ThrowException(actual, expected, path, customMessage, shouldlyMethod);
-            }
-            else if (actual == null)
-            {
-                ThrowException(actual, expected, path, customMessage, shouldlyMethod);
-            }
-
-            return false;
         }
 
         private static void CompareStrings(string actual, string expected, IEnumerable<string> path,
@@ -119,7 +124,8 @@ namespace Shouldly
                 ThrowException(actual, expected, path, customMessage, shouldlyMethod);
         }
 
-        private static void CompareEnumerables(IEnumerable actual, IEnumerable expected, IEnumerable<string> path,
+        private static void CompareEnumerables(IEnumerable actual, IEnumerable expected,
+            IEnumerable<string> path, IDictionary<object, IList<object>> previousComparisons,
             [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
         {
             var expectedList = expected.Cast<object>().ToList();
@@ -134,11 +140,12 @@ namespace Shouldly
             for (var i = 0; i < actualList.Count; i++)
             {
                 var newPath = path.Concat(new[] { $"Element [{i}]" });
-                CompareObjects(actualList[i], expectedList[i], newPath.ToList(), customMessage, shouldlyMethod);
+                CompareObjects(actualList[i], expectedList[i], newPath.ToList(), previousComparisons, customMessage, shouldlyMethod);
             }
         }
 
-        private static void CompareProperties(object actual, object expected, IEnumerable<PropertyInfo> properties, IEnumerable<string> path,
+        private static void CompareProperties(object actual, object expected, IEnumerable<PropertyInfo> properties,
+            IEnumerable<string> path, IDictionary<object, IList<object>> previousComparisons,
             [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
         {
             foreach (var property in properties)
@@ -147,7 +154,7 @@ namespace Shouldly
                 var expectedValue = property.GetValue(expected, new object[0]);
 
                 var newPath = path.Concat(new[] { property.Name });
-                CompareObjects(actualValue, expectedValue, newPath.ToList(), customMessage, shouldlyMethod);
+                CompareObjects(actualValue, expectedValue, newPath.ToList(), previousComparisons, customMessage, shouldlyMethod);
             }
         }
 
@@ -156,6 +163,21 @@ namespace Shouldly
         {
             throw new ShouldAssertException(
                 new ExpectedEquvalenceShouldlyMessage(expected, actual, path, customMessage, shouldlyMethod).ToString());
+        }
+
+        private static bool Contains(this IDictionary<object, IList<object>> comparisons, object actual, object expected)
+        {
+            return comparisons.TryGetValue(actual, out IList<object> list)
+                   && list.Contains(expected);
+        }
+
+        private static void Record(this IDictionary<object, IList<object>> comparisons, object actual,
+            object expected)
+        {
+            if (comparisons.TryGetValue(actual, out IList<object> list))
+                list.Add(expected);
+            else
+                comparisons.Add(actual, new List<object>(new[] { expected }));
         }
     }
 }

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -132,6 +132,18 @@ namespace Shouldly
         }
     }
 
+    internal class ExpectedEquvalenceShouldlyMessage : ShouldlyMessage
+    {
+        public ExpectedEquvalenceShouldlyMessage(object expected, object actual, IList<string> path, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        {
+            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
+            {
+                Path = path
+            };
+            if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
+        }
+    }
+
     internal class ShouldlyThrowMessage : ShouldlyMessage
     {
         public ShouldlyThrowMessage(object expected, string exceptionMessage, Func<string> customMessage,
@@ -259,7 +271,8 @@ namespace Shouldly
             new ShouldBePositiveMessageGenerator(),
             new ShouldBeNegativeMessageGenerator(),
             new ShouldBeTypeMessageGenerator(),
-            new ShouldBeInOrderMessageGenerator()
+            new ShouldBeInOrderMessageGenerator(),
+            new ShouldBeEquivalentToMessageGenerator()
         };
 
         protected IShouldlyAssertionContext ShouldlyAssertionContext { get; set; }

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -134,7 +134,7 @@ namespace Shouldly
 
     internal class ExpectedEquvalenceShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedEquvalenceShouldlyMessage(object expected, object actual, IList<string> path, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        public ExpectedEquvalenceShouldlyMessage(object expected, object actual, IEnumerable<string> path, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
         {
             ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {


### PR DESCRIPTION
I took a stab at implementing object graph comparison, noted in issue #370. I've done similar stuff in other projects, and thought I could knock it out. Let me know what you think.

For any two objects (actual & expected), the process is:
* First check for `null` values.
  * Both `null`, then exit.
  * Only one `null`, throw exception.
* Then compare data types.
  * Different, throw exception.
* Now compare values according to data type (in order of precedence)
  * `ValueType`
    * Compare using `Object.Equals()`.
  * `String`
    * Compare using `StringComparison.Ordinal`.
  * `IEnumerable` (any list)
    * Loop through each item and start new comparison. (recursion)
  * \<else\>
    * Use reflection to get all public, non-static properties of the data type.
    * Loop through each property and start new comparison. (recursion)

Throughout the recursion process, it also keeps track of the current path, so if an error occurs somewhere in the object graph it appears in the error message. The format ends up looking like this:

```
<root object> [<data type>]
    <property> [<data type>]
        Element [<index>] [<data type>]
            ...

    Expected value to be
<expected>
    but was
<actual>
```