### PR TITLE
More shoulds

### DIFF
--- a/GitVersionConfig.yaml
+++ b/GitVersionConfig.yaml
@@ -1,1 +1,1 @@
-next-version: 3.0.0
+next-version: 3.1.0

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
@@ -204,6 +204,9 @@ namespace Shouldly
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string customMessage) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Func<string> customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer, string customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount, string customMessage) { }
@@ -225,6 +228,9 @@ namespace Shouldly
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string customMessage) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Func<string> customMessage) { }
+        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer, string customMessage) { }
+        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string customMessage) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string> customMessage) { }
@@ -319,9 +325,15 @@ namespace Shouldly
         public static void ShouldBe<T>(this T actual, T expected) { }
         public static void ShouldBe<T>(this T actual, T expected, string customMessage) { }
         public static void ShouldBe<T>(this T actual, T expected, System.Func<string> customMessage) { }
+        public static void ShouldBe<T>(this T actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public static void ShouldBe<T>(this T actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer, string customMessage) { }
+        public static void ShouldBe<T>(this T actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, bool ignoreOrder = False) { }
         public static void ShouldBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, bool ignoreOrder, string customMessage) { }
         public static void ShouldBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, bool ignoreOrder, System.Func<string> customMessage) { }
+        public static void ShouldBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, System.Collections.Generic.IEqualityComparer<T> comparer, bool ignoreOrder = False) { }
+        public static void ShouldBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, System.Collections.Generic.IEqualityComparer<T> comparer, bool ignoreOrder, string customMessage) { }
+        public static void ShouldBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, System.Collections.Generic.IEqualityComparer<T> comparer, bool ignoreOrder, System.Func<string> customMessage) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance, string customMessage) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance, System.Func<string> customMessage) { }
@@ -448,6 +460,9 @@ namespace Shouldly
         public static void ShouldNotBe<T>(this T actual, T expected) { }
         public static void ShouldNotBe<T>(this T actual, T expected, string customMessage) { }
         public static void ShouldNotBe<T>(this T actual, T expected, System.Func<string> customMessage) { }
+        public static void ShouldNotBe<T>(this T actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer) { }
+        public static void ShouldNotBe<T>(this T actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer, string customMessage) { }
+        public static void ShouldNotBe<T>(this T actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldNotBeAssignableTo<T>(this object actual) { }
         public static void ShouldNotBeAssignableTo<T>(this object actual, string customMessage) { }
         public static void ShouldNotBeAssignableTo<T>(this object actual, System.Func<string> customMessage) { }

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
@@ -148,9 +148,15 @@ namespace Shouldly
         public static void ShouldBeFalse(this bool actual) { }
         public static void ShouldBeFalse(this bool actual, string customMessage) { }
         public static void ShouldBeFalse(this bool actual, System.Func<string> customMessage) { }
+        public static void ShouldBeFalse(this System.Nullable<bool> actual) { }
+        public static void ShouldBeFalse(this System.Nullable<bool> actual, string customMessage) { }
+        public static void ShouldBeFalse(this System.Nullable<bool> actual, System.Func<string> customMessage) { }
         public static void ShouldBeTrue(this bool actual) { }
         public static void ShouldBeTrue(this bool actual, string customMessage) { }
         public static void ShouldBeTrue(this bool actual, System.Func<string> customMessage) { }
+        public static void ShouldBeTrue(this System.Nullable<bool> actual) { }
+        public static void ShouldBeTrue(this System.Nullable<bool> actual, string customMessage) { }
+        public static void ShouldBeTrue(this System.Nullable<bool> actual, System.Func<string> customMessage) { }
     }
     [Shouldly.ShouldlyMethodsAttribute()]
     public class static ShouldBeDictionaryTestExtensions

--- a/src/Shouldly.Tests/ConventionTests/ShouldlyConventions.ShouldHaveCustomMessageOverloads.approved.txt
+++ b/src/Shouldly.Tests/ConventionTests/ShouldlyConventions.ShouldHaveCustomMessageOverloads.approved.txt
@@ -1,10 +1,10 @@
-﻿'The following shouldly methods are missing one or more of the custom message overloads' for 'Types in Shouldly extension classes'
+'The following shouldly methods are missing one or more of the custom message overloads' for 'Types in Shouldly extension classes'
 ----------------------------------------------------------------------------------------------------------------------------------
 
-	ShouldBe(this System.String actual, System.String expected, Shouldly.StringCompareShould options)
 	ShouldBe(this System.String actual, System.String expected, Shouldly.StringCompareShould option)
-	ShouldStartWith(this System.String actual, System.String expected)
+	ShouldBe(this System.String actual, System.String expected, Shouldly.StringCompareShould options)
 	ShouldEndWith(this System.String actual, System.String expected)
-	ShouldNotStartWith(this System.String actual, System.String expected)
-	ShouldNotEndWith(this System.String actual, System.String expected)
 	ShouldMatchApproved(this System.String actual)
+	ShouldNotEndWith(this System.String actual, System.String expected)
+	ShouldNotStartWith(this System.String actual, System.String expected)
+	ShouldStartWith(this System.String actual, System.String expected)

--- a/src/Shouldly.Tests/ConventionTests/ShouldlyMethodsShouldHaveCustomMessageOverload.cs
+++ b/src/Shouldly.Tests/ConventionTests/ShouldlyMethodsShouldHaveCustomMessageOverload.cs
@@ -16,6 +16,7 @@ namespace Shouldly.Tests.ConventionTests
                 where typeof (object).GetMethods().All(m => m.Name != shouldlyMethods.Name)
                 group shouldlyMethods by FormatKey(shouldlyMethods) into shouldlyMethod
                 where HasNoCustomMessageOverload(shouldlyMethod)
+                orderby shouldlyMethod.Key ascending 
                 select shouldlyMethod.Key;
 
             result.Is(

--- a/src/Shouldly.Tests/ShouldBeBoolean/FalseScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeBoolean/FalseScenario.cs
@@ -10,7 +10,7 @@ namespace Shouldly.Tests.ShouldBeBoolean
         {
             const bool myValue = true;
             Verify.ShouldFail(() =>
-                myValue.ShouldBeFalse("Some additional context"),
+myValue.ShouldBeFalse("Some additional context"),
 
 errorWithSource:
 @"myValue
@@ -36,6 +36,38 @@ Additional Info:
         public void ShouldPass()
         {
             false.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void NullableFalseScenarioShouldFail() {
+            bool? myValue = true;
+            Verify.ShouldFail(() =>
+myValue.ShouldBeFalse("Some additional context"),
+
+errorWithSource:
+@"myValue
+    should be
+False
+    but was
+True
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"True
+    should be
+False
+    but was not
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void NullableShouldPass() {
+            bool? value = false;
+            value.ShouldBeFalse();
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeBoolean/TrueScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeBoolean/TrueScenario.cs
@@ -37,5 +37,40 @@ Additional Info:
         {
             true.ShouldBeTrue();
         }
+
+        [Fact]
+        public void NullableTrueScenarioShouldFail()
+        {
+            const bool myValue = false;
+            Verify.ShouldFail(() =>
+myValue.ShouldBeTrue("Some additional context"),
+
+errorWithSource:
+@"myValue
+    should be
+True
+    but was
+False
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"False
+    should be
+True
+    but was not
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void NullableShouldPass()
+        {
+            bool? value = true;
+            value.ShouldBeTrue();
+        }
+
     }
 }

--- a/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
+++ b/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
@@ -14,7 +14,7 @@ namespace Shouldly.Tests.ShouldMatchApproved
 {
     public class ShouldMatchApprovedScenarios
     {
-        readonly Func<string, string> _scrubber = v => Regex.Replace(v, @"\w:.+?shouldly\\src", "C:\\PathToCode\\shouldly\\src");
+        readonly Func<string, string> _scrubber = v => Regex.Replace(v, @"\w:.+?[Ss]houldly\\src", "C:\\PathToCode\\shouldly\\src");
 
         [Fact]
         public void Simple()

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -10,7 +10,7 @@
     <DebugType>full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>2.0.5</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -9,6 +9,10 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <DebugType>full</DebugType>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="**\*.approved.cs;**\*.received.cs" />
   </ItemGroup>

--- a/src/Shouldly/Internals/Is.cs
+++ b/src/Shouldly/Internals/Is.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Reflection;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -41,6 +42,11 @@ namespace Shouldly
 
         public static bool Equal<T>(IEnumerable<T> actual, IEnumerable<T> expected)
         {
+            return Equal(actual, expected, GetEqualityComparer<T>());
+        }
+
+        public static bool Equal<T>(IEnumerable<T> actual, IEnumerable<T> expected, [NotNull] IEqualityComparer<T> comparer)
+        {
             if (actual == null && expected == null)
                 return true;
             if (actual == null || expected == null)
@@ -57,14 +63,20 @@ namespace Shouldly
                 if (!expectedHasData && !actualHasData)
                     return true;
 
-                if (expectedHasData != actualHasData || !Equal(actualEnum.Current, expectedEnum.Current))
+                if (expectedHasData != actualHasData || !Equal(actualEnum.Current, expectedEnum.Current, comparer))
                 {
                     return false;
                 }
             }
+
         }
 
         public static bool EqualIgnoreOrder<T>(IEnumerable<T> actual, IEnumerable<T> expected)
+        {
+            return EqualIgnoreOrder(actual, expected, GetEqualityComparer<T>());
+        }
+
+        public static bool EqualIgnoreOrder<T>(IEnumerable<T> actual, IEnumerable<T> expected, [NotNull] IEqualityComparer<T> comparer)
         {
             if (actual == null && expected == null)
                 return true;
@@ -79,7 +91,7 @@ namespace Shouldly
             var expectedList = expected.ToList();
             foreach (var actualElement in actual)
             {
-                var match = expectedList.FirstOrDefault(x => Equal(x, actualElement));
+                var match = expectedList.FirstOrDefault(x => Equal(x, actualElement, comparer));
                 if (!expectedList.Remove(match))
                     return false;
             }
@@ -197,8 +209,7 @@ namespace Shouldly
 
             return actual.IndexOf(expected, StringComparison.Ordinal) != -1;
         }
-
-
+        
         public static bool EndsWithUsingCaseSensitivity(string actual, string expected, Case caseSensitivity)
         {
             if (actual == null)
@@ -304,6 +315,7 @@ namespace Shouldly
         {
             return comparer.Compare(actual, expected);
         }
+
         static decimal Compare<T>(IComparable<T> comparable, T expected)
         {
             if (!typeof(T).IsValueType())

--- a/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
+++ b/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
@@ -36,7 +36,7 @@ namespace Shouldly
             {
                 throw new ShouldAssertException(ex.Message, ex);
             }
-            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(originalExpected, originalActual, customMessage, shouldlyMethod).ToString());
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(originalExpected, originalActual, customMessage, shouldlyMethod));
         }
 
         internal static void AssertAwesomelyWithCaseSensitivity<T>(
@@ -55,7 +55,7 @@ namespace Shouldly
             }
 
             var message = new ExpectedActualWithCaseSensitivityShouldlyMessage(originalExpected, originalActual, caseSensitivity, customMessage, shouldlyMethod);
-            throw new ShouldAssertException(message.ToString());
+            throw new ShouldAssertException(message);
         }
 
         internal static void AssertAwesomelyIgnoringOrder<T>(
@@ -76,7 +76,7 @@ namespace Shouldly
                 throw new ShouldAssertException(ex.Message, ex);
             }
 
-            throw new ShouldAssertException(new ExpectedActualIgnoreOrderShouldlyMessage(originalExpected, originalActual, customMessage, shouldlyMethod).ToString());
+            throw new ShouldAssertException(new ExpectedActualIgnoreOrderShouldlyMessage(originalExpected, originalActual, customMessage, shouldlyMethod));
         }
 
         internal static void AssertAwesomely<T>(
@@ -97,7 +97,7 @@ namespace Shouldly
                 throw new ShouldAssertException(ex.Message, ex);
             }
 
-            throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(originalExpected, originalActual, tolerance, customMessage, shouldlyMethod).ToString());
+            throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(originalExpected, originalActual, tolerance, customMessage, shouldlyMethod));
         }
 
         internal static void AssertAwesomely<T>(
@@ -118,7 +118,7 @@ namespace Shouldly
                 throw new ShouldAssertException(ex.Message, ex);
             }
 
-            throw new ShouldAssertException(new ExpectedActualWithCaseSensitivityShouldlyMessage(originalExpected, originalActual, caseSensitivity, customMessage, shouldlyMethod).ToString());
+            throw new ShouldAssertException(new ExpectedActualWithCaseSensitivityShouldlyMessage(originalExpected, originalActual, caseSensitivity, customMessage, shouldlyMethod));
         }
     }
 }

--- a/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
+++ b/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
@@ -30,7 +30,7 @@ namespace Shouldly
 
                 if (!dynamicAsDictionary.ContainsKey(propertyName))
                 {
-                    throw new ShouldAssertException(new ExpectedShouldlyMessage(propertyName, customMessage).ToString());
+                    throw new ShouldAssertException(new ExpectedShouldlyMessage(propertyName, customMessage));
                 }
             }
             else
@@ -39,7 +39,7 @@ namespace Shouldly
                 var properties = dynamicAsObject.GetType().GetProperties();
                 if (!properties.Select(x => x.Name).Contains(propertyName))
                 {
-                    throw new ShouldAssertException(new ExpectedShouldlyMessage(propertyName, customMessage).ToString());
+                    throw new ShouldAssertException(new ExpectedShouldlyMessage(propertyName, customMessage));
                 }
             }
         }

--- a/src/Shouldly/ShouldStaticClasses/ShouldCompleteInExtensions.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldCompleteInExtensions.cs
@@ -124,7 +124,7 @@ namespace Shouldly
                 // When exception is a timeout exception we can provide a better error, otherwise rethrow
                 if (exception != null)
                 {
-                    var message = new CompleteInShouldlyMessage(what, timeout, customMessage).ToString();
+                    var message = new CompleteInShouldlyMessage(what, timeout, customMessage);
                     throw new ShouldCompleteInException(message, exception);
                 }
 

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrow.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrow.cs
@@ -35,10 +35,10 @@ namespace Shouldly
             }
             catch (Exception e)
             {
-                throw new ShouldAssertException(new ShouldlyThrowMessage(typeof(TException), e.GetType(), customMessage, shouldlyMethod).ToString(), e);
+                throw new ShouldAssertException(new ShouldlyThrowMessage(typeof(TException), e.GetType(), customMessage, shouldlyMethod), e);
             }
 
-            throw new ShouldAssertException(new ShouldlyThrowMessage(typeof(TException), customMessage, shouldlyMethod).ToString());
+            throw new ShouldAssertException(new ShouldlyThrowMessage(typeof(TException), customMessage, shouldlyMethod));
         }
 
         /*** Should.Throw(Action) ***/
@@ -68,10 +68,10 @@ namespace Shouldly
                     return e;
                 }
 
-                throw new ShouldAssertException(new ShouldlyThrowMessage(exceptionType, e.GetType(), customMessage, shouldlyMethod).ToString(), e);
+                throw new ShouldAssertException(new ShouldlyThrowMessage(exceptionType, e.GetType(), customMessage, shouldlyMethod), e);
             }
 
-            throw new ShouldAssertException(new ShouldlyThrowMessage(exceptionType, customMessage, shouldlyMethod).ToString());
+            throw new ShouldAssertException(new ShouldlyThrowMessage(exceptionType, customMessage, shouldlyMethod));
         }
 
         /*** Should.NotThrow(Action) ***/
@@ -96,7 +96,7 @@ namespace Shouldly
             }
             catch (Exception ex)
             {
-                throw new ShouldAssertException(new ShouldlyThrowMessage(ex.GetType(), ex.Message, customMessage, shouldlyMethod).ToString());
+                throw new ShouldAssertException(new ShouldlyThrowMessage(ex.GetType(), ex.Message, customMessage, shouldlyMethod));
             }
         }
 
@@ -126,7 +126,7 @@ namespace Shouldly
             }
             catch (Exception ex)
             {
-                throw new ShouldAssertException(new ShouldlyThrowMessage(ex.GetType(), ex.Message, customMessage, shouldlyMethod).ToString());
+                throw new ShouldAssertException(new ShouldlyThrowMessage(ex.GetType(), ex.Message, customMessage, shouldlyMethod));
             }
         }
     }

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
@@ -127,10 +127,10 @@ namespace Shouldly
                 if (e is TException)
                     return (TException)e;
 
-                throw new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), e.GetType(), customMessage, shouldlyMethod).ToString());
+                throw new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), e.GetType(), customMessage, shouldlyMethod));
             }
 
-            throw new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), customMessage, shouldlyMethod).ToString());
+            throw new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), customMessage, shouldlyMethod));
         }
 
         /*** Should.Throw(Func<Task>, TimeSpan) ***/
@@ -172,10 +172,10 @@ namespace Shouldly
                     return e;
                 }
 
-                throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, e.GetType(), customMessage, shouldlyMethod).ToString());
+                throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, e.GetType(), customMessage, shouldlyMethod));
             }
 
-            throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, customMessage, shouldlyMethod).ToString());
+            throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, customMessage, shouldlyMethod));
         }
 
         /*** Should.NotThrow(Task) ***/
@@ -262,11 +262,11 @@ namespace Shouldly
             }
             catch (AggregateException ex)
             {
-                throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.InnerException.GetType(), ex.InnerException.Message, customMessage, shouldlyMethod).ToString());
+                throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.InnerException.GetType(), ex.InnerException.Message, customMessage, shouldlyMethod));
             }
             catch (Exception ex)
             {
-                throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.GetType(), ex.Message, customMessage, shouldlyMethod).ToString());
+                throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.GetType(), ex.Message, customMessage, shouldlyMethod));
             }
         }
 
@@ -333,11 +333,11 @@ namespace Shouldly
             }
             catch (AggregateException ex)
             {
-                throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.InnerException.GetType(), ex.InnerException.Message, customMessage, shouldlyMethod).ToString());
+                throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.InnerException.GetType(), ex.InnerException.Message, customMessage, shouldlyMethod));
             }
             catch (Exception ex)
             {
-                throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.GetType(), ex.Message, customMessage, shouldlyMethod).ToString());
+                throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.GetType(), ex.Message, customMessage, shouldlyMethod));
             }
         }
 
@@ -361,7 +361,7 @@ namespace Shouldly
             if (innerException is TException)
                 return (TException)innerException;
 
-            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(typeof(TException), innerException.GetType(), customMessage).ToString());
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(typeof(TException), innerException.GetType(), customMessage));
         }
 
         private static Exception HandleAggregateException(AggregateException e, [InstantHandle] Func<string> customMessage, Type exceptionType)
@@ -370,7 +370,7 @@ namespace Shouldly
             if (innerException.GetType() == exceptionType)
                 return innerException;
 
-            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(exceptionType, innerException.GetType(), customMessage).ToString());
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(exceptionType, innerException.GetType(), customMessage));
         }
     }
 }

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
@@ -53,16 +53,16 @@ namespace Shouldly
                 if (t.IsFaulted)
                 {
                     if (t.Exception == null)
-                        throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), customMessage, stackTrace).ToString());
+                        throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), customMessage, stackTrace));
 
                     return HandleAggregateException<TException>(t.Exception, customMessage);
                 }
 
                 if (t.IsCanceled)
-                    throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), customMessage, stackTrace).ToString()
+                    throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), customMessage, stackTrace)
                         , new TaskCanceledException("Task is cancelled"));
 
-                throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), customMessage, stackTrace).ToString());
+                throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), customMessage, stackTrace));
             });
 #else
             return actual().ContinueWith(t =>
@@ -70,16 +70,16 @@ namespace Shouldly
                 if (t.IsFaulted)
                 {
                     if (t.Exception == null)
-                        throw new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), customMessage).ToString());
+                        throw new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), customMessage));
 
                     return HandleAggregateException<TException>(t.Exception, customMessage);
                 }
 
                 if (t.IsCanceled)
-                    throw new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), customMessage).ToString()
+                    throw new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), customMessage)
                         , new TaskCanceledException("Task is cancelled"));
 
-                throw new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), customMessage).ToString());
+                throw new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), customMessage));
             });
 #endif
         }
@@ -102,16 +102,16 @@ namespace Shouldly
                 if (t.IsFaulted)
                 {
                     if (t.Exception == null)
-                        throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(exceptionType, customMessage, stackTrace).ToString());
+                        throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(exceptionType, customMessage, stackTrace));
 
                     return HandleAggregateException(t.Exception, customMessage, exceptionType);
                 }
 
                 if (t.IsCanceled)
-                    throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(exceptionType, customMessage, stackTrace).ToString()
+                    throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(exceptionType, customMessage, stackTrace)
                         , new TaskCanceledException("Task is cancelled"));
 
-                throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(exceptionType, customMessage, stackTrace).ToString());
+                throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(exceptionType, customMessage, stackTrace));
             });
 #else
             return actual().ContinueWith(t =>
@@ -119,16 +119,16 @@ namespace Shouldly
                 if (t.IsFaulted)
                 {
                     if (t.Exception == null)
-                        throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, customMessage).ToString());
+                        throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, customMessage));
 
                     return HandleAggregateException(t.Exception, customMessage, exceptionType);
                 }
 
                 if (t.IsCanceled)
-                    throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, customMessage).ToString()
+                    throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, customMessage)
                         , new TaskCanceledException("Task is cancelled"));
 
-                throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, customMessage).ToString());
+                throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, customMessage));
             });
 #endif
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
@@ -28,6 +28,20 @@ namespace Shouldly
                 actual.AssertAwesomely(v => Is.Equal(v, expected), actual, expected, customMessage);
         }
 
+        public static void ShouldBe<T>(this T actual, T expected, [NotNull] IEqualityComparer<T> comparer)
+        {
+            ShouldBe(actual, expected, comparer, () => null);
+        }
+        public static void ShouldBe<T>(this T actual, T expected, [NotNull] IEqualityComparer<T> comparer, string customMessage)
+        {
+            ShouldBe(actual, expected, comparer, () => customMessage);
+        }
+        public static void ShouldBe<T>(this T actual, T expected, [NotNull] IEqualityComparer<T> comparer, [InstantHandle] Func<string> customMessage)
+        {
+            comparer.ShouldNotBeNull();
+            actual.AssertAwesomely(v => Is.Equal(v, expected, comparer), actual, expected, customMessage);
+        }
+
         [ContractAnnotation("actual:null,expected:null => halt")]
         public static void ShouldNotBe<T>(this T actual, T expected)
         {
@@ -42,6 +56,20 @@ namespace Shouldly
         public static void ShouldNotBe<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage)
         {
             actual.AssertAwesomely(v => !Is.Equal(v, expected), actual, expected, customMessage);
+        }
+
+        public static void ShouldNotBe<T>(this T actual, T expected, [NotNull] IEqualityComparer<T> comparer)
+        {
+            ShouldNotBe(actual, expected, comparer, () => null);
+        }
+        public static void ShouldNotBe<T>(this T actual, T expected, [NotNull] IEqualityComparer<T> comparer, string customMessage)
+        {
+            ShouldNotBe(actual, expected, comparer, () => customMessage);
+        }
+        public static void ShouldNotBe<T>(this T actual, T expected, [NotNull] IEqualityComparer<T> comparer, [InstantHandle] Func<string> customMessage)
+        {
+            comparer.ShouldNotBeNull();
+            actual.AssertAwesomely(v => !Is.Equal(v, expected, comparer), actual, expected, customMessage);
         }
 
         public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool ignoreOrder = false)
@@ -68,6 +96,26 @@ namespace Shouldly
                 {
                     actual.AssertAwesomely(v => Is.Equal(v, expected), actual, expected, customMessage);
                 }
+            }
+        }
+
+        public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, [NotNull] IEqualityComparer<T> comparer, bool ignoreOrder = false)
+        { 
+            ShouldBe(actual, expected, comparer, ignoreOrder, () => null);
+        }
+        public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, [NotNull] IEqualityComparer<T> comparer, bool ignoreOrder, string customMessage)
+        { 
+            ShouldBe(actual, expected, comparer, ignoreOrder, () => customMessage);
+        }
+        public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, [NotNull] IEqualityComparer<T> comparer, bool ignoreOrder, [InstantHandle] Func<string> customMessage)
+        { 
+            if (ignoreOrder)
+            {
+                actual.AssertAwesomelyIgnoringOrder(v => Is.EqualIgnoreOrder(v, expected, comparer), actual, expected, customMessage);
+            }
+            else
+            {
+                actual.AssertAwesomely(v => Is.Equal(v, expected, comparer), actual, expected, customMessage);
             }
         }
 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringNullOrEmptyTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringNullOrEmptyTestExtensions.cs
@@ -21,7 +21,7 @@ namespace Shouldly
         public static void ShouldBeNullOrEmpty(this string actual, [InstantHandle] Func<string> customMessage)
         {
             if (!string.IsNullOrEmpty(actual))
-                throw new ShouldAssertException(new ActualShouldlyMessage(actual, customMessage).ToString());
+                throw new ShouldAssertException(new ActualShouldlyMessage(actual, customMessage));
         }
 
         [ContractAnnotation("actual:null => halt")]
@@ -40,7 +40,7 @@ namespace Shouldly
         public static void ShouldNotBeNullOrEmpty(this string actual, [InstantHandle] Func<string> customMessage)
         {
             if (string.IsNullOrEmpty(actual))
-                throw new ShouldAssertException(new ActualShouldlyMessage(actual, customMessage).ToString());
+                throw new ShouldAssertException(new ActualShouldlyMessage(actual, customMessage));
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringNullOrWhitespaceTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringNullOrWhitespaceTestExtensions.cs
@@ -21,7 +21,7 @@ namespace Shouldly
         public static void ShouldBeNullOrWhiteSpace(this string actual, [InstantHandle] Func<string> customMessage)
         {
             if (!actual.IsNullOrWhiteSpace())
-                throw new ShouldAssertException(new ActualShouldlyMessage(actual, customMessage).ToString());
+                throw new ShouldAssertException(new ActualShouldlyMessage(actual, customMessage));
         }
 
         [ContractAnnotation("actual:null => halt")]
@@ -45,7 +45,7 @@ namespace Shouldly
 #else
             if (string.IsNullOrWhiteSpace(actual))
 #endif
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage));
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeBooleanExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeBooleanExtensions.cs
@@ -24,6 +24,23 @@ namespace Shouldly
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(true, actual, customMessage).ToString());
         }
 
+        public static void ShouldBeTrue(this bool? actual)
+        {
+            ShouldBeTrue(actual, () => null);
+        }
+
+        public static void ShouldBeTrue(this bool? actual, string customMessage)
+        {
+            ShouldBeTrue(actual, () => customMessage);
+        }
+
+        public static void ShouldBeTrue(this bool? actual, [InstantHandle]Func<string> customMessage)
+        {
+            if (!actual.HasValue || !actual.GetValueOrDefault()) {
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(true, actual, customMessage).ToString());
+            }
+        }
+
         public static void ShouldBeFalse(this bool actual)
         {
             ShouldBeFalse(actual, () => null);
@@ -38,6 +55,23 @@ namespace Shouldly
         {
             if (actual)
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(false, actual, customMessage).ToString());
+        }
+
+        public static void ShouldBeFalse(this bool? actual)
+        {
+            ShouldBeFalse(actual, () => null);
+        }
+
+        public static void ShouldBeFalse(this bool? actual, string customMessage)
+        {
+            ShouldBeFalse(actual, () => customMessage);
+        }
+
+        public static void ShouldBeFalse(this bool? actual, [InstantHandle]Func<string> customMessage)
+        {
+            if (!actual.HasValue || actual.GetValueOrDefault()) {
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(false, actual, customMessage).ToString());
+            }
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeBooleanExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeBooleanExtensions.cs
@@ -21,7 +21,7 @@ namespace Shouldly
         public static void ShouldBeTrue(this bool actual, [InstantHandle]Func<string> customMessage)
         {
             if (!actual)
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(true, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(true, actual, customMessage));
         }
 
         public static void ShouldBeTrue(this bool? actual)
@@ -37,7 +37,7 @@ namespace Shouldly
         public static void ShouldBeTrue(this bool? actual, [InstantHandle]Func<string> customMessage)
         {
             if (!actual.HasValue || !actual.GetValueOrDefault()) {
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(true, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(true, actual, customMessage));
             }
         }
 
@@ -54,7 +54,7 @@ namespace Shouldly
         public static void ShouldBeFalse(this bool actual, [InstantHandle]Func<string> customMessage)
         {
             if (actual)
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(false, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(false, actual, customMessage));
         }
 
         public static void ShouldBeFalse(this bool? actual)
@@ -70,7 +70,7 @@ namespace Shouldly
         public static void ShouldBeFalse(this bool? actual, [InstantHandle]Func<string> customMessage)
         {
             if (!actual.HasValue || actual.GetValueOrDefault()) {
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(false, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(false, actual, customMessage));
             }
         }
     }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
@@ -22,7 +22,7 @@ namespace Shouldly
         public static void ShouldContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, [InstantHandle] Func<string> customMessage)
         {
             if (!dictionary.ContainsKey(key))
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage));
         }
 
         public static void ShouldNotContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
@@ -38,7 +38,7 @@ namespace Shouldly
         public static void ShouldNotContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, [InstantHandle] Func<string> customMessage)
         {
             if (dictionary.ContainsKey(key))
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage));
         }
 
         public static void ShouldContainKeyAndValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val) 
@@ -54,7 +54,7 @@ namespace Shouldly
         public static void ShouldContainKeyAndValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, [InstantHandle] Func<string> customMessage)
         {
             if (!dictionary.ContainsKey(key) || !Equals(dictionary[key], val))
-                throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage));
         }
 
         public static void ShouldNotContainValueForKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val)
@@ -70,7 +70,7 @@ namespace Shouldly
         public static void ShouldNotContainValueForKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, [InstantHandle] Func<string> customMessage)
         {
             if (!dictionary.ContainsKey(key) || Equals(dictionary[key], val))
-                throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage));
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumExtensions.cs
@@ -18,7 +18,7 @@ namespace Shouldly.ShouldlyExtensionMethods
             CheckEnumHasFlagAttribute(actual);
             if (!actual.HasFlag(expectedFlag))
             {
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expectedFlag, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expectedFlag, actual, customMessage));
             }
         }
 
@@ -34,7 +34,7 @@ namespace Shouldly.ShouldlyExtensionMethods
             CheckEnumHasFlagAttribute(actual);
             if (actual.HasFlag(expectedFlag))
             {
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expectedFlag, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expectedFlag, actual, customMessage));
             }
         }
 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -59,7 +59,7 @@ namespace Shouldly
         public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, [InstantHandle] Func<string> customMessage)
         {
             if (actual.Contains(expected))
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage));
         }
 
         public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, [NotNull] IEqualityComparer<T> comparer)
@@ -102,7 +102,7 @@ namespace Shouldly
             var actualCount = actual.Count(condition);
             if (actualCount != expectedCount)
             {
-                throw new ShouldAssertException(new ShouldContainWithCountShouldlyMessage(elementPredicate.Body, actual, expectedCount, customMessage).ToString());
+                throw new ShouldAssertException(new ShouldContainWithCountShouldlyMessage(elementPredicate.Body, actual, expectedCount, customMessage));
             }
         }
 
@@ -115,7 +115,7 @@ namespace Shouldly
         {
             var condition = elementPredicate.Compile();
             if (!actual.Any(condition))
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(elementPredicate.Body, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(elementPredicate.Body, actual, customMessage));
         }
 
         public static void ShouldNotContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate)
@@ -132,7 +132,7 @@ namespace Shouldly
         {
             var condition = elementPredicate.Compile();
             if (actual.Any(condition))
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(elementPredicate.Body, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(elementPredicate.Body, actual, customMessage));
         }
 
         public static void ShouldAllBe<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate)
@@ -150,7 +150,7 @@ namespace Shouldly
             var condition = elementPredicate.Compile();
             var actualResults = actual.Where(part => !condition(part));
             if (actualResults.Any())
-                throw new ShouldAssertException(new ActualFilteredWithPredicateShouldlyMessage(elementPredicate.Body, actualResults, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ActualFilteredWithPredicateShouldlyMessage(elementPredicate.Body, actualResults, actual, customMessage));
         }
 
         public static void ShouldBeEmpty<T>(this IEnumerable<T> actual)
@@ -166,7 +166,7 @@ namespace Shouldly
         public static void ShouldBeEmpty<T>(this IEnumerable<T> actual, [InstantHandle] Func<string> customMessage)
         {
             if (actual == null || actual.Any())
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage));
         }
 
         public static void ShouldNotBeEmpty<T>(this IEnumerable<T> actual)
@@ -182,7 +182,7 @@ namespace Shouldly
         public static void ShouldNotBeEmpty<T>(this IEnumerable<T> actual, [InstantHandle] Func<string> customMessage)
         {
             if (actual == null || !actual.Any())
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage));
         }
 
         public static T ShouldHaveSingleItem<T>(this IEnumerable<T> actual)
@@ -198,7 +198,7 @@ namespace Shouldly
         public static T ShouldHaveSingleItem<T>(this IEnumerable<T> actual, [InstantHandle] Func<string> customMessage)
         {
             if (actual == null || actual.Count() != 1)
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage));
 
             return actual.Single();
         }
@@ -216,7 +216,7 @@ namespace Shouldly
         public static void ShouldContain(this IEnumerable<float> actual, float expected, double tolerance, [InstantHandle] Func<string> customMessage)
         {
             if (!actual.Any(a => Math.Abs(expected - a) < tolerance))
-                throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance, customMessage));
         }
 
         public static void ShouldContain(this IEnumerable<double> actual, double expected, double tolerance)
@@ -232,7 +232,7 @@ namespace Shouldly
         public static void ShouldContain(this IEnumerable<double> actual, double expected, double tolerance, [InstantHandle] Func<string> customMessage)
         {
             if (!actual.Any(a => Math.Abs(expected - a) < tolerance))
-                throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance, customMessage));
         }
 
         public static void ShouldBeSubsetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected)
@@ -252,7 +252,7 @@ namespace Shouldly
 
             var missing = actual.Except(expected);
             if (missing.Any())
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage));
         }
 
         public static void ShouldBeUnique<T>(this IEnumerable<T> actual)
@@ -269,7 +269,7 @@ namespace Shouldly
         {
             var duplicates = GetDuplicates(actual);
             if (duplicates.Any())
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(actual, duplicates, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(actual, duplicates, customMessage));
         }
 
         public static void ShouldBe(this IEnumerable<string> actual, IEnumerable<string> expected, Case caseSensitivity)
@@ -370,7 +370,7 @@ namespace Shouldly
                     && isOutOfOrder(previousItem, currentItem))
                 {
                     throw new ShouldAssertException(
-                        new ExpectedOrderShouldlyMessage(actual, expectedSortDirection, currentIndex, currentItem, customMessage).ToString());
+                        new ExpectedOrderShouldlyMessage(actual, expectedSortDirection, currentIndex, currentItem, customMessage));
                 }
 
                 previousItem = currentItem;

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -24,7 +24,26 @@ namespace Shouldly
         public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, [InstantHandle] Func<string> customMessage)
         {
             if (!actual.Contains(expected))
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage));
+        }
+
+        public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, [NotNull] IEqualityComparer<T> comparer)
+        {
+            ShouldContain(actual, expected, comparer, () => null);
+        }
+
+        public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, [NotNull] IEqualityComparer<T> comparer, string customMessage)
+        {
+            ShouldContain(actual, expected, comparer, () => customMessage);
+        }
+
+        public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, [NotNull] IEqualityComparer<T> comparer, [InstantHandle] Func<string> customMessage)
+        {
+            comparer.ShouldNotBeNull();
+            if (!actual.Contains(expected, comparer))
+            {
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage));
+            }
         }
 
         public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected)
@@ -41,6 +60,25 @@ namespace Shouldly
         {
             if (actual.Contains(expected))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
+        }
+
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, [NotNull] IEqualityComparer<T> comparer)
+        {
+            ShouldNotContain(actual, expected, comparer, () => null);
+        }
+
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, [NotNull] IEqualityComparer<T> comparer, string customMessage)
+        {
+            ShouldNotContain(actual, expected, comparer, () => customMessage);
+        }
+
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, [NotNull] IEqualityComparer<T> comparer, [InstantHandle] Func<string> customMessage)
+        {
+            comparer.ShouldNotBeNull();
+            if (actual.Contains(expected, comparer))
+            {
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage));
+            }
         }
 
         public static void ShouldContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate)

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeNullExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeNullExtensions.cs
@@ -24,7 +24,7 @@ namespace Shouldly
         public static void ShouldBeNull<T>(this T actual, [InstantHandle]Func<string> customMessage)
         {
             if (actual != null)
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage));
         }
 
         [ContractAnnotation("actual:null => halt")]
@@ -43,7 +43,7 @@ namespace Shouldly
         public static void ShouldNotBeNull<T>(this T actual, [InstantHandle]Func<string> customMessage)
         {
             if (actual == null)
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage));
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeRangeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeRangeTestExtensions.cs
@@ -17,7 +17,7 @@ namespace Shouldly
         public static void ShouldBeOneOf<T>(this T actual, T[] expected, [InstantHandle] Func<string> customMessage)
         {
             if (!expected.Contains(actual))
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage));
         }
 
         public static void ShouldNotBeOneOf<T>(this T actual, params T[] expected)
@@ -31,7 +31,7 @@ namespace Shouldly
         public static void ShouldNotBeOneOf<T>(this T actual, T[] expected, [InstantHandle] Func<string> customMessage)
         {
             if (expected.Contains(actual))
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage));
         }
 
         public static void ShouldBeInRange<T>(this T actual, T from, T to) where T : IComparable<T>

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAllConditionsTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAllConditionsTestExtensions.cs
@@ -35,7 +35,7 @@ namespace Shouldly
             if (errorMessages.Any())
             {
                 var errorMessageString = BuildErrorMessageString(errorMessages);
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(errorMessageString, actual, customMessage).ToString());
+                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(errorMessageString, actual, customMessage));
             }
         }
 

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -332,5 +332,10 @@ $@"{codePart}
             }
             return message;
         }
+
+        public static implicit operator string(ShouldlyMessage message)
+        {
+            return message.ToString();
+        }
     }
 }


### PR DESCRIPTION
Sorry for putting all this in one PR. They are all each separate commits.

- Adding  support for ShouldBe(bool?)
- Implicitly casting ShouldlyMessage to string, no more .ToString(), and cleanup call sites
- Consistent ordering in ShouldlyConventions.ShouldHaveCustomMessageOverloads
- Adding IEqualityComparer<T> support for ShouldBe, ShouldNotBe, ShouldContain, ShouldNotContain
