### PR TITLE
[WIP] Net Standard 2.0 and Should Match Approved

### DIFF
--- a/src/Shouldly/Configuration/DiffToolConfiguration.cs
+++ b/src/Shouldly/Configuration/DiffToolConfiguration.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Shouldly.Configuration
 {
@@ -28,7 +29,7 @@ namespace Shouldly.Configuration
 
         public void SetDiffToolPriorities(params DiffTool[] diffTools)
         {
-            var notRegistered = diffTools.Except(_diffTools);
+            var notRegistered = diffTools.Except(_diffTools).ToArray();
             if (notRegistered.Any())
             {
                 var notRegisteredNames = string.Join(", ", notRegistered.Select(r => r.Name).ToArray());

--- a/src/Shouldly/Configuration/FindMethodUsingAttribute.cs
+++ b/src/Shouldly/Configuration/FindMethodUsingAttribute.cs
@@ -1,6 +1,7 @@
 #if ShouldMatchApproved
 using System;
 using System.Diagnostics;
+using System.Reflection;
 using System.Linq;
 
 namespace Shouldly.Configuration
@@ -18,8 +19,11 @@ namespace Shouldly.Configuration
                     throw new Exception($"Cannot find method in call stack with attribute {typeof(T).FullName}");
                 }
                 callingFrame = stackTrace.GetFrame(i++);
+#if NETSTANDARD2_0
+            } while (!callingFrame.GetMethod().GetType().GetTypeInfo().GetCustomAttributes(typeof(T), true).Any());
+#else
             } while (!callingFrame.GetMethod().GetCustomAttributes(typeof(T), true).Any());
-
+#endif
             return new TestMethodInfo(callingFrame);
         }
     }

--- a/src/Shouldly/Configuration/FindMethodUsingAttribute.cs
+++ b/src/Shouldly/Configuration/FindMethodUsingAttribute.cs
@@ -6,6 +6,21 @@ using System.Linq;
 
 namespace Shouldly.Configuration
 {
+#if NETSTANDARD2_0
+    public class FindMethodUsingAttribute<T> : ITestMethodFinder where T : Attribute
+    {
+        public TestMethodInfo GetTestMethodInfo(StackTrace stackTrace, int startAt = 0)
+        {
+            var frames = stackTrace.GetFrames();
+            foreach (var frame in frames)
+            {
+                if (frame.GetMethod().GetType().GetTypeInfo().GetCustomAttributes(typeof(T), true).Any())
+                    return new TestMethodInfo(frame);
+            }
+            throw new Exception($"Cannot find method in call stack with attribute {typeof(T).FullName}");
+        }
+    }
+#else
     public class FindMethodUsingAttribute<T> : ITestMethodFinder where T : Attribute
     {
         public TestMethodInfo GetTestMethodInfo(StackTrace stackTrace, int startAt = 0)
@@ -19,13 +34,11 @@ namespace Shouldly.Configuration
                     throw new Exception($"Cannot find method in call stack with attribute {typeof(T).FullName}");
                 }
                 callingFrame = stackTrace.GetFrame(i++);
-#if NETSTANDARD2_0
-            } while (!callingFrame.GetMethod().GetType().GetTypeInfo().GetCustomAttributes(typeof(T), true).Any());
-#else
             } while (!callingFrame.GetMethod().GetCustomAttributes(typeof(T), true).Any());
-#endif
+
             return new TestMethodInfo(callingFrame);
         }
     }
+#endif
 }
 #endif

--- a/src/Shouldly/Configuration/TestMethodInfo.cs
+++ b/src/Shouldly/Configuration/TestMethodInfo.cs
@@ -23,6 +23,16 @@ namespace Shouldly.Configuration
             {
                 return method;
             }
+#if NETSTANDARD2_0
+            if (!ContainsAttribute(declaringType.GetTypeInfo().GetCustomAttributes(false) as object[], "System.Runtime.CompilerServices.CompilerGeneratedAttribute"))
+            {
+                return method;
+            }
+            if (declaringType.GetTypeInfo().GetInterface("System.Runtime.CompilerServices.IAsyncStateMachine") == null)
+            {
+                return method;
+            }
+#else
             if (!ContainsAttribute(declaringType.GetCustomAttributes(false), "System.Runtime.CompilerServices.CompilerGeneratedAttribute"))
             {
                 return method;
@@ -31,6 +41,7 @@ namespace Shouldly.Configuration
             {
                 return method;
             }
+#endif
             if (!declaringType.Name.Contains("<") || !declaringType.Name.Contains(">"))
             {
                 return method;

--- a/src/Shouldly/Configuration/VisualStudioDiffTool.cs
+++ b/src/Shouldly/Configuration/VisualStudioDiffTool.cs
@@ -124,7 +124,7 @@ namespace Shouldly.Configuration
                     return null;
                 }
 
-                var procInfo = new PROCESSENTRY32 { dwSize = (uint)Marshal.SizeOf(typeof(PROCESSENTRY32)) };
+                var procInfo = new PROCESSENTRY32 { dwSize = (uint)Marshal.SizeOf<PROCESSENTRY32>() };
 
 
                 // Read first

--- a/src/Shouldly/Configuration/VisualStudioDiffTool.cs
+++ b/src/Shouldly/Configuration/VisualStudioDiffTool.cs
@@ -50,6 +50,7 @@ namespace Shouldly.Configuration
                 return null;
             }
 
+#if !NETSTANDARD2_0
             if (process != null)
             {
                 var processModule = process.MainModule;
@@ -59,6 +60,7 @@ namespace Shouldly.Configuration
                     return processModule.FileName;
                 }
             }
+#endif
 
             return null;
         }

--- a/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
+++ b/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
@@ -8,12 +8,21 @@ namespace Shouldly
 {
     internal static class ShouldlyCoreExtensions
     {
-#if StackTrace
+#if NETSTANDARD2_0
         internal static bool IsShouldlyMethod(this MethodBase method)
         {
             if (method.DeclaringType == null)
                 return false;
-            
+
+            return method.DeclaringType.GetTypeInfo().GetCustomAttributes(typeof(ShouldlyMethodsAttribute), true).Any()
+               || (method.DeclaringType.DeclaringType != null && method.DeclaringType.DeclaringType.GetTypeInfo().GetCustomAttributes(typeof(ShouldlyMethodsAttribute), true).Any());
+        }
+#else
+        internal static bool IsShouldlyMethod(this MethodBase method)
+        {
+            if (method.DeclaringType == null)
+                return false;
+
             return method.DeclaringType.GetCustomAttributes(typeof(ShouldlyMethodsAttribute), true).Any()
                || (method.DeclaringType.DeclaringType != null && method.DeclaringType.DeclaringType.GetCustomAttributes(typeof(ShouldlyMethodsAttribute), true).Any());
         }

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
@@ -47,9 +47,9 @@ namespace Shouldly
         public static Task<TException> ThrowAsync<TException>(Func<Task> actual, [InstantHandle] Func<string> customMessage) where TException : Exception
         {
 #if StackTrace
-            var stackTrace = new StackTrace(true);
             return actual().ContinueWith(t =>
             {
+                var stackTrace = new StackTrace(t.Exception, true);
                 if (t.IsFaulted)
                 {
                     if (t.Exception == null)
@@ -96,9 +96,9 @@ namespace Shouldly
         public static Task<Exception> ThrowAsync(Func<Task> actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
         {
 #if StackTrace
-            var stackTrace = new StackTrace(true);
             return actual().ContinueWith(t =>
             {
+                var stackTrace = new StackTrace(t.Exception, true);
                 if (t.IsFaulted)
                 {
                     if (t.Exception == null)

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Shouldly - Assertion framework for .NET. The way asserting *Should* be</Description>
-    <TargetFrameworks>net451;net40;netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net451;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3</TargetFrameworks>
     <AssemblyName>Shouldly</AssemblyName>
     <PackageId>Shouldly</PackageId>
@@ -22,6 +22,15 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -45,4 +54,7 @@
     <DefineConstants>$(DefineConstants);NewReflection;ExpressionTrees</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);ShouldMatchApproved;StackTrace;NewReflection;ExpressionTrees</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Shouldly - Assertion framework for .NET. The way asserting *Should* be</Description>
     <TargetFrameworks>net451;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <AssemblyName>Shouldly</AssemblyName>
     <PackageId>Shouldly</PackageId>
     <PackageTags>test;unit;testing;TDD;AAA;should;testunit;rspec;assert;assertion;framework</PackageTags>
@@ -26,6 +26,8 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
@@ -41,6 +43,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <PackageReference Include="System.Threading" Version="4.3.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">

--- a/src/Shouldly/ShouldlyConfiguration.cs
+++ b/src/Shouldly/ShouldlyConfiguration.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 #if ShouldMatchApproved
 using Shouldly.Configuration;
-using System.Runtime.Remoting.Messaging;
+using System.Threading;
 #endif
 
 namespace Shouldly
@@ -21,6 +21,7 @@ namespace Shouldly
 
         public static List<string> CompareAsObjectTypes { get; private set; }
 #if ShouldMatchApproved
+        private static AsyncLocal<bool> ShouldlyDisableSourceInErrors = new AsyncLocal<bool>();
         private static Lazy<DiffToolConfiguration> _lazyDiffTools = new Lazy<DiffToolConfiguration>(() => new DiffToolConfiguration());
         public static DiffToolConfiguration DiffTools {
             get => _lazyDiffTools.Value;
@@ -44,20 +45,20 @@ namespace Shouldly
         /// </summary>
         public static IDisposable DisableSourceInErrors()
         {
-            CallContext.LogicalSetData("ShouldlyDisableSourceInErrors", true);
+            ShouldlyDisableSourceInErrors.Value = true;
             return new EnableSourceInErrorsDisposable();
         }
 
         public static bool IsSourceDisabledInErrors()
         {
-            return (bool?) CallContext.LogicalGetData("ShouldlyDisableSourceInErrors") == true;
+            return ShouldlyDisableSourceInErrors.Value == true;
         }
 
         class EnableSourceInErrorsDisposable : IDisposable
         {
             public void Dispose()
             {
-                CallContext.LogicalSetData("ShouldlyDisableSourceInErrors", null);
+                ShouldlyDisableSourceInErrors.Value = false;
             }
         }
 #endif

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldMatchApprovedTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldMatchApprovedTestExtensions.cs
@@ -1,5 +1,4 @@
-﻿// TODO Try and get this working with Core
-#if ShouldMatchApproved
+﻿#if ShouldMatchApproved
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -36,7 +35,7 @@ namespace Shouldly
         public static void ShouldMatchApproved(this string actual, Func<string> customMessage, Action<ShouldMatchConfigurationBuilder> configureOptions)
         {
             var codeGetter = new ActualCodeTextGetter();
-            var stackTrace = new StackTrace(true);
+            var stackTrace = new StackTrace(null, true);
             codeGetter.GetCodeText(actual, stackTrace);
 
             var configurationBuilder = new ShouldMatchConfigurationBuilder(ShouldlyConfiguration.ShouldMatchApprovedDefaults.Build());


### PR DESCRIPTION
A work in progress to see what is needed to get `ShouldMatchApproved` working under `netstandard2.0`

- [x] Added `netstandard2.0` to csproj
- [x] Enabled `ShouldMatchApproved` define
- [ ] Fix compile errors :boom:
- [ ] Cross-platform diff tool support

Interesting side note, I have `ShouldMatchApproved` working in `netstandard1.6` by removing the `StackFrame` walking. 