### PR TITLE
Fix broken .netcoreapp2.0 tests locally

### DIFF
--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -9,6 +9,9 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <DebugType>full</DebugType>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <DebugType>portable</DebugType>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="**\*.approved.cs;**\*.received.cs" />
   </ItemGroup>


### PR DESCRIPTION
.netcore2.0 pdbs on Windows do not include filename or line number.

This is fixed and will be released in 2.1. However, for the time being
if we switch to using portable pdbs, these then work (just like they do
on linux/mac).

Once we switch the target up to 2.1, this change can be removed.