### PR TITLE
Added ShouldBeSetEqualTo(), ShouldBeSequenceEqualTo(), and ShouldSati…

### DIFF
--- a/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSequenceEqualToExamples.ShouldBe.codeSample.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSequenceEqualToExamples.ShouldBe.codeSample.approved.txt
@@ -1,0 +1,6 @@
+var apu = new Person() { Name = "Apu" };
+var homer = new Person() { Name = "Homer" };
+var skinner = new Person() { Name = "Skinner" };
+var barney = new Person() { Name = "Barney" };
+var theBeSharps = new List<Person>() { apu, homer, skinner, barney };
+theBeSharps.ShouldBe(new[] { barnet, skinner, homer, apu });

--- a/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSequenceEqualToExamples.ShouldBe.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSequenceEqualToExamples.ShouldBe.exceptionText.approved.txt
@@ -1,0 +1,7 @@
+theBeSharps
+    should be
+[Apu, Homer, Skinner, Barney]
+    but was
+[Barney, Skinner, Homer, Apu]
+    difference
+[*Barney*, *Skinner*, *Homer*, *Apu*]

--- a/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSetEqualToExamples.ShouldBe.codeSample.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSetEqualToExamples.ShouldBe.codeSample.approved.txt
@@ -1,0 +1,6 @@
+var apu = new Person() { Name = "Apu" };
+var homer = new Person() { Name = "Homer" };
+var skinner = new Person() { Name = "Skinner" };
+var barney = new Person() { Name = "Barney" };
+var theBeSharps = new List<Person>() { homer, skinner, barney };
+theBeSharps.ShouldBe(new[] { apu, homer, skinner, barney });

--- a/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSetEqualToExamples.ShouldBe.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSetEqualToExamples.ShouldBe.exceptionText.approved.txt
@@ -1,0 +1,7 @@
+theBeSharps
+    should be (ignoring order)
+[Apu, Homer, Skinner, Barney]
+    but
+[Homer, Skinner, Barney]
+    is missing
+[Apu]

--- a/src/DocumentationExamples/CodeExamples/ShouldSatisfyAnyConditionsExamples.ShouldSatisfyAllConditions.codeSample.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldSatisfyAnyConditionsExamples.ShouldSatisfyAllConditions.codeSample.approved.txt
@@ -1,0 +1,6 @@
+var mrBurns = new Person() { Name = null };
+mrBurns.ShouldSatisfyAnyConditions
+                    (
+                        () => mrBurns.Name.ShouldNotBeNullOrEmpty(),
+                        () => mrBurns.Name.ShouldBe("Mr.Burns")
+                    );

--- a/src/DocumentationExamples/CodeExamples/ShouldSatisfyAnyConditionsExamples.ShouldSatisfyAllConditions.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldSatisfyAnyConditionsExamples.ShouldSatisfyAllConditions.exceptionText.approved.txt
@@ -1,0 +1,23 @@
+mrBurns
+    should satisfy any of the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    mrBurns.Name (null)
+        should not be null or empty
+
+--------------- Error 2 ---------------
+    mrBurns.Name
+        should be
+    "Mr.Burns"
+        but was
+    null
+        difference
+    Difference     |  |    |    |    |    |    |    |    |   
+                   | \|/  \|/  \|/  \|/  \|/  \|/  \|/  \|/  
+    Index          | 0    1    2    3    4    5    6    7    
+    Expected Value | M    r    .    B    u    r    n    s    
+    Actual Value   | n    u    l    l                        
+    Expected Code  | 77   114  46   66   117  114  110  115  
+    Actual Code    | 110  117  108  108                      
+
+-----------------------------------------

--- a/src/DocumentationExamples/EnumerableShouldBeSequanceEqualTo.cs
+++ b/src/DocumentationExamples/EnumerableShouldBeSequanceEqualTo.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Shouldly;
+using Simpsons;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DocumentationExamples
+{
+    public class EnumerableShouldBeSequenceEqualToExamples
+    {
+        readonly ITestOutputHelper _testOutputHelper;
+
+        public EnumerableShouldBeSequenceEqualToExamples(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public void ShouldBe()
+        {
+            DocExampleWriter.Document(() =>
+            {
+                var apu = new Person() { Name = "Apu" };
+                var homer = new Person() { Name = "Homer" };
+                var skinner = new Person() { Name = "Skinner" };
+                var barney = new Person() { Name = "Barney" };
+                var theBeSharps = new List<Person>() { apu, homer, skinner, barney };
+
+                theBeSharps.ShouldBeSequenceEqualTo(new[] { barney, skinner, homer, apu });
+            }, _testOutputHelper);
+        }
+
+    }
+}

--- a/src/DocumentationExamples/EnumerableShouldBeSetEqualToExamples.cs
+++ b/src/DocumentationExamples/EnumerableShouldBeSetEqualToExamples.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Shouldly;
+using Simpsons;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DocumentationExamples
+{
+    public class EnumerableShouldBeSetEqualToExamples
+    {
+        readonly ITestOutputHelper _testOutputHelper;
+
+        public EnumerableShouldBeSetEqualToExamples(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public void ShouldBe()
+        {
+            DocExampleWriter.Document(() =>
+            {
+                var apu = new Person() { Name = "Apu" };
+                var homer = new Person() { Name = "Homer" };
+                var skinner = new Person() { Name = "Skinner" };
+                var barney = new Person() { Name = "Barney" };
+                var theBeSharps = new List<Person>() { homer, skinner, barney };
+
+                theBeSharps.ShouldBeSetEqualTo(new[] { apu, homer, skinner, barney });
+            }, _testOutputHelper);
+        }
+
+    }
+}

--- a/src/DocumentationExamples/ShouldSatisfyAnyConditionsExamples.cs
+++ b/src/DocumentationExamples/ShouldSatisfyAnyConditionsExamples.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Threading;
+using Shouldly;
+using Simpsons;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace DocumentationExamples
+{
+    public class ShouldSatisfyAnyConditionsExamples
+    {
+        readonly ITestOutputHelper _testOutputHelper;
+
+        public ShouldSatisfyAnyConditionsExamples(ITestOutputHelper testOutputHelper)
+        {
+            _testOutputHelper = testOutputHelper;
+        }
+
+        [Fact]
+        public void ShouldSatisfyAnyConditions()
+        {
+            DocExampleWriter.Document(() =>
+            {
+                var mrBurns = new Person() { Name = null };
+                mrBurns.ShouldSatisfyAnyConditions
+                    (
+                        () => mrBurns.Name.ShouldNotBeNullOrEmpty(),
+                        () => mrBurns.Name.ShouldBe("Mr.Burns")
+                    );
+            }, _testOutputHelper);
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeSequenceEqualTo/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSequenceEqualTo/IntegerArrayScenario.cs
@@ -1,0 +1,45 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeSequenceEqualTo
+{
+    public class IntegerArrayScenario
+    {
+
+        [Fact]
+        public void IntegerArrayScenarioShouldFail()
+        {
+            Verify.ShouldFail(() =>
+    new[] { 1, 2, 3, 4 }.ShouldBeSequenceEqualTo(new[] { 4, 3, 2, 1 }, "Some additional context"),
+
+    errorWithSource:
+    @"new[] { 1, 2, 3, 4 }
+    should be
+[4, 3, 2, 1]
+    but was
+[1, 2, 3, 4]
+    difference
+[*1*, *2*, *3*, *4*]
+
+Additional Info:
+    Some additional context",
+
+    errorWithoutSource:
+    @"[1, 2, 3, 4]
+    should be
+[4, 3, 2, 1]
+    but was not
+    difference
+[*1*, *2*, *3*, *4*]
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            new[] { 1, 2, 3, 4 }.ShouldBeSequenceEqualTo(new[] { 1, 2, 3, 4 });
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeSetEqualTo/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSetEqualTo/IntegerArrayScenario.cs
@@ -1,0 +1,54 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeSetEqualTo
+{
+    public class IntegerArrayScenario
+    {
+
+        [Fact]
+        public void IntegerArrayScenarioShouldFail()
+        {
+            Verify.ShouldFail(() =>
+    new[] { 99, 2, 3, 5 }.ShouldBeSetEqualTo(new[] { 1, 2, 3, 4 }, "Some additional context"),
+
+    errorWithSource:
+    @"new[] { 99, 2, 3, 5 }
+    should be (ignoring order)
+[1, 2, 3, 4]
+    but
+new[] { 99, 2, 3, 5 }
+    is missing
+[1, 4]
+    and
+[1, 2, 3, 4]
+    is missing
+[99, 5]
+
+Additional Info:
+    Some additional context",
+
+    errorWithoutSource:
+    @"[99, 2, 3, 5]
+    should be (ignoring order)
+[1, 2, 3, 4]
+    but
+[99, 2, 3, 5]
+    is missing
+[1, 4]
+    and
+[1, 2, 3, 4]
+    is missing
+[99, 5]
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            new[] { 1, 2, 3, 4 }.ShouldBeSetEqualTo(new[] { 4, 3, 2, 1 });
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldSatisfyAnyConditions/MultipleConditionsScenario.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAnyConditions/MultipleConditionsScenario.cs
@@ -1,0 +1,103 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldSatisfyAnyConditions
+{
+    public class MultipleConditionsScenario
+    {
+
+        [Fact]
+        public void MultipleConditionsScenarioShouldFail()
+        {
+            int result = 4;
+            Verify.ShouldFail(() =>
+result.ShouldSatisfyAnyConditions
+    (
+        "Some additional context",
+        () => result.ShouldBeOfType<float>("Some additional context"),
+        () => result.ShouldBeGreaterThan(5, "Some additional context")
+    ),
+
+errorWithSource:
+@"result
+    should satisfy any of the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    result
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    result
+        should be greater than
+    5
+        but was
+    4
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"4
+    should satisfy any of the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    4
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    4
+        should be greater than
+    5
+        but was not
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            int result = 4;
+            
+            result.ShouldSatisfyAnyConditions
+                    (
+                        () => result.ShouldBeOfType<int>(),
+                        () => result.ShouldBeGreaterThan(3)
+                    );
+
+            result.ShouldSatisfyAnyConditions
+                    (
+                        () => result.ShouldBeOfType<float>(),
+                        () => result.ShouldBeGreaterThan(3)
+                    );
+
+            result.ShouldSatisfyAnyConditions
+                    (
+                        () => result.ShouldBeOfType<int>(),
+                        () => result.ShouldBeGreaterThan(5)
+                    );
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldSatisfyAnyConditions/MultipleConditionsScenario_MultiLine.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAnyConditions/MultipleConditionsScenario_MultiLine.cs
@@ -1,0 +1,105 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldSatisfyAnyConditions
+{
+    public class MultipleConditionsScenario_MultiLine
+    {
+
+        [Fact]
+        public void MultipleConditionsScenario_MultiLineShouldFail()
+        {
+            int result = 4;
+            Verify.ShouldFail(() =>
+result.ShouldSatisfyAnyConditions
+(
+    () => result.ShouldBeOfType<float>("Some additional context"),
+    () => result.ShouldBeGreaterThan(5, "Some additional context")
+),
+
+errorWithSource:
+@"result
+    should satisfy any of the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    result
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    result
+        should be greater than
+    5
+        but was
+    4
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------",
+
+errorWithoutSource:
+@"4
+    should satisfy any of the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    4
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    4
+        should be greater than
+    5
+        but was not
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            int result = 4;
+
+            result.ShouldSatisfyAnyConditions
+                    (
+                        ()
+                            => result.ShouldBeOfType<int>(),
+                        ()
+                            =>
+                            result.ShouldBeGreaterThan(3)
+                    );
+
+            result.ShouldSatisfyAnyConditions
+                    (
+                        ()
+                            => result.ShouldBeOfType<float>(),
+                        ()
+                            =>
+                            result.ShouldBeGreaterThan(3)
+                    );
+
+            result.ShouldSatisfyAnyConditions
+                    (
+                        ()
+                            => result.ShouldBeOfType<int>(),
+                        ()
+                            =>
+                            result.ShouldBeGreaterThan(5)
+                    );
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldSatisfyAnyConditions/MultipleConditionsScenario_MultiLine2.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAnyConditions/MultipleConditionsScenario_MultiLine2.cs
@@ -1,0 +1,111 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldSatisfyAnyConditions
+{
+    public class MultipleConditionsScenario_MultiLine2
+    {
+
+        [Fact]
+        public void MultipleConditionsScenario_MultiLine2ShouldFail()
+        {
+            int result = 4;
+            Verify.ShouldFail(() =>
+result.ShouldSatisfyAnyConditions
+(
+    () => result.ShouldBeOfType<float>("Some additional context"),
+    () => result.ShouldBeGreaterThan(5, "Some additional context")
+),
+
+errorWithSource:
+@"result
+    should satisfy any of the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    result
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    result
+        should be greater than
+    5
+        but was
+    4
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------",
+
+errorWithoutSource:
+@"4
+    should satisfy any of the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    4
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    4
+        should be greater than
+    5
+        but was not
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            int result = 4;
+
+            result.ShouldSatisfyAnyConditions
+                    (
+                        ()
+                            => result
+                                .ShouldBeOfType<int>(),
+                        ()
+                            =>
+                            result
+                            .ShouldBeGreaterThan(3)
+                    );
+
+            result.ShouldSatisfyAnyConditions
+                    (
+                        ()
+                            => result
+                                .ShouldBeOfType<float>(),
+                        ()
+                            =>
+                            result
+                            .ShouldBeGreaterThan(3)
+                    );
+
+            result.ShouldSatisfyAnyConditions
+                    (
+                        ()
+                            => result
+                                .ShouldBeOfType<int>(),
+                        ()
+                            =>
+                            result
+                            .ShouldBeGreaterThan(5)
+                    );
+        }
+    }
+}

--- a/src/Shouldly/MessageGenerators/ShouldSatisfyAnyConditionsMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldSatisfyAnyConditionsMessageGenerator.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Shouldly.MessageGenerators
+{
+    internal class ShouldSatisfyAnyConditionsMessageGenerator : ShouldlyMessageGenerator
+    {
+        static readonly Regex Validator = new Regex("ShouldSatisfyAnyConditions");
+
+        public override bool CanProcess(IShouldlyAssertionContext context)
+        {
+            return Validator.IsMatch(context.ShouldMethod);
+        }
+
+        public override string GenerateErrorMessage(IShouldlyAssertionContext context)
+        {
+            var codePart = context.CodePart;
+            var expectedValue = context.Expected.ToString();
+
+            return
+$@"{codePart}
+    should satisfy any of the conditions specified, but does not.
+The following errors were found ...
+{expectedValue}";
+        }
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -11,6 +11,36 @@ namespace Shouldly
     [ShouldlyMethods]
     public static class ShouldBeEnumerableTestExtensions
     {
+        public static void ShouldBeSetEqualTo<T>(this IEnumerable<T> actual, IEnumerable<T> expected)
+        {
+            ShouldBeSetEqualTo(actual, expected, () => null);
+        }
+
+        public static void ShouldBeSetEqualTo<T>(this IEnumerable<T> actual, IEnumerable<T> expected, string customMessage)
+        {
+            ShouldBeSetEqualTo(actual, expected, () => customMessage);
+        }
+
+        public static void ShouldBeSetEqualTo<T>(this IEnumerable<T> actual, IEnumerable<T> expected, [InstantHandle] Func<string> customMessage)
+        {
+            ShouldBeTestExtensions.ShouldBe(actual, expected, true, customMessage);
+        }
+
+        public static void ShouldBeSequenceEqualTo<T>(this IEnumerable<T> actual, IEnumerable<T> expected)
+        {
+            ShouldBeSequenceEqualTo(actual, expected, () => null);
+        }
+
+        public static void ShouldBeSequenceEqualTo<T>(this IEnumerable<T> actual, IEnumerable<T> expected, string customMessage)
+        {
+            ShouldBeSequenceEqualTo(actual, expected, () => customMessage);
+        }
+
+        public static void ShouldBeSequenceEqualTo<T>(this IEnumerable<T> actual, IEnumerable<T> expected, [InstantHandle] Func<string> customMessage)
+        {
+            ShouldBeTestExtensions.ShouldBe(actual, expected, false, customMessage);
+        }
+
         public static void ShouldContain<T>(this IEnumerable<T> actual, T expected)
         {
             ShouldContain(actual, expected, () => null);

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAnyConditionsTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAnyConditionsTestExtensions.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System;
+using System.Text;
+using JetBrains.Annotations;
+
+namespace Shouldly
+{
+    [ShouldlyMethods]
+    public static class ShouldSatisfyAnyConditionsTestExtensions
+    {
+        public static void ShouldSatisfyAnyConditions(this object actual, [InstantHandle] params Action[] conditions)
+        {
+            ShouldSatisfyAnyConditions(actual, () => null, conditions);
+        }
+        public static void ShouldSatisfyAnyConditions(this object actual, string customMessage, [InstantHandle] params Action[] conditions)
+        {
+            ShouldSatisfyAnyConditions(actual, () => customMessage, conditions);
+        }
+        public static void ShouldSatisfyAnyConditions(this object actual, [InstantHandle] Func<string> customMessage, [InstantHandle] params Action[] conditions)
+        {
+            var errorMessages = new List<Exception>();
+            foreach (var action in conditions) 
+            {
+                try
+                {
+                    action.Invoke();
+                    return;
+                }
+                catch (Exception exc)
+                {
+                    errorMessages.Add(exc);
+                }
+            }
+
+            var errorMessageString = BuildErrorMessageString(errorMessages);
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(errorMessageString, actual, customMessage).ToString());
+        }
+
+        static string BuildErrorMessageString(IEnumerable<Exception> errorMessages)
+        {
+            var errorCount = 1;
+            var sb = new StringBuilder();
+            foreach (var errorMessage in errorMessages)
+            {
+                sb.AppendLine($"--------------- Error {errorCount} ---------------");
+                var lines = errorMessage.Message.Replace("\r\n", "\n").Split('\n');
+                var paddedLines = lines.Select(l => string.IsNullOrEmpty(l) ? l : "    " + l);
+                var value = string.Join("\r\n", paddedLines.ToArray());
+                sb.AppendLine(value);
+                sb.AppendLine();
+                errorCount++;
+            }
+            sb.AppendLine("-----------------------------------------");
+
+            return sb.ToString().TrimEnd();
+        }
+    }
+}

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -248,6 +248,7 @@ namespace Shouldly
             new ShouldContainPredicateMessageGenerator(),
             new ShouldBeIgnoringOrderMessageGenerator(),
             new ShouldSatisfyAllConditionsMessageGenerator(),
+            new ShouldSatisfyAnyConditionsMessageGenerator(),
             new ShouldBeSubsetOfMessageGenerator(),
             new ShouldHaveSingleItemMessageGenerator(),
             new ShouldBeBooleanMessageGenerator(),


### PR DESCRIPTION
I've had a few custom extension methods sitting in my projects for a while, so I thought I'd formalize them and push them up for everyone.

ShouldBeSetEqualTo()
ShouldBeSequenceEqualTo()
ShouldSatisfyAnyConditions()

I've written tests for each of them. Since ShouldBeSetEqualTo() and ShouldBeSequenceEqualTo() are just proxies for ShouldBe(IEnumerable<T>) with ignoreOrder true and false, respectively, I didn't replicate all of the tests done for that method. I just made a single scenario for each one that exercises the ignoreOrder parameter. I figure if the scenarios fail and pass properly, and produce the correct message, it's a sufficient indication that ShouldBe() is being called properly under the hood.

I also did my best to write the Documentation items that match the formatting and structure of existing methods, but I imagine it's not quite right. Please let me know if I should change anything.
