### PR TITLE
Fixes #367 - a problem with tests failing on different Windows culture.

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ShouldlyConventions.cs
+++ b/src/Shouldly.Tests/ConventionTests/ShouldlyConventions.cs
@@ -1,4 +1,5 @@
 using System;
+using Shouldly.Tests.TestHelpers;
 using TestStack.ConventionTests;
 using TestStack.ConventionTests.ConventionData;
 using Xunit;
@@ -17,6 +18,7 @@ namespace Shouldly.Tests.ConventionTests
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public void ShouldHaveCustomMessageOverloads()
         {
             Convention.GetFailures(new ShouldlyMethodsShouldHaveCustomMessageOverload(), _shouldlyMethodClasses)

--- a/src/Shouldly.Tests/ShouldBe/ShouldBeScenarios.cs
+++ b/src/Shouldly.Tests/ShouldBe/ShouldBeScenarios.cs
@@ -8,6 +8,7 @@ namespace Shouldly.Tests.ShouldBe
     public class ShouldBeScenarios
     {
         [Fact]
+        [UseCulture("en-US")]
         public void BoolFailure()
         {
             const bool myValue = false;
@@ -35,6 +36,7 @@ Additional Info:
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public void BoxedComparableFailureScenario()
         {
             object a = 0;

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/DecimalScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/DecimalScenario.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBe.WithTolerance
@@ -7,6 +8,7 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
     public class DecimalScenario
     {
         [Fact]
+        [UseCulture("en-US")]
         public void DecimalScenarioShouldFail()
         {
             const decimal pi = (decimal)Math.PI;

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/DoubleScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/DoubleScenario.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBe.WithTolerance
@@ -7,6 +8,7 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
     public class DoubleScenario
     {
         [Fact]
+        [UseCulture("en-US")]
         public void DoubleScenarioShouldFail()
         {
             const double pi = Math.PI;

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfDecimalScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfDecimalScenario.cs
@@ -1,4 +1,5 @@
 ﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBe.WithTolerance
@@ -6,6 +7,7 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
     public class EnumerableOfDecimalScenario
     {
         [Fact]
+        [UseCulture("en-US")]
         public void EnumerableOfDecimalScenarioShouldFail()
         {
             var firstSet = new[] { 1.23m, 2.34m, 3.45001m };

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfDoubleScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfDoubleScenario.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBe.WithTolerance
@@ -8,6 +9,7 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
     {
 
     [Fact]
+    [UseCulture("en-US")]
     public void EnumerableOfDoubleScenarioShouldFail()
     {
         Verify.ShouldFail(() =>

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfFloatScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfFloatScenario.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBe.WithTolerance
@@ -8,6 +9,7 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
     {
 
     [Fact]
+    [UseCulture("en-US")]
     public void EnumerableOfFloatScenarioShouldFail()
     {
         Verify.ShouldFail(() =>

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/FloatScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/FloatScenario.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBe.WithTolerance
@@ -7,6 +8,7 @@ namespace Shouldly.Tests.ShouldBe.WithTolerance
     public class FloatScenario
     {
         [Fact]
+        [UseCulture("en-US")]
         public void FloatScenarioShouldFail()
         {
             const float pi = (float)Math.PI;

--- a/src/Shouldly.Tests/ShouldBeInOrder/DoubleArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/DoubleArrayScenario.cs
@@ -1,15 +1,17 @@
 ﻿using System.Collections.Generic;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBeInOrder
-{
+{ 
     public class DoubleArrayScenario
     {
         private readonly double[] _ascendingTarget = { 1.1, 1.2, 1.3, 1.4, 1.5 };
         private readonly double[] _descendingTarget = { 1.5, 1.4, 1.3, 1.2, 1.1 };
 
         [Fact]
+        [UseCulture("en-US")]
         public void ShouldFailWithDefaultDirection()
         {
             Verify.ShouldFail(() =>
@@ -35,6 +37,7 @@ Additional Info:
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public void ShouldFailWhenAscendingIsSpecified()
         {
             Verify.ShouldFail(() =>
@@ -60,6 +63,7 @@ Additional Info:
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public void ShouldFailWhenDescendingIsSpecified()
         {
             Verify.ShouldFail(() =>
@@ -85,6 +89,7 @@ Additional Info:
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public void ShouldFailWhenDescendingIsSpecifiedAndComparerIsGiven()
         {
             Verify.ShouldFail(() =>

--- a/src/Shouldly.Tests/ShouldBeInRange/DecimalScenaro.cs
+++ b/src/Shouldly.Tests/ShouldBeInRange/DecimalScenaro.cs
@@ -1,4 +1,5 @@
 ﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBeInRange
@@ -7,6 +8,7 @@ namespace Shouldly.Tests.ShouldBeInRange
     {
 
     [Fact]
+    [UseCulture("en-US")]
     public void DecimalScenaroShouldFail()
     {
         var val = 1.5m;
@@ -33,7 +35,7 @@ Additional Info:
     Some additional context");
     }
 
-        [Fact]
+    [Fact]
     public void ShouldPass()
     {
         1.5m.ShouldBeInRange(1.4m, 1.6m);

--- a/src/Shouldly.Tests/ShouldBeNegative/DecimalScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeNegative/DecimalScenario.cs
@@ -1,8 +1,10 @@
 ﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBeNegative
 {
+    [UseCulture("en-US")]
     public class DecimalScenario
     {
         [Fact]

--- a/src/Shouldly.Tests/ShouldBeNegative/DoubleScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeNegative/DoubleScenario.cs
@@ -1,8 +1,10 @@
 ﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBeNegative
 {
+    [UseCulture("en-US")]
     public class DoubleScenario
     {
         [Fact]

--- a/src/Shouldly.Tests/ShouldBePositive/DecimalScenario.cs
+++ b/src/Shouldly.Tests/ShouldBePositive/DecimalScenario.cs
@@ -1,8 +1,10 @@
 ﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBePositive
 {
+    [UseCulture("en-US")]
     public class DecimalScenario
     {
         [Fact]

--- a/src/Shouldly.Tests/ShouldBePositive/DoubleScenario.cs
+++ b/src/Shouldly.Tests/ShouldBePositive/DoubleScenario.cs
@@ -1,4 +1,5 @@
 ﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBePositive
@@ -7,6 +8,7 @@ namespace Shouldly.Tests.ShouldBePositive
     {
 
         [Fact]
+        [UseCulture("en-US")]
         public void DoubleScenarioShouldFail()
         {
             var @double = (-3.5);

--- a/src/Shouldly.Tests/ShouldContain/DoubleWithToleranceScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/DoubleWithToleranceScenario.cs
@@ -1,4 +1,5 @@
 ﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldContain
@@ -7,6 +8,7 @@ namespace Shouldly.Tests.ShouldContain
     {
 
     [Fact]
+    [UseCulture("en-US")]
     public void DoubleWithToleranceScenarioShouldFail()
     {
         Verify.ShouldFail(() =>

--- a/src/Shouldly.Tests/ShouldContain/FloatWithToleranceScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/FloatWithToleranceScenario.cs
@@ -1,4 +1,5 @@
 ﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldContain
@@ -6,6 +7,7 @@ namespace Shouldly.Tests.ShouldContain
     public class FloatWithToleranceScenario
     {
         [Fact]
+        [UseCulture("en-US")]
         public void FloatWithToleranceScenarioShouldFail()
         {
             Verify.ShouldFail(() =>

--- a/src/Shouldly.Tests/ShouldNotBeInRangeTests.cs
+++ b/src/Shouldly.Tests/ShouldNotBeInRangeTests.cs
@@ -1,4 +1,5 @@
 ﻿using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests
@@ -6,6 +7,7 @@ namespace Shouldly.Tests
     public class ShouldNotBeInRangeTests
     {
         [Fact]
+        [UseCulture("en-US")]
         public void ShouldNotBeInRangeTestsShouldFail()
         {
             var @decimal = 1.5m;

--- a/src/Shouldly.Tests/ShouldNotThrow/ActionDelegateScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/ActionDelegateScenario.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldNotThrow
@@ -7,6 +8,7 @@ namespace Shouldly.Tests.ShouldNotThrow
     public class ActionDelegateScenario
     {
         [Fact]
+        [UseCulture("en-US")]
         public void ActionDelegateScenarioShouldFail()
         {
             Verify.ShouldFail(() =>

--- a/src/Shouldly.Tests/ShouldNotThrow/ExtractsCodeScenarios.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/ExtractsCodeScenarios.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldNotThrow
@@ -6,6 +7,7 @@ namespace Shouldly.Tests.ShouldNotThrow
     public class ExtractsCodeScenarios
     {
         [Fact]
+        [UseCulture("en-US")]
         public void ExtractsCodeCorrectly1()
         {
             TestHelpers.Should.Error(() =>
@@ -22,6 +24,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public void ExtractsCodeCorrectly3()
         {
             TestHelpers.Should.Error(() =>
@@ -30,6 +33,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public void ExtractsCodeCorrectly4()
         {
             TestHelpers.Should.Error(
@@ -44,6 +48,7 @@ namespace Shouldly.Tests.ShouldNotThrow
         }
 
         [Fact]
+        [UseCulture("en-US")]
         public void ExtractsCodeCorrectly5()
         {
             TestHelpers.Should.Error(() =>

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncDelegateScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncDelegateScenario.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldNotThrow
@@ -8,6 +9,7 @@ namespace Shouldly.Tests.ShouldNotThrow
     {
 
         [Fact]
+        [UseCulture("en-US")]
         public void FuncDelegateScenarioShouldFail()
         {
             var action = new Func<int>(() => { throw new InvalidOperationException(); });

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfStringScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfStringScenario.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldNotThrow
@@ -10,6 +11,7 @@ namespace Shouldly.Tests.ShouldNotThrow
     {
 
         [Fact]
+        [UseCulture("en-US")]
         public void FuncOfTaskOfStringScenarioShouldFail()
         {
             var task = Task.Factory.StartNew<string>(() => { throw new RankException(); },

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldNotThrow
@@ -10,6 +11,7 @@ namespace Shouldly.Tests.ShouldNotThrow
     {
 
         [Fact]
+        [UseCulture("en-US")]
         public void FuncOfTaskScenarioShouldFail()
         {
             var task = Task.Factory.StartNew(() => { throw new RankException(); },

--- a/src/Shouldly.Tests/ShouldNotThrow/TaskOfTScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/TaskOfTScenario.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldNotThrow
@@ -10,6 +11,7 @@ namespace Shouldly.Tests.ShouldNotThrow
     {
 
         [Fact]
+        [UseCulture("en-US")]
         public void TaskOfTScenarioShouldFail()
         {
             var task = Task.Factory.StartNew<string>(() => { throw new RankException(); },

--- a/src/Shouldly.Tests/ShouldNotThrow/TaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/TaskScenario.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Shouldly.Tests.Strings;
+using Shouldly.Tests.TestHelpers;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldNotThrow
@@ -9,6 +10,7 @@ namespace Shouldly.Tests.ShouldNotThrow
     public class TaskScenario
     {
         [Fact]
+        [UseCulture("en-US")]
         public void TaskScenarioShouldFail()
         {
             var task = Task.Factory.StartNew(() => { throw new RankException(); },

--- a/src/Shouldly.Tests/TestHelpers/UseCultureAttribute.cs
+++ b/src/Shouldly.Tests/TestHelpers/UseCultureAttribute.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using System.Threading;
+using Xunit.Sdk;
+
+namespace Shouldly.Tests.TestHelpers
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class UseCultureAttribute : BeforeAfterTestAttribute
+    {
+        private readonly Lazy<CultureInfo> _culture;
+        private CultureInfo _originalCulture;
+
+        /// <summary>
+        /// Replaces the culture and of the current thread with
+        /// <paramref name="culture" />
+        /// </summary>
+        /// <param name="culture">The name of the culture.</param>
+        /// <remarks>
+        /// <para>
+        /// This constructor overload uses <paramref name="culture" /> for <see cref="Culture" /> .
+        /// </para>
+        /// </remarks>
+        public UseCultureAttribute(string culture)
+        {
+            _culture = new Lazy<CultureInfo>(() => new CultureInfo(culture));
+        }
+
+        /// <summary>
+        /// Gets the culture.
+        /// </summary>
+        public CultureInfo Culture => _culture.Value;
+
+        /// <summary>
+        /// Stores the current <see cref="Thread.CurrentPrincipal" />
+        /// <see cref="CultureInfo.CurrentCulture" /> and <see cref="CultureInfo.CurrentUICulture" />
+        /// and replaces them with the new cultures defined in the constructor.
+        /// </summary>
+        /// <param name="methodUnderTest">The method under test</param>
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            _originalCulture = Thread.CurrentThread.CurrentCulture;
+
+            Thread.CurrentThread.CurrentCulture = Culture;
+        }
+
+        /// <summary>
+        /// Restores the original <see cref="CultureInfo.CurrentCulture" /> and
+        /// </summary>
+        /// <param name="methodUnderTest">The method under test</param>
+        public override void After(MethodInfo methodUnderTest)
+        {
+            Thread.CurrentThread.CurrentCulture = _originalCulture;
+        }
+    }
+}

--- a/src/Shouldly.Tests/TestHelpers/UseCultureAttribute.cs
+++ b/src/Shouldly.Tests/TestHelpers/UseCultureAttribute.cs
@@ -6,31 +6,55 @@ using Xunit.Sdk;
 
 namespace Shouldly.Tests.TestHelpers
 {
+    /// <summary>
+    /// Apply this attribute to your test method to replace the
+    /// <see cref="Thread.CurrentThread" /> <see cref="CultureInfo.CurrentCulture" /> and
+    /// <see cref="CultureInfo.CurrentUICulture" /> with another culture.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
     public class UseCultureAttribute : BeforeAfterTestAttribute
     {
         private readonly Lazy<CultureInfo> _culture;
+        private readonly Lazy<CultureInfo> _uiCulture;
+
         private CultureInfo _originalCulture;
+        private CultureInfo _originalUiCulture;
 
         /// <summary>
-        /// Replaces the culture and of the current thread with
+        /// Replaces the culture and UI culture of the current thread with
         /// <paramref name="culture" />
         /// </summary>
         /// <param name="culture">The name of the culture.</param>
         /// <remarks>
         /// <para>
-        /// This constructor overload uses <paramref name="culture" /> for <see cref="Culture" /> .
+        /// This constructor overload uses <paramref name="culture" /> for both
+        /// <see cref="Culture" /> and <see cref="UiCulture" />.
         /// </para>
         /// </remarks>
         public UseCultureAttribute(string culture)
+            : this(culture, culture) { }
+
+        /// <summary>
+        /// Replaces the culture and UI culture of the current thread with
+        /// <paramref name="culture" /> and <paramref name="uiCulture" />
+        /// </summary>
+        /// <param name="culture">The name of the culture.</param>
+        /// <param name="uiCulture">The name of the UI culture.</param>
+        public UseCultureAttribute(string culture, string uiCulture)
         {
             _culture = new Lazy<CultureInfo>(() => new CultureInfo(culture));
+            _uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture));
         }
 
         /// <summary>
         /// Gets the culture.
         /// </summary>
         public CultureInfo Culture => _culture.Value;
+
+        /// <summary>
+        /// Gets the UI culture.
+        /// </summary>
+        public CultureInfo UiCulture => _uiCulture.Value;
 
         /// <summary>
         /// Stores the current <see cref="Thread.CurrentPrincipal" />
@@ -41,17 +65,21 @@ namespace Shouldly.Tests.TestHelpers
         public override void Before(MethodInfo methodUnderTest)
         {
             _originalCulture = Thread.CurrentThread.CurrentCulture;
+            _originalUiCulture = Thread.CurrentThread.CurrentUICulture;
 
             Thread.CurrentThread.CurrentCulture = Culture;
+            Thread.CurrentThread.CurrentUICulture = UiCulture;
         }
 
         /// <summary>
         /// Restores the original <see cref="CultureInfo.CurrentCulture" /> and
+        /// <see cref="CultureInfo.CurrentUICulture" /> to <see cref="Thread.CurrentPrincipal" />
         /// </summary>
         /// <param name="methodUnderTest">The method under test</param>
         public override void After(MethodInfo methodUnderTest)
         {
             Thread.CurrentThread.CurrentCulture = _originalCulture;
+            Thread.CurrentThread.CurrentUICulture = _originalUiCulture;
         }
     }
 }


### PR DESCRIPTION
Borrowed and slightly modified a sample [solution from xUnit](https://github.com/xunit/samples.xunit/blob/07f0d3f47acc32c1f3e131321abf14e0aaf21eb2/UseCulture/UseCultureAttribute.cs).
Not a perfect solution, but default culture option in test runner is expected to be in xUnit 3.0 as mentioned [here](https://github.com/xunit/xunit/issues/1934). 