### PR TITLE
Add listing failures from enumerables

### DIFF
--- a/src/Shouldly.Tests/ShouldNotContain/PredicateClosureScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/PredicateClosureScenario.cs
@@ -8,7 +8,7 @@ namespace Shouldly.Tests.ShouldNotContain
         [Fact]
         public void PredicateClosureScenarioShouldFail()
         {
-            var capturedOuterVar = 4;
+            var capturedOuterVar = 3;
             var arr = new[] { 1, 2, 3 };
             Verify.ShouldFail(() =>
 arr.ShouldNotContain(i => i < capturedOuterVar, "Some additional context"),
@@ -18,6 +18,7 @@ errorWithSource:
     should not contain an element satisfying the condition
 (i < capturedOuterVar)
     but does
+        [[0 => 1], [1 => 2]]
 
 Additional Info:
     Some additional context",
@@ -27,6 +28,7 @@ errorWithoutSource:
     should not contain an element satisfying the condition
 (i < capturedOuterVar)
     but does
+        [[0 => 1], [1 => 2]]
 
 Additional Info:
     Some additional context");

--- a/src/Shouldly.Tests/ShouldNotContain/PredicateObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/PredicateObjectScenario.cs
@@ -10,7 +10,7 @@ namespace Shouldly.Tests.ShouldNotContain
         public void PredicateObjectScenarioShouldFail()
         {
             var a = new object();
-            var b = new object();
+            var b = "string";
             var c = new object();
             Verify.ShouldFail(() =>
 new[] { a, b, c }.ShouldNotContain(o => o.GetType().FullName.Equals("System.Object"),
@@ -21,15 +21,17 @@ errorWithSource:
     should not contain an element satisfying the condition
 o.GetType().FullName.Equals(""System.Object"")
     but does
+        [[0 => System.Object (000000)], [2 => System.Object (000000)]]
 
 Additional Info:
     Some additional context",
 
 errorWithoutSource:
-@"[System.Object (000000), System.Object (000000), System.Object (000000)]
+@"[System.Object (000000), ""string"", System.Object (000000)]
     should not contain an element satisfying the condition
 o.GetType().FullName.Equals(""System.Object"")
     but does
+        [[0 => System.Object (000000)], [2 => System.Object (000000)]]
 
 Additional Info:
     Some additional context");

--- a/src/Shouldly.Tests/ShouldNotContain/PredicateScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/PredicateScenario.cs
@@ -1,4 +1,5 @@
-﻿using Shouldly.Tests.Strings;
+﻿using System.Collections.Generic;
+using Shouldly.Tests.Strings;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldNotContain
@@ -9,13 +10,14 @@ namespace Shouldly.Tests.ShouldNotContain
         public void PredicateScenarioShouldFail()
         {
             Verify.ShouldFail(() =>
-new[] { 1, 2, 3 }.ShouldNotContain(i => i < 4, "Some additional context"),
+new[] { 1, 2, 3 }.ShouldNotContain(i => i < 3, "Some additional context"),
 
 errorWithSource:
 @"new[] { 1, 2, 3 }
     should not contain an element satisfying the condition
-(i < 4)
+(i < 3)
     but does
+        [[0 => 1], [1 => 2]]
 
 Additional Info:
     Some additional context",
@@ -23,11 +25,68 @@ Additional Info:
 errorWithoutSource:
 @"[1, 2, 3]
     should not contain an element satisfying the condition
-(i < 4)
+(i < 3)
     but does
+        [[0 => 1], [1 => 2]]
 
 Additional Info:
     Some additional context");
+        }
+
+        [Fact]
+        public void PredicateScenarioShouldFailWithNamedIEnumerable()
+        {
+            IEnumerable<int> iEnumerable = new List<int> {1, 2, 3, 4, 2};
+            Verify.ShouldFail(() =>
+iEnumerable.ShouldNotContain(i => i == 2, "Some additional context"),
+
+errorWithSource:
+@"iEnumerable
+    should not contain an element satisfying the condition
+(i == 2)
+    but does
+        [[1 => 2], [4 => 2]]
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"[1, 2, 3, 4, 2]
+    should not contain an element satisfying the condition
+(i == 2)
+    but does
+        [[1 => 2], [4 => 2]]
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void PredicateScenarioShouldFailWithNamedIEnumerableAndStringPredicate()
+        {
+            IEnumerable<string> testResults = new List<string> {"pass", "not fail", "an error", "all good", "Error: oops"};
+            Verify.ShouldFail(() =>
+testResults.ShouldNotContain(result => result.ToUpper().Contains("ERROR"), "From a Github issue example"),
+
+errorWithSource:
+@"testResults
+    should not contain an element satisfying the condition
+result.ToUpper().Contains(""ERROR"")
+    but does
+        [[2 => ""an error""], [4 => ""Error: oops""]]
+
+Additional Info:
+    From a Github issue example",
+
+errorWithoutSource:
+            @"[""pass"", ""not fail"", ""an error"", ""all good"", ""Error: oops""]
+    should not contain an element satisfying the condition
+result.ToUpper().Contains(""ERROR"")
+    but does
+        [[2 => ""an error""], [4 => ""Error: oops""]]
+
+Additional Info:
+    From a Github issue example");
         }
 
         [Fact]

--- a/src/Shouldly/Internals/IShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/IShouldlyAssertionContext.cs
@@ -24,6 +24,8 @@ namespace Shouldly
         // is relevant.
         bool HasRelevantActual { get; set; }
         bool HasRelevantKey { get; set; }
+        bool HasListedFailures { get; set; }
+        Dictionary<int, object> ListedFailures { get; set; }
 
         bool IsNegatedAssertion { get; }
         string CustomMessage { get; set; }

--- a/src/Shouldly/Internals/ShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/ShouldlyAssertionContext.cs
@@ -29,6 +29,8 @@ namespace Shouldly
         // is relevant.
         public bool HasRelevantActual { get; set; }
         public bool HasRelevantKey { get; set; }
+        public bool HasListedFailures { get; set; }
+        public Dictionary<int, object> ListedFailures { get; set; } = new Dictionary<int, object>();
 
         public bool IsNegatedAssertion => ShouldMethod.Contains("Not");
         public string CustomMessage { get; set; }

--- a/src/Shouldly/MessageGenerators/ShouldContainPredicateMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldContainPredicateMessageGenerator.cs
@@ -25,14 +25,17 @@ namespace Shouldly.MessageGenerators
 $@"{codePart}
     {context.ShouldMethod.PascalToSpaced()} {elementPhrase} satisfying the condition
 {context.Expected.ToStringAwesomely()}
-    but does{""}";
+    but does{""}{(!context.HasListedFailures ? "" : $@"
+        {context.ListedFailures.ToStringAwesomely()}")}";
             }
 
             return
 $@"{codePart}
     {context.ShouldMethod.PascalToSpaced()} {elementPhrase} satisfying the condition
 {context.Expected.ToStringAwesomely()}
-    but does not";
+    but does not{(!context.HasListedFailures ? "" : $@"
+        {context.ListedFailures.ToStringAwesomely()}")}";
+
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -93,8 +93,24 @@ namespace Shouldly
         public static void ShouldNotContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, [InstantHandle] Func<string> customMessage)
         {
             var condition = elementPredicate.Compile();
-            if (actual.Any(condition))
-                throw new ShouldAssertException(new ExpectedActualShouldlyMessage(elementPredicate.Body, actual, customMessage).ToString());
+
+            var failedElements = new Dictionary<int, object>();
+            int elementIndex = 0;
+            foreach (T element in actual)
+            {
+                if (condition(element))
+                {
+                    failedElements.Add(elementIndex, element);
+                }
+
+                ++elementIndex;
+            }
+
+            if (failedElements.Any())
+            {
+                throw new ShouldAssertException(
+                    new ExpectedActualWithListedFailuresShouldlyMessage(elementPredicate.Body, actual, failedElements, customMessage).ToString());
+            }
         }
 
         public static void ShouldAllBe<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate)

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -41,6 +41,21 @@ namespace Shouldly
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
+
+    internal class ExpectedActualWithListedFailuresShouldlyMessage : ShouldlyMessage
+    {
+        public ExpectedActualWithListedFailuresShouldlyMessage(object expected, object actual, Dictionary<int, object> failures, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        {
+            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
+            {
+                ListedFailures = failures,
+                HasRelevantActual = true,
+                HasListedFailures = true
+            };
+            if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
+        }
+    }
+
     internal class ActualFilteredWithPredicateShouldlyMessage : ShouldlyMessage
     {
         public ActualFilteredWithPredicateShouldlyMessage(Expression filter, object result, object actual, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)


### PR DESCRIPTION
This PR adds the enhancement for issue #482. It lists the failed items with their indexes, like so:
![image](https://user-images.githubusercontent.com/16086384/50860796-71e0fd00-135c-11e9-8fc5-7c81a1001f2b.png)
![image](https://user-images.githubusercontent.com/16086384/50860914-d00de000-135c-11e9-8b4c-c823b371ecc6.png)