### PR TITLE
Add WinMerge to known diff tools

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
@@ -684,6 +684,7 @@ namespace Shouldly.Configuration
         public readonly Shouldly.Configuration.DiffTool KDiff3;
         public readonly Shouldly.Configuration.DiffTool P4Merge;
         public readonly Shouldly.Configuration.DiffTool TortoiseGitMerge;
+        public readonly Shouldly.Configuration.DiffTool WinMerge;
         public KnownDiffTools() { }
         public static Shouldly.Configuration.KnownDiffTools Instance { get; }
     }

--- a/src/Shouldly/Configuration/KnownDiffTools.cs
+++ b/src/Shouldly/Configuration/KnownDiffTools.cs
@@ -19,6 +19,8 @@ namespace Shouldly.Configuration
         [UsedImplicitly]
         public readonly DiffTool TortoiseGitMerge = new DiffTool("Tortoise Git Merge", @"TortoiseGit\bin\TortoiseGitMerge.exe", TortoiseGitMergeArgs);
         [UsedImplicitly]
+        public readonly DiffTool WinMerge = new DiffTool("WinMerge", @"WinMerge\WinMergeU.exe", WinMergeArgs);
+        [UsedImplicitly]
         public readonly DiffTool CurrentVisualStudio = new CurrentlyRunningVisualStudioDiffTool();
 
         public static KnownDiffTools Instance { get; } = new KnownDiffTools();
@@ -56,6 +58,14 @@ namespace Shouldly.Configuration
                 File.AppendAllText(approved, string.Empty);
 
             return $"\"{received}\" \"{approved}\"";
+        }
+
+        static string WinMergeArgs(string received, string approved, bool approvedExists)
+        {
+            if (!approvedExists)
+                File.AppendAllText(approved, string.Empty);
+
+            return $"/u /wl \"{received}\" \"{approved}\" \"{approved}\"";
         }
     }
 }


### PR DESCRIPTION
`/u` keeps WinMerge from adding the files to the MRU list
`/wl` makes the left file (received) read-only