### PR TITLE
Fix for #415 (ShouldlyMethods attribute were missing on ShouldBeEnumE…

### DIFF
--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumExtensions.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 
 namespace Shouldly.ShouldlyExtensionMethods
 {
+    [ShouldlyMethods]
     public static class ShouldHaveEnumExtensions
     {
         public static void ShouldHaveFlag(this Enum actual, Enum expectedFlag)


### PR DESCRIPTION
…xtensions class, causing ActualCodeTextGetter.ParseStackTrace to fail in finding the code frame of the assertion).