### PR TITLE
[WIP] Use portable pdbs on .NET Framework

### DIFF
--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net472;</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Optimize>false</Optimize>
-    <DebugType Condition=" '$(OS)' == 'Windows_NT' ">full</DebugType>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">2.1.3</RuntimeFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Shouldly/Internals/SourceCodeTextGetter.cs
+++ b/src/Shouldly/Internals/SourceCodeTextGetter.cs
@@ -27,6 +27,14 @@ namespace Shouldly.Internals
         public string FileName { get; private set; }
         public int LineNumber { get; private set; }
 
+        static ActualCodeTextGetter()
+        {
+#if NET46
+            // Needs to be called in the case of running on .NETFramework 4.7.1 and below
+            AppContext.SetSwitch("Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces", false);
+#endif
+        }
+
         public string GetCodeText(object actual, StackTrace stackTrace)
         {
             if (ShouldlyConfiguration.IsSourceDisabledInErrors())

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Shouldly - Assertion framework for .NET. The way asserting *Should* be</Description>
     <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net451;net40;</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net46;net451;net40;</TargetFrameworks>
     <PackageTags>test;unit;testing;TDD;AAA;should;testunit;rspec;assert;assertion;framework</PackageTags>
     <PackageIconUrl>https://raw.githubusercontent.com/shouldly/shouldly/master/assets/logo_128x128.png</PackageIconUrl>
     <PackageProjectUrl>http://shouldly.github.com</PackageProjectUrl>
@@ -35,10 +35,17 @@
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
     <DefineConstants>$(DefineConstants);ShouldMatchApproved;StackTrace;Serializable;CallerMemberNamePolyfill</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">
+    <DefineConstants>$(DefineConstants);ShouldMatchApproved;StackTrace;Serializable</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <DefineConstants>$(DefineConstants);ShouldMatchApproved;StackTrace;Serializable</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">

--- a/src/Shouldly/ShouldlyConfiguration.cs
+++ b/src/Shouldly/ShouldlyConfiguration.cs
@@ -21,8 +21,10 @@ namespace Shouldly
                 "Shouldly.Tests.TestHelpers.Strange"
             };
             
+#if NET46
             // Needs to be called in the case of running on .NETFramework 4.7.1 and below
             AppContext.SetSwitch("Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces", false);
+#endif
         }
 
         public static List<string> CompareAsObjectTypes { get; private set; }

--- a/src/Shouldly/ShouldlyConfiguration.cs
+++ b/src/Shouldly/ShouldlyConfiguration.cs
@@ -20,6 +20,9 @@ namespace Shouldly
                 "Newtonsoft.Json.Linq.JToken",
                 "Shouldly.Tests.TestHelpers.Strange"
             };
+            
+            // Needs to be called in the case of running on .NETFramework 4.7.1 and below
+            AppContext.SetSwitch("Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces", false);
         }
 
         public static List<string> CompareAsObjectTypes { get; private set; }

--- a/src/Shouldly/ShouldlyConfiguration.cs
+++ b/src/Shouldly/ShouldlyConfiguration.cs
@@ -20,11 +20,6 @@ namespace Shouldly
                 "Newtonsoft.Json.Linq.JToken",
                 "Shouldly.Tests.TestHelpers.Strange"
             };
-            
-#if NET46
-            // Needs to be called in the case of running on .NETFramework 4.7.1 and below
-            AppContext.SetSwitch("Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces", false);
-#endif
         }
 
         public static List<string> CompareAsObjectTypes { get; private set; }


### PR DESCRIPTION
I suspect this is why on some version on .NET Framework you have to use full pdbs, given they are dead and problematic, I'm hoping this will remove the need for them.