### PR TITLE
Fixed Test.csproj Now will work on linux

### DIFF
--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netcoreapp2.0;net452</TargetFrameworks>
     <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFramework>
     <AssemblyName>Shouldly.Tests</AssemblyName>
     <PackageId>Shouldly.Tests</PackageId>


### PR DESCRIPTION
I tried to run the tests on my linux environment but they didnt work so i noticed that it is trying to target 452 which is not present on linux so i simply put a condition there to help it not interefere. 
Note: 
I was using dotnet core 2.1.101
and and was on ubuntu 16.04