### PR TITLE
add generic overloads for ShouldSatisfyAllConditions #472

### DIFF
--- a/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditionsGeneric.codeSample.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditionsGeneric.codeSample.approved.txt
@@ -1,0 +1,6 @@
+var mrBurns = new Person() { Name = null };
+mrBurns.ShouldSatisfyAllConditions
+                    (
+                        p => p.Name.ShouldNotBeNullOrEmpty(),
+                        p => p.Name.ShouldBe("Mr.Burns")
+                    );

--- a/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditionsGeneric.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditionsGeneric.exceptionText.approved.txt
@@ -1,0 +1,23 @@
+mrBurns
+    should satisfy all the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    p => p.Name (null)
+        should not be null or empty
+
+--------------- Error 2 ---------------
+    p => p.Name
+        should be
+    "Mr.Burns"
+        but was
+    null
+        difference
+    Difference     |  |    |    |    |    |    |    |    |   
+                   | \|/  \|/  \|/  \|/  \|/  \|/  \|/  \|/  
+    Index          | 0    1    2    3    4    5    6    7    
+    Expected Value | M    r    .    B    u    r    n    s    
+    Actual Value   | n    u    l    l                        
+    Expected Code  | 77   114  46   66   117  114  110  115  
+    Actual Code    | 110  117  108  108                      
+
+-----------------------------------------

--- a/src/DocumentationExamples/ShouldSatisfyAllConditionsExamples.cs
+++ b/src/DocumentationExamples/ShouldSatisfyAllConditionsExamples.cs
@@ -29,5 +29,19 @@ namespace DocumentationExamples
                     );
             }, _testOutputHelper);
         }
+
+        [Fact]
+        public void ShouldSatisfyAllConditionsGeneric()
+        {
+            DocExampleWriter.Document(() =>
+            {
+                var mrBurns = new Person() { Name = null };
+                mrBurns.ShouldSatisfyAllConditions
+                    (
+                        p => p.Name.ShouldNotBeNullOrEmpty(),
+                        p => p.Name.ShouldBe("Mr.Burns")
+                    );
+            }, _testOutputHelper);
+        }
     }
 }

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
@@ -506,6 +506,9 @@ namespace Shouldly
     [Shouldly.ShouldlyMethodsAttribute()]
     public class static ShouldSatisfyAllConditionsTestExtensions
     {
+        public static void ShouldSatisfyAllConditions<T>(this T actual, params System.Action<>[] conditions) { }
+        public static void ShouldSatisfyAllConditions<T>(this T actual, string customMessage, params System.Action<>[] conditions) { }
+        public static void ShouldSatisfyAllConditions<T>(this T actual, System.Func<string> customMessage, params System.Action<>[] conditions) { }
         public static void ShouldSatisfyAllConditions(this object actual, params System.Action[] conditions) { }
         public static void ShouldSatisfyAllConditions(this object actual, string customMessage, params System.Action[] conditions) { }
         public static void ShouldSatisfyAllConditions(this object actual, System.Func<string> customMessage, params System.Action[] conditions) { }

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario.cs
@@ -1,0 +1,90 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldSatisfyAllConditions
+{
+    public class GenericMultipleConditionsScenario
+    {
+
+        [Fact]
+        public void GenericMultipleConditionsScenarioShouldFail()
+        {
+            int result = 4;
+            Verify.ShouldFail(() =>
+result.ShouldSatisfyAllConditions
+    (
+        "Some additional context",
+        r => r.ShouldBeOfType<float>("Some additional context"),
+        r => r.ShouldBeGreaterThan(5, "Some additional context")
+    ),
+
+errorWithSource:
+@"result
+    should satisfy all the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    r => r
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    r => r
+        should be greater than
+    5
+        but was
+    4
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"4
+    should satisfy all the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    4
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    4
+        should be greater than
+    5
+        but was not
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            int result = 4;
+            result.ShouldSatisfyAllConditions
+                    (
+                        r => result.ShouldBeOfType<int>(),
+                        r => result.ShouldBeGreaterThan(3)
+                    );
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine.cs
@@ -1,0 +1,86 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldSatisfyAllConditions
+{
+    public class GenericMultipleConditionsScenario_MultiLine
+    {
+
+        [Fact]
+        public void GenericMultipleConditionsScenario_MultiLineShouldFail()
+        {
+            int result = 4;
+            Verify.ShouldFail(() =>
+result.ShouldSatisfyAllConditions
+(
+    r => r.ShouldBeOfType<float>("Some additional context"),
+    r => r.ShouldBeGreaterThan(5, "Some additional context")
+),
+
+errorWithSource:
+@"result
+    should satisfy all the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    r => r
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    r => r
+        should be greater than
+    5
+        but was
+    4
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------",
+
+errorWithoutSource:
+@"4
+    should satisfy all the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    4
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    4
+        should be greater than
+    5
+        but was not
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            int result = 4;
+            result.ShouldSatisfyAllConditions
+                    (
+                        r
+                            => r.ShouldBeOfType<int>(),
+                        r
+                            =>
+                            r.ShouldBeGreaterThan(3)
+                    );
+        }
+    }
+}

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine2.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine2.cs
@@ -1,0 +1,88 @@
+﻿using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldSatisfyAllConditions
+{
+    public class GenericMultipleConditionsScenario_MultiLine2
+  {
+
+        [Fact]
+        public void GenericMultipleConditionsScenario_MultiLine2ShouldFail()
+        {
+            int result = 4;
+            Verify.ShouldFail(() =>
+result.ShouldSatisfyAllConditions
+(
+    r => r.ShouldBeOfType<float>("Some additional context"),
+    r => r.ShouldBeGreaterThan(5, "Some additional context")
+),
+
+errorWithSource:
+@"result
+    should satisfy all the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    r => r
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    r => r
+        should be greater than
+    5
+        but was
+    4
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------",
+
+errorWithoutSource:
+@"4
+    should satisfy all the conditions specified, but does not.
+The following errors were found ...
+--------------- Error 1 ---------------
+    4
+        should be of type
+    System.Single
+        but was
+    System.Int32
+
+    Additional Info:
+        Some additional context
+
+--------------- Error 2 ---------------
+    4
+        should be greater than
+    5
+        but was not
+
+    Additional Info:
+        Some additional context
+
+-----------------------------------------");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            int result = 4;
+            result.ShouldSatisfyAllConditions
+                    (
+                        r
+                            => r
+                                .ShouldBeOfType<int>(),
+                        r
+                            =>
+                            r
+                            .ShouldBeGreaterThan(3)
+                    );
+        }
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAllConditionsTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAllConditionsTestExtensions.cs
@@ -9,6 +9,18 @@ namespace Shouldly
     [ShouldlyMethods]
     public static class ShouldSatisfyAllConditionsTestExtensions
     {
+        public static void ShouldSatisfyAllConditions<T>(this T actual, [InstantHandle] params Action<T>[] conditions)
+        {
+          ShouldSatisfyAllConditions(actual, () => null, CreateParameterlessActions(actual, conditions));
+        }
+        public static void ShouldSatisfyAllConditions<T>(this T actual, string customMessage, [InstantHandle] params Action<T>[] conditions)
+        {
+          ShouldSatisfyAllConditions(actual, () => customMessage, CreateParameterlessActions(actual, conditions));
+        }
+        public static void ShouldSatisfyAllConditions<T>(this T actual, [InstantHandle] Func<string> customMessage, [InstantHandle] params Action<T>[] conditions)
+        {
+          ShouldSatisfyAllConditions(actual, customMessage, CreateParameterlessActions(actual, conditions));
+        }
         public static void ShouldSatisfyAllConditions(this object actual, [InstantHandle] params Action[] conditions)
         {
             ShouldSatisfyAllConditions(actual, () => null, conditions);
@@ -37,6 +49,10 @@ namespace Shouldly
                 var errorMessageString = BuildErrorMessageString(errorMessages);
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(errorMessageString, actual, customMessage).ToString());
             }
+        }
+
+        static Action[] CreateParameterlessActions<T>(T parameter, params Action<T>[] actions) {
+          return actions.Select(a => new Action(() => a(parameter))).ToArray();
         }
 
         static string BuildErrorMessageString(IEnumerable<Exception> errorMessages)


### PR DESCRIPTION
add three new generic overloads to give actions passed to ShouldSatisfyAllConditions some context as suggested in #472

added: 
```
public static void ShouldSatisfyAllConditions<T>(this T actual, [InstantHandle] params Action<T>[] conditions)
public static void ShouldSatisfyAllConditions<T>(this T actual, string customMessage, [InstantHandle] params Action<T>[] conditions)
public static void ShouldSatisfyAllConditions<T>(this T actual, [InstantHandle] Func<string> customMessage, [InstantHandle] params Action<T>[] conditions)
```