### PR TITLE
Add new Do Not Launch Strategy

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicAPI.ShouldlyApi.approved.cs
@@ -654,6 +654,11 @@ namespace Shouldly.Configuration
         public DoNotLaunchWhenEnvVariableIsPresent(string environmentalVariable) { }
         public bool ShouldNotLaunch() { }
     }
+    public class DoNotLaunchWhenTypeIsLoaded : Shouldly.Configuration.IShouldNotLaunchDiffTool
+    {
+        public DoNotLaunchWhenTypeIsLoaded(string typeName) { }
+        public bool ShouldNotLaunch() { }
+    }
     public delegate string FilenameGenerator(Shouldly.Configuration.TestMethodInfo testMethodInfo, string descriminator, string fileType, string fileExtension);
     public class FindMethodUsingAttribute<T> : Shouldly.Configuration.ITestMethodFinder
         where T : System.Attribute
@@ -697,6 +702,7 @@ namespace Shouldly.Configuration
         public readonly Shouldly.Configuration.IShouldNotLaunchDiffTool NCrunch;
         public readonly Shouldly.Configuration.IShouldNotLaunchDiffTool TeamCity;
         public readonly Shouldly.Configuration.IShouldNotLaunchDiffTool TravisCI;
+        public readonly Shouldly.Configuration.IShouldNotLaunchDiffTool VisualStudioLiveUnitTesting;
         public readonly Shouldly.Configuration.IShouldNotLaunchDiffTool VSTS;
         public KnownDoNotLaunchStrategies() { }
     }

--- a/src/Shouldly/Configuration/DoNotLaunchWhenTypeIsLoaded.cs
+++ b/src/Shouldly/Configuration/DoNotLaunchWhenTypeIsLoaded.cs
@@ -1,0 +1,22 @@
+#if ShouldMatchApproved
+using System;
+using System.Linq;
+
+namespace Shouldly.Configuration
+{
+    public class DoNotLaunchWhenTypeIsLoaded : IShouldNotLaunchDiffTool
+    {
+        readonly string _typeName;
+
+        public DoNotLaunchWhenTypeIsLoaded(string typeName)
+        {
+            _typeName = typeName;
+        }
+
+        public bool ShouldNotLaunch()
+        {
+            return AppDomain.CurrentDomain.GetAssemblies().Any(a => a.GetName().Name == _typeName);
+        }
+    }
+}
+#endif

--- a/src/Shouldly/Configuration/KnownDoNotLaunchStrategies.cs
+++ b/src/Shouldly/Configuration/KnownDoNotLaunchStrategies.cs
@@ -8,6 +8,8 @@ namespace Shouldly.Configuration
         [UsedImplicitly]
         public readonly IShouldNotLaunchDiffTool NCrunch = new DoNotLaunchWhenEnvVariableIsPresent("NCRUNCH");
         [UsedImplicitly]
+        public readonly IShouldNotLaunchDiffTool VisualStudioLiveUnitTesting = new DoNotLaunchWhenTypeIsLoaded("Microsoft.CodeAnalysis.LiveUnitTesting.Runtime");
+        [UsedImplicitly]
         public readonly IShouldNotLaunchDiffTool TeamCity = new DoNotLaunchWhenEnvVariableIsPresent("TeamCity");
         [UsedImplicitly]
         public readonly IShouldNotLaunchDiffTool AppVeyor = new DoNotLaunchWhenEnvVariableIsPresent("AppVeyor");


### PR DESCRIPTION
This should stop diff tool launching when using
Visual Studio Live Unit Testing.  This check is based on the FAQ from
https://blogs.msdn.microsoft.com/visualstudio/2017/03/09/live-unit-testing-in-visual-studio-2017-enterprise/