### PR TITLE
Nullable reference types

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,16 @@
+<Project>
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AnnotatedReferenceAssemblyVersion>3.0.0</AnnotatedReferenceAssemblyVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.97" PrivateAssets="all" />
+    <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[$(AnnotatedReferenceAssemblyVersion)]" />
+  </ItemGroup>
+
+</Project>

--- a/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.ShouldNotBeNull.codeSample.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.ShouldNotBeNull.codeSample.approved.txt
@@ -1,2 +1,2 @@
-string myRef = null;
+string? myRef = null;
 myRef.ShouldNotBeNull();

--- a/src/DocumentationExamples/CodeExamples/ShouldNotThrowExamples.ShouldNotThrowFunc.codeSample.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldNotThrowExamples.ShouldNotThrowFunc.codeSample.approved.txt
@@ -1,2 +1,2 @@
-string name = null;
-Should.NotThrow(() => new Person(name));
+string? name = null;
+Should.NotThrow(() => new Person(name!));

--- a/src/DocumentationExamples/CodeExamples/ShouldNotThrowExamples.ShouldNotThrowFunc.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldNotThrowExamples.ShouldNotThrowFunc.exceptionText.approved.txt
@@ -1,4 +1,4 @@
-`new Person(name)`
+`new Person(name!)`
     should not throw but threw
 System.ArgumentNullException
     with message

--- a/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditions.codeSample.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditions.codeSample.approved.txt
@@ -1,4 +1,4 @@
-var mrBurns = new Person() { Name = null };
+var mrBurns = new Person() { Name = null! };
 mrBurns.ShouldSatisfyAllConditions
                     (
                         () => mrBurns.Name.ShouldNotBeNullOrEmpty(),

--- a/src/DocumentationExamples/DocExampleWriter.cs
+++ b/src/DocumentationExamples/DocExampleWriter.cs
@@ -21,12 +21,12 @@ namespace DocumentationExamples
             new ConcurrentDictionary<string, List<MethodDeclarationSyntax>>();
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void Document(Action shouldMethod, ITestOutputHelper testOutputHelper, Action<ShouldMatchConfigurationBuilder> additionConfig = null)
+        public static void Document(Action shouldMethod, ITestOutputHelper testOutputHelper, Action<ShouldMatchConfigurationBuilder>? additionConfig = null)
         {
             var stackTrace = new StackTrace(true);
-            var caller = stackTrace.GetFrame(1);
-            var callerFileName = caller.GetFileName();
-            var callerMethod = caller.GetMethod();
+            var caller = stackTrace.GetFrame(1)!;
+            var callerFileName = caller.GetFileName()!;
+            var callerMethod = caller.GetMethod()!;
 
             var testMethod = FileMethodsLookup.GetOrAdd(callerFileName, fn =>
             {

--- a/src/DocumentationExamples/DocumentationExamples.csproj
+++ b/src/DocumentationExamples/DocumentationExamples.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="PublicApiGenerator" Version="10.0.0-beta3" />
+    <PackageReference Include="PublicApiGenerator" Version="10.0.0" />
     <PackageReference Include="TestStack.ConventionTests" Version="3.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.9.0" />
   </ItemGroup>

--- a/src/DocumentationExamples/DocumentationExamples.csproj
+++ b/src/DocumentationExamples/DocumentationExamples.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="PublicApiGenerator" Version="8.1.0" />
+    <PackageReference Include="PublicApiGenerator" Version="10.0.0-beta3" />
     <PackageReference Include="TestStack.ConventionTests" Version="3.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.9.0" />
   </ItemGroup>

--- a/src/DocumentationExamples/ExampleClasses.cs
+++ b/src/DocumentationExamples/ExampleClasses.cs
@@ -4,9 +4,9 @@ namespace Simpsons
 {
     public abstract class Pet
     {
-        public abstract string Name { get; set; }
+        public abstract string? Name { get; set; }
 
-        public override string ToString()
+        public override string? ToString()
         {
             return Name;
         }
@@ -14,12 +14,12 @@ namespace Simpsons
 
     public class Cat : Pet
     {
-        public override string Name { get; set; }
+        public override string? Name { get; set; }
     }
 
     public class Dog : Pet
     {
-        public override string Name { get; set; }
+        public override string? Name { get; set; }
     }
 
     public class Person
@@ -33,11 +33,11 @@ namespace Simpsons
             Name = name ?? throw new ArgumentNullException(nameof(name));
         }
 
-        public string Name { get; set; }
+        public string? Name { get; set; }
         public int Salary { get; set; }
 
 
-        public override string ToString()
+        public override string? ToString()
         {
             return Name;
         }

--- a/src/DocumentationExamples/ShouldBeNullNotNullExamples.cs
+++ b/src/DocumentationExamples/ShouldBeNullNotNullExamples.cs
@@ -28,7 +28,7 @@ namespace DocumentationExamples
         {
             DocExampleWriter.Document(() =>
             {
-                string myRef = null;
+                string? myRef = null;
                 myRef.ShouldNotBeNull();
             }, _testOutputHelper);
         }

--- a/src/DocumentationExamples/ShouldNotThrowExamples.cs
+++ b/src/DocumentationExamples/ShouldNotThrowExamples.cs
@@ -34,8 +34,8 @@ namespace DocumentationExamples
         {
             DocExampleWriter.Document(() =>
             {
-                string name = null;
-                Should.NotThrow(() => new Person(name));
+                string? name = null;
+                Should.NotThrow(() => new Person(name!));
             }, _testOutputHelper);
         }
 

--- a/src/DocumentationExamples/ShouldSatisfyAllConditionsExamples.cs
+++ b/src/DocumentationExamples/ShouldSatisfyAllConditionsExamples.cs
@@ -21,7 +21,7 @@ namespace DocumentationExamples
         {
             DocExampleWriter.Document(() =>
             {
-                var mrBurns = new Person() { Name = null };
+                var mrBurns = new Person() { Name = null! };
                 mrBurns.ShouldSatisfyAllConditions
                     (
                         () => mrBurns.Name.ShouldNotBeNullOrEmpty(),

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -9,139 +9,139 @@ namespace Shouldly
     public static class DynamicShould
     {
         public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName) { }
-        public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName, string? customMessage) { }
         public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName, System.Func<string?>? customMessage) { }
+        public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName, string? customMessage) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ObjectGraphTestExtensions
     {
         public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected) { }
-        public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, string? customMessage) { }
         public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, System.Func<string?>? customMessage) { }
+        public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, string? customMessage) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class Should
     {
         public static void CompleteIn(System.Action action, System.TimeSpan timeout) { }
-        public static void CompleteIn(System.Action action, System.TimeSpan timeout, string? customMessage) { }
-        public static void CompleteIn(System.Action action, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
-        public static T CompleteIn<T>(System.Func<T> function, System.TimeSpan timeout) { }
-        public static T CompleteIn<T>(System.Func<T> function, System.TimeSpan timeout, string? customMessage) { }
-        public static T CompleteIn<T>(System.Func<T> function, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
         public static void CompleteIn(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeout) { }
-        public static void CompleteIn(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeout, string? customMessage) { }
-        public static void CompleteIn(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
-        public static T CompleteIn<T>(System.Func<System.Threading.Tasks.Task<T>> actual, System.TimeSpan timeout) { }
-        public static T CompleteIn<T>(System.Func<System.Threading.Tasks.Task<T>> actual, System.TimeSpan timeout, string? customMessage) { }
-        public static T CompleteIn<T>(System.Func<System.Threading.Tasks.Task<T>> actual, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
         public static void CompleteIn(System.Threading.Tasks.Task actual, System.TimeSpan timeout) { }
-        public static void CompleteIn(System.Threading.Tasks.Task actual, System.TimeSpan timeout, string? customMessage) { }
+        public static void CompleteIn(System.Action action, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
+        public static void CompleteIn(System.Action action, System.TimeSpan timeout, string? customMessage) { }
+        public static void CompleteIn(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
+        public static void CompleteIn(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeout, string? customMessage) { }
         public static void CompleteIn(System.Threading.Tasks.Task actual, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
+        public static void CompleteIn(System.Threading.Tasks.Task actual, System.TimeSpan timeout, string? customMessage) { }
+        public static T CompleteIn<T>(System.Func<System.Threading.Tasks.Task<T>> actual, System.TimeSpan timeout) { }
+        public static T CompleteIn<T>(System.Func<T> function, System.TimeSpan timeout) { }
         public static T CompleteIn<T>(System.Threading.Tasks.Task<T> actual, System.TimeSpan timeout) { }
-        public static T CompleteIn<T>(System.Threading.Tasks.Task<T> actual, System.TimeSpan timeout, string? customMessage) { }
+        public static T CompleteIn<T>(System.Func<System.Threading.Tasks.Task<T>> actual, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
+        public static T CompleteIn<T>(System.Func<System.Threading.Tasks.Task<T>> actual, System.TimeSpan timeout, string? customMessage) { }
+        public static T CompleteIn<T>(System.Func<T> function, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
+        public static T CompleteIn<T>(System.Func<T> function, System.TimeSpan timeout, string? customMessage) { }
         public static T CompleteIn<T>(System.Threading.Tasks.Task<T> actual, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
+        public static T CompleteIn<T>(System.Threading.Tasks.Task<T> actual, System.TimeSpan timeout, string? customMessage) { }
         public static void NotThrow(System.Action action) { }
-        public static void NotThrow(System.Action action, string? customMessage) { }
-        public static void NotThrow(System.Action action, System.Func<string?>? customMessage) { }
-        public static T NotThrow<T>(System.Func<T> action) { }
-        public static T NotThrow<T>(System.Func<T> action, string? customMessage) { }
-        public static T NotThrow<T>(System.Func<T> action, System.Func<string?>? customMessage) { }
-        public static void NotThrow(System.Threading.Tasks.Task action) { }
-        public static void NotThrow(System.Threading.Tasks.Task action, string? customMessage) { }
-        public static void NotThrow(System.Threading.Tasks.Task action, System.Func<string?>? customMessage) { }
-        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action) { }
-        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, string? customMessage) { }
-        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.Func<string?>? customMessage) { }
         public static void NotThrow(System.Func<System.Threading.Tasks.Task> action) { }
-        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, string? customMessage) { }
+        public static void NotThrow(System.Threading.Tasks.Task action) { }
+        public static void NotThrow(System.Action action, System.Func<string?>? customMessage) { }
+        public static void NotThrow(System.Action action, string? customMessage) { }
         public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.Func<string?>? customMessage) { }
-        public static void NotThrow(System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter) { }
-        public static void NotThrow(System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, string? customMessage) { }
-        public static void NotThrow(System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter) { }
-        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, string? customMessage) { }
+        public static void NotThrow(System.Threading.Tasks.Task action, System.Func<string?>? customMessage) { }
+        public static void NotThrow(System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter) { }
+        public static void NotThrow(System.Threading.Tasks.Task action, string? customMessage) { }
         public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
+        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static void NotThrow(System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
+        public static void NotThrow(System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, string? customMessage) { }
         public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action) { }
-        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, string? customMessage) { }
+        public static T NotThrow<T>(System.Func<T> action) { }
+        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action) { }
         public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.Func<string?>? customMessage) { }
-        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter) { }
-        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, string? customMessage) { }
-        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter) { }
-        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, string? customMessage) { }
+        public static T NotThrow<T>(System.Func<T> action, System.Func<string?>? customMessage) { }
+        public static T NotThrow<T>(System.Func<T> action, string? customMessage) { }
+        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.Func<string?>? customMessage) { }
+        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter) { }
+        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, string? customMessage) { }
         public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
+        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
+        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static System.Exception Throw(System.Action actual, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<object?> actual, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Action actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Action actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<object?> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<object?> actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Threading.Tasks.Task actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
         public static TException Throw<TException>(System.Action actual)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Action actual, string? customMessage)
+        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual)
+            where TException : System.Exception { }
+        public static TException Throw<TException>(System.Func<object?> actual)
+            where TException : System.Exception { }
+        public static TException Throw<TException>(System.Threading.Tasks.Task actual)
             where TException : System.Exception { }
         public static TException Throw<TException>(System.Action actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
-        public static System.Exception Throw(System.Action actual, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Action actual, string? customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Action actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
-        public static TException Throw<TException>(System.Func<object?> actual)
-            where TException : System.Exception { }
-        public static TException Throw<TException>(System.Func<object?> actual, string? customMessage)
-            where TException : System.Exception { }
-        public static TException Throw<TException>(System.Func<object?> actual, System.Func<string?>? customMessage)
-            where TException : System.Exception { }
-        public static System.Exception Throw(System.Func<object?> actual, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<object?> actual, string? customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<object?> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
-        public static TException Throw<TException>(System.Threading.Tasks.Task actual)
-            where TException : System.Exception { }
-        public static TException Throw<TException>(System.Threading.Tasks.Task actual, string? customMessage)
-            where TException : System.Exception { }
-        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.Func<string?>? customMessage)
-            where TException : System.Exception { }
-        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Threading.Tasks.Task actual, string? customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
-        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual)
-            where TException : System.Exception { }
-        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
+        public static TException Throw<TException>(System.Action actual, string? customMessage)
             where TException : System.Exception { }
         public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
-        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
-        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter)
-            where TException : System.Exception { }
-        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage)
-            where TException : System.Exception { }
-        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage)
-            where TException : System.Exception { }
-        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage)
+        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
+            where TException : System.Exception { }
+        public static TException Throw<TException>(System.Func<object?> actual, System.Func<string?>? customMessage)
+            where TException : System.Exception { }
+        public static TException Throw<TException>(System.Func<object?> actual, string? customMessage)
+            where TException : System.Exception { }
+        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.Func<string?>? customMessage)
+            where TException : System.Exception { }
+        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter)
+            where TException : System.Exception { }
+        public static TException Throw<TException>(System.Threading.Tasks.Task actual, string? customMessage)
             where TException : System.Exception { }
         public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage)
             where TException : System.Exception { }
-        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Threading.Tasks.Task task)
+        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Threading.Tasks.Task task, string? customMessage)
+        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Threading.Tasks.Task task, System.Func<string?>? customMessage)
+        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage)
             where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Threading.Tasks.Task task, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Threading.Tasks.Task task, string? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Threading.Tasks.Task task, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Threading.Tasks.Task task, string? customMessage, System.Type exceptionType) { }
         public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Func<System.Threading.Tasks.Task> actual)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
+        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Threading.Tasks.Task task)
             where TException : System.Exception { }
         public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
+            where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Threading.Tasks.Task task, System.Func<string?>? customMessage)
+            where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Threading.Tasks.Task task, string? customMessage)
+            where TException : System.Exception { }
     }
     public class ShouldAssertException : System.Exception
     {
@@ -153,332 +153,332 @@ namespace Shouldly
     public static class ShouldBeBooleanExtensions
     {
         public static void ShouldBeFalse([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(true)] this bool actual) { }
-        public static void ShouldBeFalse([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(true)] this bool actual, string? customMessage) { }
         public static void ShouldBeFalse([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(true)] this bool actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeFalse([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(true)] this bool actual, string? customMessage) { }
         public static void ShouldBeTrue([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] this bool actual) { }
-        public static void ShouldBeTrue([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] this bool actual, string? customMessage) { }
         public static void ShouldBeTrue([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] this bool actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeTrue([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] this bool actual, string? customMessage) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeDictionaryTestExtensions
     {
         public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key)
             where TKey :  notnull { }
-        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage)
-            where TKey :  notnull { }
         public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, System.Func<string?>? customMessage)
+            where TKey :  notnull { }
+        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage)
             where TKey :  notnull { }
         public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val)
             where TKey :  notnull { }
-        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage)
-            where TKey :  notnull { }
         public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, System.Func<string?>? customMessage)
+            where TKey :  notnull { }
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage)
             where TKey :  notnull { }
         public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key)
             where TKey :  notnull { }
-        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage)
-            where TKey :  notnull { }
         public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, System.Func<string?>? customMessage)
+            where TKey :  notnull { }
+        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage)
             where TKey :  notnull { }
         public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val)
             where TKey :  notnull { }
-        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage)
-            where TKey :  notnull { }
         public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, System.Func<string?>? customMessage)
+            where TKey :  notnull { }
+        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage)
             where TKey :  notnull { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeEnumerableTestExtensions
     {
         public static void ShouldAllBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate) { }
-        public static void ShouldAllBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string? customMessage) { }
         public static void ShouldAllBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string?>? customMessage) { }
+        public static void ShouldAllBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string? customMessage) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<string> actual, System.Collections.Generic.IEnumerable<string> expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<string> actual, System.Collections.Generic.IEnumerable<string> expected, Shouldly.Case caseSensitivity, string? customMessage) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<string> actual, System.Collections.Generic.IEnumerable<string> expected, Shouldly.Case caseSensitivity, System.Func<string?>? customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<string> actual, System.Collections.Generic.IEnumerable<string> expected, Shouldly.Case caseSensitivity, string? customMessage) { }
         public static void ShouldBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual) { }
-        public static void ShouldBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage) { }
         public static void ShouldBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage) { }
         public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, string? customMessage) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, string? customMessage) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Func<string?>? customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, string? customMessage) { }
         public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T>? customComparer) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T>? customComparer, string? customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Func<string?>? customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, string? customMessage) { }
         public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T>? customComparer, System.Func<string?>? customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T>? customComparer, string? customMessage) { }
         public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected) { }
-        public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, string? customMessage) { }
         public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, System.Func<string?>? customMessage) { }
+        public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, string? customMessage) { }
         public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual) { }
-        public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual, string? customMessage) { }
         public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Func<string?>? customMessage) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string? customMessage) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Func<string?>? customMessage) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount, string? customMessage) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount, System.Func<string?>? customMessage) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string? customMessage) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string?>? customMessage) { }
-        public static void ShouldContain(this System.Collections.Generic.IEnumerable<float> actual, float expected, double tolerance) { }
-        public static void ShouldContain(this System.Collections.Generic.IEnumerable<float> actual, float expected, double tolerance, string? customMessage) { }
-        public static void ShouldContain(this System.Collections.Generic.IEnumerable<float> actual, float expected, double tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual, string? customMessage) { }
         public static void ShouldContain(this System.Collections.Generic.IEnumerable<double> actual, double expected, double tolerance) { }
-        public static void ShouldContain(this System.Collections.Generic.IEnumerable<double> actual, double expected, double tolerance, string? customMessage) { }
+        public static void ShouldContain(this System.Collections.Generic.IEnumerable<float> actual, float expected, double tolerance) { }
         public static void ShouldContain(this System.Collections.Generic.IEnumerable<double> actual, double expected, double tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldContain(this System.Collections.Generic.IEnumerable<double> actual, double expected, double tolerance, string? customMessage) { }
+        public static void ShouldContain(this System.Collections.Generic.IEnumerable<float> actual, float expected, double tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldContain(this System.Collections.Generic.IEnumerable<float> actual, float expected, double tolerance, string? customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string?>? customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string? customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Func<string?>? customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string? customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount, System.Func<string?>? customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount, string? customMessage) { }
         public static T ShouldHaveSingleItem<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual) { }
-        public static T ShouldHaveSingleItem<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage) { }
         public static T ShouldHaveSingleItem<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, System.Func<string?>? customMessage) { }
+        public static T ShouldHaveSingleItem<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage) { }
         public static void ShouldNotBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual) { }
-        public static void ShouldNotBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage) { }
         public static void ShouldNotBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, System.Func<string?>? customMessage) { }
-        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected) { }
-        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string? customMessage) { }
-        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate) { }
-        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string? customMessage) { }
+        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string?>? customMessage) { }
+        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string? customMessage) { }
+        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string? customMessage) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeNullExtensions
     {
         public static void ShouldBeNull<T>([System.Diagnostics.CodeAnalysis.MaybeNull] this T actual) { }
-        public static void ShouldBeNull<T>([System.Diagnostics.CodeAnalysis.MaybeNull] this T actual, string? customMessage) { }
         public static void ShouldBeNull<T>([System.Diagnostics.CodeAnalysis.MaybeNull] this T actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeNull<T>([System.Diagnostics.CodeAnalysis.MaybeNull] this T actual, string? customMessage) { }
         public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T actual) { }
-        public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T actual, string? customMessage) { }
         public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T actual, string? customMessage) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeStringTestExtensions
     {
         public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected) { }
-        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, string customMessage) { }
-        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, System.Func<string?> customMessage) { }
         public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, Shouldly.StringCompareShould options) { }
-        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, string customMessage, Shouldly.StringCompareShould option) { }
+        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, System.Func<string?> customMessage) { }
+        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, string customMessage) { }
         public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, System.Func<string?> customMessage, Shouldly.StringCompareShould options) { }
+        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, string customMessage, Shouldly.StringCompareShould option) { }
         public static void ShouldBeNullOrEmpty(this string? actual) { }
-        public static void ShouldBeNullOrEmpty(this string? actual, string? customMessage) { }
         public static void ShouldBeNullOrEmpty(this string? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeNullOrEmpty(this string? actual, string? customMessage) { }
         public static void ShouldBeNullOrWhiteSpace(this string? actual) { }
-        public static void ShouldBeNullOrWhiteSpace(this string? actual, string? customMessage) { }
         public static void ShouldBeNullOrWhiteSpace(this string? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeNullOrWhiteSpace(this string? actual, string? customMessage) { }
         public static void ShouldContain(this string actual, string expected) { }
         public static void ShouldContain(this string actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldContain(this string actual, string expected, string? customMessage) { }
-        public static void ShouldContain(this string actual, string expected, string? customMessage, Shouldly.Case caseSensitivity) { }
         public static void ShouldContain(this string actual, string expected, System.Func<string?>? customMessage) { }
+        public static void ShouldContain(this string actual, string expected, string? customMessage) { }
         public static void ShouldContain(this string actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity) { }
+        public static void ShouldContain(this string actual, string expected, string? customMessage, Shouldly.Case caseSensitivity) { }
         public static void ShouldContainWithoutWhitespace(this string actual, object? expected) { }
-        public static void ShouldContainWithoutWhitespace(this string actual, object? expected, string? customMessage) { }
         public static void ShouldContainWithoutWhitespace(this string actual, object? expected, System.Func<string?>? customMessage) { }
+        public static void ShouldContainWithoutWhitespace(this string actual, object? expected, string? customMessage) { }
         public static void ShouldEndWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected) { }
         public static void ShouldEndWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldEndWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
         public static void ShouldEndWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldEndWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
         public static void ShouldMatch(this string actual, string regexPattern) { }
-        public static void ShouldMatch(this string actual, string regexPattern, string? customMessage) { }
         public static void ShouldMatch(this string actual, string regexPattern, System.Func<string?>? customMessage) { }
+        public static void ShouldMatch(this string actual, string regexPattern, string? customMessage) { }
         public static void ShouldNotBeNullOrEmpty([System.Diagnostics.CodeAnalysis.NotNull] this string? actual) { }
-        public static void ShouldNotBeNullOrEmpty([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string? customMessage) { }
         public static void ShouldNotBeNullOrEmpty([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeNullOrEmpty([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string? customMessage) { }
         public static void ShouldNotBeNullOrWhiteSpace([System.Diagnostics.CodeAnalysis.NotNull] this string? actual) { }
-        public static void ShouldNotBeNullOrWhiteSpace([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string? customMessage) { }
         public static void ShouldNotBeNullOrWhiteSpace([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeNullOrWhiteSpace([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string? customMessage) { }
         public static void ShouldNotContain(this string actual, string expected) { }
         public static void ShouldNotContain(this string actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldNotContain(this string actual, string expected, string? customMessage) { }
-        public static void ShouldNotContain(this string actual, string expected, string? customMessage, Shouldly.Case caseSensitivity) { }
         public static void ShouldNotContain(this string actual, string expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotContain(this string actual, string expected, string? customMessage) { }
         public static void ShouldNotContain(this string actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity) { }
+        public static void ShouldNotContain(this string actual, string expected, string? customMessage, Shouldly.Case caseSensitivity) { }
         public static void ShouldNotEndWith(this string? actual, string expected) { }
         public static void ShouldNotEndWith(this string? actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldNotEndWith(this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
         public static void ShouldNotEndWith(this string? actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldNotEndWith(this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
         public static void ShouldNotMatch(this string actual, string regexPattern) { }
-        public static void ShouldNotMatch(this string actual, string regexPattern, string? customMessage) { }
         public static void ShouldNotMatch(this string actual, string regexPattern, System.Func<string?>? customMessage) { }
+        public static void ShouldNotMatch(this string actual, string regexPattern, string? customMessage) { }
         public static void ShouldNotStartWith(this string? actual, string expected) { }
         public static void ShouldNotStartWith(this string? actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldNotStartWith(this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
         public static void ShouldNotStartWith(this string? actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldNotStartWith(this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
         public static void ShouldStartWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected) { }
         public static void ShouldStartWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldStartWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
         public static void ShouldStartWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldStartWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeTestExtensions
     {
-        public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance) { }
-        public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, string? customMessage) { }
-        public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
-        public static void ShouldBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance) { }
-        public static void ShouldBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, string? customMessage) { }
-        public static void ShouldBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
-        public static void ShouldBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance) { }
-        public static void ShouldBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, string? customMessage) { }
-        public static void ShouldBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
-        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] T expected) { }
-        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] T expected, string? customMessage) { }
-        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] T expected, System.Func<string?>? customMessage) { }
-        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this System.Collections.Generic.IEnumerable<T>? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] System.Collections.Generic.IEnumerable<T>? expected, bool ignoreOrder = False) { }
-        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this System.Collections.Generic.IEnumerable<T>? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] System.Collections.Generic.IEnumerable<T>? expected, bool ignoreOrder, string? customMessage) { }
-        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this System.Collections.Generic.IEnumerable<T>? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] System.Collections.Generic.IEnumerable<T>? expected, bool ignoreOrder, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance, string? customMessage) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance, System.Func<string?>? customMessage) { }
-        public static void ShouldBe(this float actual, float expected, double tolerance) { }
-        public static void ShouldBe(this float actual, float expected, double tolerance, string? customMessage) { }
-        public static void ShouldBe(this float actual, float expected, double tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<double> actual, System.Collections.Generic.IEnumerable<double> expected, double tolerance) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<double> actual, System.Collections.Generic.IEnumerable<double> expected, double tolerance, string? customMessage) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<double> actual, System.Collections.Generic.IEnumerable<double> expected, double tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<float> actual, System.Collections.Generic.IEnumerable<float> expected, double tolerance) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<float> actual, System.Collections.Generic.IEnumerable<float> expected, double tolerance, string? customMessage) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<float> actual, System.Collections.Generic.IEnumerable<float> expected, double tolerance, System.Func<string?>? customMessage) { }
-        public static void ShouldBe(this double actual, double expected, double tolerance) { }
-        public static void ShouldBe(this double actual, double expected, double tolerance, string? customMessage) { }
-        public static void ShouldBe(this double actual, double expected, double tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance) { }
+        public static void ShouldBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance) { }
+        public static void ShouldBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance) { }
         public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance) { }
-        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, string? customMessage) { }
+        public static void ShouldBe(this double actual, double expected, double tolerance) { }
+        public static void ShouldBe(this float actual, float expected, double tolerance) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance, string? customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<double> actual, System.Collections.Generic.IEnumerable<double> expected, double tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<double> actual, System.Collections.Generic.IEnumerable<double> expected, double tolerance, string? customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<float> actual, System.Collections.Generic.IEnumerable<float> expected, double tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<float> actual, System.Collections.Generic.IEnumerable<float> expected, double tolerance, string? customMessage) { }
+        public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, string? customMessage) { }
+        public static void ShouldBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, string? customMessage) { }
+        public static void ShouldBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, string? customMessage) { }
         public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, System.Func<string?>? customMessage) { }
-        public static T ShouldBeAssignableTo<T>(this object? actual) { }
-        public static T ShouldBeAssignableTo<T>(this object? actual, string? customMessage) { }
-        public static T ShouldBeAssignableTo<T>(this object? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, string? customMessage) { }
+        public static void ShouldBe(this double actual, double expected, double tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldBe(this double actual, double expected, double tolerance, string? customMessage) { }
+        public static void ShouldBe(this float actual, float expected, double tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldBe(this float actual, float expected, double tolerance, string? customMessage) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] T expected) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this System.Collections.Generic.IEnumerable<T>? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] System.Collections.Generic.IEnumerable<T>? expected, bool ignoreOrder = false) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] T expected, System.Func<string?>? customMessage) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] T expected, string? customMessage) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this System.Collections.Generic.IEnumerable<T>? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] System.Collections.Generic.IEnumerable<T>? expected, bool ignoreOrder, System.Func<string?>? customMessage) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this System.Collections.Generic.IEnumerable<T>? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] System.Collections.Generic.IEnumerable<T>? expected, bool ignoreOrder, string? customMessage) { }
         public static void ShouldBeAssignableTo(this object? actual, System.Type expected) { }
-        public static void ShouldBeAssignableTo(this object? actual, System.Type expected, string? customMessage) { }
         public static void ShouldBeAssignableTo(this object? actual, System.Type expected, System.Func<string?>? customMessage) { }
+        public static void ShouldBeAssignableTo(this object? actual, System.Type expected, string? customMessage) { }
+        public static T ShouldBeAssignableTo<T>(this object? actual) { }
+        public static T ShouldBeAssignableTo<T>(this object? actual, System.Func<string?>? customMessage) { }
+        public static T ShouldBeAssignableTo<T>(this object? actual, string? customMessage) { }
         public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected)
             where T : System.IComparable<T>? { }
         public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer) { }
-        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
-        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string?>? customMessage) { }
-        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage)
-            where T : System.IComparable<T>? { }
         public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage)
             where T : System.IComparable<T>? { }
+        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string?>? customMessage) { }
+        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
         public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer) { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage)
             where T : System.IComparable<T>? { }
         public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage)
             where T : System.IComparable<T>? { }
-        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer) { }
-        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
         public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string?>? customMessage) { }
-        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage)
-            where T : System.IComparable<T>? { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
         public static void ShouldBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to, string? customMessage)
             where T : System.IComparable<T> { }
         public static void ShouldBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to, System.Func<string?>? customMessage)
             where T : System.IComparable<T> { }
+        public static void ShouldBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to, string? customMessage)
+            where T : System.IComparable<T> { }
         public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer) { }
+        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage)
             where T : System.IComparable<T>? { }
         public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage)
             where T : System.IComparable<T>? { }
-        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer) { }
-        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
         public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string?>? customMessage) { }
-        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage)
-            where T : System.IComparable<T>? { }
+        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
         public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer) { }
+        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage)
             where T : System.IComparable<T>? { }
         public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage)
             where T : System.IComparable<T>? { }
-        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer) { }
-        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
         public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string?>? customMessage) { }
-        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage)
-            where T : System.IComparable<T>? { }
+        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
         public static void ShouldBeNegative(this decimal actual) { }
-        public static void ShouldBeNegative(this decimal actual, string? customMessage) { }
-        public static void ShouldBeNegative(this decimal actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeNegative(this double actual) { }
-        public static void ShouldBeNegative(this double actual, string? customMessage) { }
-        public static void ShouldBeNegative(this double actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeNegative(this float actual) { }
-        public static void ShouldBeNegative(this float actual, string? customMessage) { }
-        public static void ShouldBeNegative(this float actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeNegative(this int actual) { }
-        public static void ShouldBeNegative(this int actual, string? customMessage) { }
-        public static void ShouldBeNegative(this int actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeNegative(this long actual) { }
-        public static void ShouldBeNegative(this long actual, string? customMessage) { }
-        public static void ShouldBeNegative(this long actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeNegative(this short actual) { }
-        public static void ShouldBeNegative(this short actual, string? customMessage) { }
+        public static void ShouldBeNegative(this decimal actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeNegative(this decimal actual, string? customMessage) { }
+        public static void ShouldBeNegative(this double actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeNegative(this double actual, string? customMessage) { }
+        public static void ShouldBeNegative(this float actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeNegative(this float actual, string? customMessage) { }
+        public static void ShouldBeNegative(this int actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeNegative(this int actual, string? customMessage) { }
+        public static void ShouldBeNegative(this long actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeNegative(this long actual, string? customMessage) { }
         public static void ShouldBeNegative(this short actual, System.Func<string?>? customMessage) { }
-        public static T ShouldBeOfType<T>([System.Diagnostics.CodeAnalysis.NotNull] this object? actual) { }
-        public static T ShouldBeOfType<T>([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, string? customMessage) { }
-        public static T ShouldBeOfType<T>([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeNegative(this short actual, string? customMessage) { }
         public static void ShouldBeOfType([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, System.Type expected) { }
-        public static void ShouldBeOfType([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, System.Type expected, string? customMessage) { }
         public static void ShouldBeOfType([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, System.Type expected, System.Func<string?>? customMessage) { }
+        public static void ShouldBeOfType([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, System.Type expected, string? customMessage) { }
+        public static T ShouldBeOfType<T>([System.Diagnostics.CodeAnalysis.NotNull] this object? actual) { }
+        public static T ShouldBeOfType<T>([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, System.Func<string?>? customMessage) { }
+        public static T ShouldBeOfType<T>([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, string? customMessage) { }
         public static void ShouldBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, params T[] expected) { }
-        public static void ShouldBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, T[] expected, string? customMessage) { }
         public static void ShouldBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, T[] expected, System.Func<string?>? customMessage) { }
+        public static void ShouldBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, T[] expected, string? customMessage) { }
         public static void ShouldBePositive(this decimal actual) { }
-        public static void ShouldBePositive(this decimal actual, string? customMessage) { }
-        public static void ShouldBePositive(this decimal actual, System.Func<string?>? customMessage) { }
         public static void ShouldBePositive(this double actual) { }
-        public static void ShouldBePositive(this double actual, string? customMessage) { }
-        public static void ShouldBePositive(this double actual, System.Func<string?>? customMessage) { }
         public static void ShouldBePositive(this float actual) { }
-        public static void ShouldBePositive(this float actual, string? customMessage) { }
-        public static void ShouldBePositive(this float actual, System.Func<string?>? customMessage) { }
         public static void ShouldBePositive(this int actual) { }
-        public static void ShouldBePositive(this int actual, string? customMessage) { }
-        public static void ShouldBePositive(this int actual, System.Func<string?>? customMessage) { }
         public static void ShouldBePositive(this long actual) { }
-        public static void ShouldBePositive(this long actual, string? customMessage) { }
-        public static void ShouldBePositive(this long actual, System.Func<string?>? customMessage) { }
         public static void ShouldBePositive(this short actual) { }
-        public static void ShouldBePositive(this short actual, string? customMessage) { }
+        public static void ShouldBePositive(this decimal actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBePositive(this decimal actual, string? customMessage) { }
+        public static void ShouldBePositive(this double actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBePositive(this double actual, string? customMessage) { }
+        public static void ShouldBePositive(this float actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBePositive(this float actual, string? customMessage) { }
+        public static void ShouldBePositive(this int actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBePositive(this int actual, string? customMessage) { }
+        public static void ShouldBePositive(this long actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBePositive(this long actual, string? customMessage) { }
         public static void ShouldBePositive(this short actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBePositive(this short actual, string? customMessage) { }
         public static void ShouldBeSameAs([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected) { }
-        public static void ShouldBeSameAs([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, string? customMessage) { }
         public static void ShouldBeSameAs([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, System.Func<string?>? customMessage) { }
+        public static void ShouldBeSameAs([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, string? customMessage) { }
         public static void ShouldNotBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance) { }
-        public static void ShouldNotBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, string? customMessage) { }
-        public static void ShouldNotBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldNotBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance) { }
-        public static void ShouldNotBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, string? customMessage) { }
-        public static void ShouldNotBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldNotBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance) { }
-        public static void ShouldNotBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, string? customMessage) { }
+        public static void ShouldNotBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, string? customMessage) { }
+        public static void ShouldNotBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, string? customMessage) { }
         public static void ShouldNotBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, string? customMessage) { }
         public static void ShouldNotBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected) { }
-        public static void ShouldNotBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage) { }
         public static void ShouldNotBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage) { }
-        public static void ShouldNotBeAssignableTo<T>(this object? actual) { }
-        public static void ShouldNotBeAssignableTo<T>(this object? actual, string? customMessage) { }
-        public static void ShouldNotBeAssignableTo<T>(this object? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage) { }
         public static void ShouldNotBeAssignableTo(this object? actual, System.Type expected) { }
-        public static void ShouldNotBeAssignableTo(this object? actual, System.Type expected, string? customMessage) { }
         public static void ShouldNotBeAssignableTo(this object? actual, System.Type expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeAssignableTo(this object? actual, System.Type expected, string? customMessage) { }
+        public static void ShouldNotBeAssignableTo<T>(this object? actual) { }
+        public static void ShouldNotBeAssignableTo<T>(this object? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeAssignableTo<T>(this object? actual, string? customMessage) { }
         public static void ShouldNotBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to)
-            where T : System.IComparable<T> { }
-        public static void ShouldNotBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to, string? customMessage)
             where T : System.IComparable<T> { }
         public static void ShouldNotBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to, System.Func<string?>? customMessage)
             where T : System.IComparable<T> { }
-        public static void ShouldNotBeOfType<T>(this object? actual) { }
-        public static void ShouldNotBeOfType<T>(this object? actual, string? customMessage) { }
-        public static void ShouldNotBeOfType<T>(this object? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to, string? customMessage)
+            where T : System.IComparable<T> { }
         public static void ShouldNotBeOfType(this object? actual, System.Type expected) { }
-        public static void ShouldNotBeOfType(this object? actual, System.Type expected, string? customMessage) { }
         public static void ShouldNotBeOfType(this object? actual, System.Type expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeOfType(this object? actual, System.Type expected, string? customMessage) { }
+        public static void ShouldNotBeOfType<T>(this object? actual) { }
+        public static void ShouldNotBeOfType<T>(this object? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeOfType<T>(this object? actual, string? customMessage) { }
         public static void ShouldNotBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, params T[] expected) { }
-        public static void ShouldNotBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, T[] expected, string? customMessage) { }
         public static void ShouldNotBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, T[] expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, T[] expected, string? customMessage) { }
         public static void ShouldNotBeSameAs(this object? actual, object? expected) { }
-        public static void ShouldNotBeSameAs(this object? actual, object? expected, string? customMessage) { }
         public static void ShouldNotBeSameAs(this object? actual, object? expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeSameAs(this object? actual, object? expected, string? customMessage) { }
     }
     public class ShouldCompleteInException : Shouldly.ShouldlyTimeoutException
     {
@@ -492,131 +492,131 @@ namespace Shouldly
     public static class ShouldMatchApprovedTestExtensions
     {
         public static void ShouldMatchApproved(this string actual) { }
-        public static void ShouldMatchApproved(this string actual, string? customMessage) { }
         public static void ShouldMatchApproved(this string actual, System.Action<Shouldly.Configuration.ShouldMatchConfigurationBuilder> configureOptions) { }
-        public static void ShouldMatchApproved(this string actual, string customMessage, System.Action<Shouldly.Configuration.ShouldMatchConfigurationBuilder> configureOptions) { }
+        public static void ShouldMatchApproved(this string actual, string? customMessage) { }
         public static void ShouldMatchApproved(this string actual, System.Func<string?> customMessage, System.Action<Shouldly.Configuration.ShouldMatchConfigurationBuilder> configureOptions) { }
+        public static void ShouldMatchApproved(this string actual, string customMessage, System.Action<Shouldly.Configuration.ShouldMatchConfigurationBuilder> configureOptions) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldSatisfyAllConditionsTestExtensions
     {
         public static void ShouldSatisfyAllConditions(this object? actual, params System.Action[] conditions) { }
-        public static void ShouldSatisfyAllConditions(this object? actual, string? customMessage, params System.Action[] conditions) { }
         public static void ShouldSatisfyAllConditions(this object? actual, System.Func<string?>? customMessage, params System.Action[] conditions) { }
+        public static void ShouldSatisfyAllConditions(this object? actual, string? customMessage, params System.Action[] conditions) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldThrowAsyncExtensions
     {
-        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task, string? customMessage)
-            where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task, System.Func<string?>? customMessage)
-            where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
         public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Threading.Tasks.Task task, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Threading.Tasks.Task task, string? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
         public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Threading.Tasks.Task task, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Threading.Tasks.Task task, string? customMessage, System.Type exceptionType) { }
         public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Func<System.Threading.Tasks.Task> actual)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
+        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task)
             where TException : System.Exception { }
         public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
+            where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task, System.Func<string?>? customMessage)
+            where TException : System.Exception { }
+        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task, string? customMessage)
+            where TException : System.Exception { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldThrowExtensions
     {
         public static void ShouldNotThrow(this System.Action action) { }
-        public static void ShouldNotThrow(this System.Action action, string? customMessage) { }
         public static void ShouldNotThrow(this System.Action action, System.Func<string?>? customMessage) { }
+        public static void ShouldNotThrow(this System.Action action, string? customMessage) { }
         public static T ShouldNotThrow<T>(this System.Func<T> action) { }
-        public static T ShouldNotThrow<T>(this System.Func<T> action, string? customMessage) { }
         public static T ShouldNotThrow<T>(this System.Func<T> action, System.Func<string?>? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Func<T> action, string? customMessage) { }
+        public static System.Exception ShouldThrow(this System.Action actual, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<object?> actual, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Action actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Action actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<object?> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<object?> actual, string? customMessage, System.Type exceptionType) { }
         public static TException ShouldThrow<TException>(this System.Action actual)
-            where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Action actual, string? customMessage)
-            where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Action actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static TException ShouldThrow<TException>(this System.Func<object?> actual)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Func<object?> actual, string? customMessage)
+        public static TException ShouldThrow<TException>(this System.Action actual, System.Func<string?>? customMessage)
+            where TException : System.Exception { }
+        public static TException ShouldThrow<TException>(this System.Action actual, string? customMessage)
             where TException : System.Exception { }
         public static TException ShouldThrow<TException>(this System.Func<object?> actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
-        public static System.Exception ShouldThrow(this System.Action actual, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Action actual, string? customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Action actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<object?> actual, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<object?> actual, string? customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<object?> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static TException ShouldThrow<TException>(this System.Func<object?> actual, string? customMessage)
+            where TException : System.Exception { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldThrowTaskExtensions
     {
-        public static void ShouldNotThrow(this System.Threading.Tasks.Task action) { }
-        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, string? customMessage) { }
-        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.Func<string?>? customMessage) { }
-        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action) { }
-        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, string? customMessage) { }
-        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.Func<string?>? customMessage) { }
         public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action) { }
-        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, string? customMessage) { }
+        public static void ShouldNotThrow(this System.Threading.Tasks.Task action) { }
         public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.Func<string?>? customMessage) { }
-        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter) { }
-        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, string? customMessage) { }
-        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter) { }
-        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, string? customMessage) { }
+        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.Func<string?>? customMessage) { }
+        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter) { }
+        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, string? customMessage) { }
         public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
+        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
+        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, string? customMessage) { }
         public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
-        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, string? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action) { }
         public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.Func<string?>? customMessage) { }
-        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter) { }
-        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, string? customMessage) { }
-        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter) { }
-        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, string? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.Func<string?>? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter) { }
+        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, string? customMessage) { }
         public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
-        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual)
-            where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, string? customMessage)
-            where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.Func<string?>? customMessage)
-            where TException : System.Exception { }
+        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
         public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
         public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
         public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
+        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual)
             where TException : System.Exception { }
         public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
-        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
-        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter)
-            where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage)
-            where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage)
-            where TException : System.Exception { }
-        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage)
+        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
+            where TException : System.Exception { }
+        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.Func<string?>? customMessage)
+            where TException : System.Exception { }
+        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter)
+            where TException : System.Exception { }
+        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, string? customMessage)
             where TException : System.Exception { }
         public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage)
             where TException : System.Exception { }
-        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage)
+            where TException : System.Exception { }
+        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage)
+            where TException : System.Exception { }
+        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage)
+            where TException : System.Exception { }
     }
     public static class ShouldlyConfiguration
     {
@@ -786,10 +786,10 @@ namespace Shouldly.ShouldlyExtensionMethods
     public static class ShouldHaveEnumExtensions
     {
         public static void ShouldHaveFlag(this System.Enum actual, System.Enum expectedFlag) { }
-        public static void ShouldHaveFlag(this System.Enum actual, System.Enum expectedFlag, string? customMessage) { }
         public static void ShouldHaveFlag(this System.Enum actual, System.Enum expectedFlag, System.Func<string?>? customMessage) { }
+        public static void ShouldHaveFlag(this System.Enum actual, System.Enum expectedFlag, string? customMessage) { }
         public static void ShouldNotHaveFlag(this System.Enum actual, System.Enum expectedFlag) { }
-        public static void ShouldNotHaveFlag(this System.Enum actual, System.Enum expectedFlag, string? customMessage) { }
         public static void ShouldNotHaveFlag(this System.Enum actual, System.Enum expectedFlag, System.Func<string?>? customMessage) { }
+        public static void ShouldNotHaveFlag(this System.Enum actual, System.Enum expectedFlag, string? customMessage) { }
     }
 }

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -472,26 +472,6 @@ namespace Shouldly
     {
         public ShouldCompleteInException(string message, Shouldly.ShouldlyTimeoutException inner) { }
     }
-    public class static ShouldlyConfiguration
-    {
-        public static double DefaultFloatingPointTolerance;
-        public static System.TimeSpan DefaultTaskTimeout;
-        public static System.Collections.Generic.List<string> CompareAsObjectTypes { get; }
-        public static Shouldly.Configuration.DiffToolConfiguration DiffTools { get; }
-        public static Shouldly.Configuration.ShouldMatchConfigurationBuilder ShouldMatchApprovedDefaults { get; }
-        public static System.IDisposable DisableSourceInErrors() { }
-        public static bool IsSourceDisabledInErrors() { }
-    }
-    public class ShouldlyMethodsAttribute : System.Attribute
-    {
-        public ShouldlyMethodsAttribute() { }
-    }
-    public class ShouldlyTimeoutException : System.TimeoutException
-    {
-        public ShouldlyTimeoutException() { }
-        public ShouldlyTimeoutException(string message, Shouldly.ShouldlyTimeoutException inner) { }
-        public override string StackTrace { get; }
-    }
     public class ShouldMatchApprovedException : Shouldly.ShouldAssertException
     {
         public ShouldMatchApprovedException(string message, string receivedFile, string approvedFile) { }
@@ -626,6 +606,26 @@ namespace Shouldly
         public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string customMessage, System.Type exceptionType) { }
         public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string> customMessage, System.Type exceptionType) { }
     }
+    public class static ShouldlyConfiguration
+    {
+        public static double DefaultFloatingPointTolerance;
+        public static System.TimeSpan DefaultTaskTimeout;
+        public static System.Collections.Generic.List<string> CompareAsObjectTypes { get; }
+        public static Shouldly.Configuration.DiffToolConfiguration DiffTools { get; }
+        public static Shouldly.Configuration.ShouldMatchConfigurationBuilder ShouldMatchApprovedDefaults { get; }
+        public static System.IDisposable DisableSourceInErrors() { }
+        public static bool IsSourceDisabledInErrors() { }
+    }
+    public class ShouldlyMethodsAttribute : System.Attribute
+    {
+        public ShouldlyMethodsAttribute() { }
+    }
+    public class ShouldlyTimeoutException : System.TimeoutException
+    {
+        public ShouldlyTimeoutException() { }
+        public ShouldlyTimeoutException(string message, Shouldly.ShouldlyTimeoutException inner) { }
+        public override string StackTrace { get; }
+    }
     public enum SortDirection
     {
         Ascending = 0,
@@ -726,8 +726,8 @@ namespace Shouldly.Configuration
         public readonly Shouldly.Configuration.IShouldNotLaunchDiffTool NCrunch;
         public readonly Shouldly.Configuration.IShouldNotLaunchDiffTool TeamCity;
         public readonly Shouldly.Configuration.IShouldNotLaunchDiffTool TravisCI;
-        public readonly Shouldly.Configuration.IShouldNotLaunchDiffTool VisualStudioLiveUnitTesting;
         public readonly Shouldly.Configuration.IShouldNotLaunchDiffTool VSTS;
+        public readonly Shouldly.Configuration.IShouldNotLaunchDiffTool VisualStudioLiveUnitTesting;
         public KnownDoNotLaunchStrategies() { }
     }
     public class ShouldMatchConfiguration

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -5,22 +5,22 @@ namespace Shouldly
         Sensitive = 0,
         Insensitive = 1,
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static DynamicShould
+    [Shouldly.ShouldlyMethods]
+    public static class DynamicShould
     {
-        public static void HaveProperty([System.Runtime.CompilerServices.DynamicAttribute()] object dynamicTestObject, string propertyName) { }
-        public static void HaveProperty([System.Runtime.CompilerServices.DynamicAttribute()] object dynamicTestObject, string propertyName, string customMessage) { }
-        public static void HaveProperty([System.Runtime.CompilerServices.DynamicAttribute()] object dynamicTestObject, string propertyName, System.Func<string> customMessage) { }
+        public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName) { }
+        public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName, string customMessage) { }
+        public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName, System.Func<string> customMessage) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ObjectGraphTestExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ObjectGraphTestExtensions
     {
         public static void ShouldBeEquivalentTo(this object actual, object expected) { }
         public static void ShouldBeEquivalentTo(this object actual, object expected, string customMessage) { }
         public static void ShouldBeEquivalentTo(this object actual, object expected, System.Func<string> customMessage) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static Should
+    [Shouldly.ShouldlyMethods]
+    public static class Should
     {
         public static void CompleteIn(System.Action action, System.TimeSpan timeout) { }
         public static void CompleteIn(System.Action action, System.TimeSpan timeout, string customMessage) { }
@@ -149,8 +149,8 @@ namespace Shouldly
         public ShouldAssertException(string message, System.Exception innerException) { }
         public override string StackTrace { get; }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldBeBooleanExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldBeBooleanExtensions
     {
         public static void ShouldBeFalse(this bool actual) { }
         public static void ShouldBeFalse(this bool actual, string customMessage) { }
@@ -159,8 +159,8 @@ namespace Shouldly
         public static void ShouldBeTrue(this bool actual, string customMessage) { }
         public static void ShouldBeTrue(this bool actual, System.Func<string> customMessage) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldBeDictionaryTestExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldBeDictionaryTestExtensions
     {
         public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key) { }
         public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string customMessage) { }
@@ -175,8 +175,8 @@ namespace Shouldly
         public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string customMessage) { }
         public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, System.Func<string> customMessage) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldBeEnumerableTestExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldBeEnumerableTestExtensions
     {
         public static void ShouldAllBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate) { }
         public static void ShouldAllBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string customMessage) { }
@@ -230,8 +230,8 @@ namespace Shouldly
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string customMessage) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string> customMessage) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldBeNullExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldBeNullExtensions
     {
         public static void ShouldBeNull<T>(this T actual) { }
         public static void ShouldBeNull<T>(this T actual, string customMessage) { }
@@ -240,8 +240,8 @@ namespace Shouldly
         public static void ShouldNotBeNull<T>(this T actual, string customMessage) { }
         public static void ShouldNotBeNull<T>(this T actual, System.Func<string> customMessage) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldBeStringTestExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldBeStringTestExtensions
     {
         public static void ShouldBe(this string actual, string expected) { }
         public static void ShouldBe(this string actual, string expected, string customMessage) { }
@@ -299,8 +299,8 @@ namespace Shouldly
         public static void ShouldStartWith(this string actual, string expected, string customMessage, Shouldly.Case caseSensitivity = 1) { }
         public static void ShouldStartWith(this string actual, string expected, System.Func<string> customMessage, Shouldly.Case caseSensitivity = 1) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldBeTestExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldBeTestExtensions
     {
         public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance) { }
         public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, string customMessage) { }
@@ -476,8 +476,8 @@ namespace Shouldly
     {
         public ShouldMatchApprovedException(string message, string receivedFile, string approvedFile) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldMatchApprovedTestExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldMatchApprovedTestExtensions
     {
         public static void ShouldMatchApproved(this string actual) { }
         public static void ShouldMatchApproved(this string actual, string customMessage) { }
@@ -485,15 +485,15 @@ namespace Shouldly
         public static void ShouldMatchApproved(this string actual, string customMessage, System.Action<Shouldly.Configuration.ShouldMatchConfigurationBuilder> configureOptions) { }
         public static void ShouldMatchApproved(this string actual, System.Func<string> customMessage, System.Action<Shouldly.Configuration.ShouldMatchConfigurationBuilder> configureOptions) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldSatisfyAllConditionsTestExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldSatisfyAllConditionsTestExtensions
     {
         public static void ShouldSatisfyAllConditions(this object actual, params System.Action[] conditions) { }
         public static void ShouldSatisfyAllConditions(this object actual, string customMessage, params System.Action[] conditions) { }
         public static void ShouldSatisfyAllConditions(this object actual, System.Func<string> customMessage, params System.Action[] conditions) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldThrowAsyncExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldThrowAsyncExtensions
     {
         public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task)
             where TException : System.Exception { }
@@ -514,8 +514,8 @@ namespace Shouldly
         public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, string customMessage, System.Type exceptionType) { }
         public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string> customMessage, System.Type exceptionType) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldThrowExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldThrowExtensions
     {
         public static void ShouldNotThrow(this System.Action action) { }
         public static void ShouldNotThrow(this System.Action action, string customMessage) { }
@@ -542,8 +542,8 @@ namespace Shouldly
         public static System.Exception ShouldThrow(this System.Func<object> actual, string customMessage, System.Type exceptionType) { }
         public static System.Exception ShouldThrow(this System.Func<object> actual, System.Func<string> customMessage, System.Type exceptionType) { }
     }
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldThrowTaskExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldThrowTaskExtensions
     {
         public static void ShouldNotThrow(this System.Threading.Tasks.Task action) { }
         public static void ShouldNotThrow(this System.Threading.Tasks.Task action, string customMessage) { }
@@ -606,7 +606,7 @@ namespace Shouldly
         public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string customMessage, System.Type exceptionType) { }
         public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string> customMessage, System.Type exceptionType) { }
     }
-    public class static ShouldlyConfiguration
+    public static class ShouldlyConfiguration
     {
         public static double DefaultFloatingPointTolerance;
         public static System.TimeSpan DefaultTaskTimeout;
@@ -631,7 +631,7 @@ namespace Shouldly
         Ascending = 0,
         Descending = 1,
     }
-    [System.FlagsAttribute()]
+    [System.Flags]
     public enum StringCompareShould
     {
         IgnoreCase = 1,
@@ -770,8 +770,8 @@ namespace Shouldly.Configuration
 }
 namespace Shouldly.ShouldlyExtensionMethods
 {
-    [Shouldly.ShouldlyMethodsAttribute()]
-    public class static ShouldHaveEnumExtensions
+    [Shouldly.ShouldlyMethods]
+    public static class ShouldHaveEnumExtensions
     {
         public static void ShouldHaveFlag(this System.Enum actual, System.Enum expectedFlag) { }
         public static void ShouldHaveFlag(this System.Enum actual, System.Enum expectedFlag, string customMessage) { }

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -342,47 +342,47 @@ namespace Shouldly
         public static void ShouldBeAssignableTo(this object actual, System.Type expected, string customMessage) { }
         public static void ShouldBeAssignableTo(this object actual, System.Type expected, System.Func<string> customMessage) { }
         public static void ShouldBeGreaterThan<T>(this T actual, T expected)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeGreaterThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
         public static void ShouldBeGreaterThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
         public static void ShouldBeGreaterThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldBeGreaterThan<T>(this T actual, T expected, string customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeGreaterThan<T>(this T actual, T expected, System.Func<string> customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, string customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
         public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
         public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, System.Func<string> customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeInRange<T>(this T actual, T from, T to)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeInRange<T>(this T actual, T from, T to, string customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeInRange<T>(this T actual, T from, T to, System.Func<string> customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeLessThan<T>(this T actual, T expected)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeLessThan<T>(this T actual, T expected, string customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeLessThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
         public static void ShouldBeLessThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
         public static void ShouldBeLessThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldBeLessThan<T>(this T actual, T expected, System.Func<string> customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, string customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
         public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
         public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
         public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, System.Func<string> customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldBeNegative(this decimal actual) { }
         public static void ShouldBeNegative(this decimal actual, string customMessage) { }
         public static void ShouldBeNegative(this decimal actual, System.Func<string> customMessage) { }
@@ -450,11 +450,11 @@ namespace Shouldly
         public static void ShouldNotBeAssignableTo(this object actual, System.Type expected, string customMessage) { }
         public static void ShouldNotBeAssignableTo(this object actual, System.Type expected, System.Func<string> customMessage) { }
         public static void ShouldNotBeInRange<T>(this T actual, T from, T to)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldNotBeInRange<T>(this T actual, T from, T to, string customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldNotBeInRange<T>(this T actual, T from, T to, System.Func<string> customMessage)
-            where T : System.IComparable<> { }
+            where T : System.IComparable<T> { }
         public static void ShouldNotBeOfType<T>(this object actual) { }
         public static void ShouldNotBeOfType<T>(this object actual, string customMessage) { }
         public static void ShouldNotBeOfType<T>(this object actual, System.Func<string> customMessage) { }

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -9,602 +9,614 @@ namespace Shouldly
     public static class DynamicShould
     {
         public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName) { }
-        public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName, string customMessage) { }
-        public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName, System.Func<string> customMessage) { }
+        public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName, string? customMessage) { }
+        public static void HaveProperty([System.Runtime.CompilerServices.Dynamic] object dynamicTestObject, string propertyName, System.Func<string?>? customMessage) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ObjectGraphTestExtensions
     {
-        public static void ShouldBeEquivalentTo(this object actual, object expected) { }
-        public static void ShouldBeEquivalentTo(this object actual, object expected, string customMessage) { }
-        public static void ShouldBeEquivalentTo(this object actual, object expected, System.Func<string> customMessage) { }
+        public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected) { }
+        public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, string? customMessage) { }
+        public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, System.Func<string?>? customMessage) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class Should
     {
         public static void CompleteIn(System.Action action, System.TimeSpan timeout) { }
-        public static void CompleteIn(System.Action action, System.TimeSpan timeout, string customMessage) { }
-        public static void CompleteIn(System.Action action, System.TimeSpan timeout, System.Func<string> customMessage) { }
+        public static void CompleteIn(System.Action action, System.TimeSpan timeout, string? customMessage) { }
+        public static void CompleteIn(System.Action action, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
         public static T CompleteIn<T>(System.Func<T> function, System.TimeSpan timeout) { }
-        public static T CompleteIn<T>(System.Func<T> function, System.TimeSpan timeout, string customMessage) { }
-        public static T CompleteIn<T>(System.Func<T> function, System.TimeSpan timeout, System.Func<string> customMessage) { }
+        public static T CompleteIn<T>(System.Func<T> function, System.TimeSpan timeout, string? customMessage) { }
+        public static T CompleteIn<T>(System.Func<T> function, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
         public static void CompleteIn(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeout) { }
-        public static void CompleteIn(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeout, string customMessage) { }
-        public static void CompleteIn(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeout, System.Func<string> customMessage) { }
+        public static void CompleteIn(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeout, string? customMessage) { }
+        public static void CompleteIn(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
         public static T CompleteIn<T>(System.Func<System.Threading.Tasks.Task<T>> actual, System.TimeSpan timeout) { }
-        public static T CompleteIn<T>(System.Func<System.Threading.Tasks.Task<T>> actual, System.TimeSpan timeout, string customMessage) { }
-        public static T CompleteIn<T>(System.Func<System.Threading.Tasks.Task<T>> actual, System.TimeSpan timeout, System.Func<string> customMessage) { }
+        public static T CompleteIn<T>(System.Func<System.Threading.Tasks.Task<T>> actual, System.TimeSpan timeout, string? customMessage) { }
+        public static T CompleteIn<T>(System.Func<System.Threading.Tasks.Task<T>> actual, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
         public static void CompleteIn(System.Threading.Tasks.Task actual, System.TimeSpan timeout) { }
-        public static void CompleteIn(System.Threading.Tasks.Task actual, System.TimeSpan timeout, string customMessage) { }
-        public static void CompleteIn(System.Threading.Tasks.Task actual, System.TimeSpan timeout, System.Func<string> customMessage) { }
+        public static void CompleteIn(System.Threading.Tasks.Task actual, System.TimeSpan timeout, string? customMessage) { }
+        public static void CompleteIn(System.Threading.Tasks.Task actual, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
         public static T CompleteIn<T>(System.Threading.Tasks.Task<T> actual, System.TimeSpan timeout) { }
-        public static T CompleteIn<T>(System.Threading.Tasks.Task<T> actual, System.TimeSpan timeout, string customMessage) { }
-        public static T CompleteIn<T>(System.Threading.Tasks.Task<T> actual, System.TimeSpan timeout, System.Func<string> customMessage) { }
+        public static T CompleteIn<T>(System.Threading.Tasks.Task<T> actual, System.TimeSpan timeout, string? customMessage) { }
+        public static T CompleteIn<T>(System.Threading.Tasks.Task<T> actual, System.TimeSpan timeout, System.Func<string?>? customMessage) { }
         public static void NotThrow(System.Action action) { }
-        public static void NotThrow(System.Action action, string customMessage) { }
-        public static void NotThrow(System.Action action, System.Func<string> customMessage) { }
+        public static void NotThrow(System.Action action, string? customMessage) { }
+        public static void NotThrow(System.Action action, System.Func<string?>? customMessage) { }
         public static T NotThrow<T>(System.Func<T> action) { }
-        public static T NotThrow<T>(System.Func<T> action, string customMessage) { }
-        public static T NotThrow<T>(System.Func<T> action, System.Func<string> customMessage) { }
+        public static T NotThrow<T>(System.Func<T> action, string? customMessage) { }
+        public static T NotThrow<T>(System.Func<T> action, System.Func<string?>? customMessage) { }
         public static void NotThrow(System.Threading.Tasks.Task action) { }
-        public static void NotThrow(System.Threading.Tasks.Task action, string customMessage) { }
-        public static void NotThrow(System.Threading.Tasks.Task action, System.Func<string> customMessage) { }
+        public static void NotThrow(System.Threading.Tasks.Task action, string? customMessage) { }
+        public static void NotThrow(System.Threading.Tasks.Task action, System.Func<string?>? customMessage) { }
         public static T NotThrow<T>(System.Threading.Tasks.Task<T> action) { }
-        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, string customMessage) { }
-        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.Func<string> customMessage) { }
+        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, string? customMessage) { }
+        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.Func<string?>? customMessage) { }
         public static void NotThrow(System.Func<System.Threading.Tasks.Task> action) { }
-        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, string customMessage) { }
-        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.Func<string> customMessage) { }
+        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, string? customMessage) { }
+        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.Func<string?>? customMessage) { }
         public static void NotThrow(System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter) { }
-        public static void NotThrow(System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, string customMessage) { }
-        public static void NotThrow(System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, System.Func<string> customMessage) { }
+        public static void NotThrow(System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static void NotThrow(System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter) { }
-        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, string customMessage) { }
-        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, System.Func<string> customMessage) { }
+        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static void NotThrow(System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action) { }
-        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, string customMessage) { }
-        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.Func<string> customMessage) { }
+        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, string? customMessage) { }
+        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.Func<string?>? customMessage) { }
         public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter) { }
-        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, string customMessage) { }
-        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, System.Func<string> customMessage) { }
+        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static T NotThrow<T>(System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter) { }
-        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, string customMessage) { }
-        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, System.Func<string> customMessage) { }
+        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static T NotThrow<T>(System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static TException Throw<TException>(System.Action actual)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Action actual, string customMessage)
+        public static TException Throw<TException>(System.Action actual, string? customMessage)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Action actual, System.Func<string> customMessage)
+        public static TException Throw<TException>(System.Action actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Exception Throw(System.Action actual, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Action actual, string customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Action actual, System.Func<string> customMessage, System.Type exceptionType) { }
-        public static TException Throw<TException>(System.Func<object> actual)
+        public static System.Exception Throw(System.Action actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Action actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static TException Throw<TException>(System.Func<object?> actual)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Func<object> actual, string customMessage)
+        public static TException Throw<TException>(System.Func<object?> actual, string? customMessage)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Func<object> actual, System.Func<string> customMessage)
+        public static TException Throw<TException>(System.Func<object?> actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
-        public static System.Exception Throw(System.Func<object> actual, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<object> actual, string customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<object> actual, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<object?> actual, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<object?> actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<object?> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static TException Throw<TException>(System.Threading.Tasks.Task actual)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Threading.Tasks.Task actual, string customMessage)
+        public static TException Throw<TException>(System.Threading.Tasks.Task actual, string? customMessage)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.Func<string> customMessage)
+        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Exception Throw(System.Threading.Tasks.Task actual, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Threading.Tasks.Task actual, string customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Threading.Tasks.Task actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, string customMessage)
+        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.Func<string> customMessage)
+        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, string customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string customMessage)
+        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string> customMessage)
+        public static TException Throw<TException>(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Exception Throw(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string customMessage)
+        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage)
             where TException : System.Exception { }
-        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string> customMessage)
+        public static TException Throw<TException>(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string customMessage, System.Type exceptionType) { }
-        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception Throw(System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Threading.Tasks.Task task)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Threading.Tasks.Task task, string customMessage)
+        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Threading.Tasks.Task task, string? customMessage)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Threading.Tasks.Task task, System.Func<string> customMessage)
+        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Threading.Tasks.Task task, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Threading.Tasks.Task task, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Threading.Tasks.Task task, string customMessage, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Threading.Tasks.Task task, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Threading.Tasks.Task task, string? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Threading.Tasks.Task task, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Func<System.Threading.Tasks.Task> actual)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Func<System.Threading.Tasks.Task> actual, string customMessage)
+        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Func<System.Threading.Tasks.Task> actual, System.Func<string> customMessage)
+        public static System.Threading.Tasks.Task<TException> ThrowAsync<TException>(System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Func<System.Threading.Tasks.Task> actual, string customMessage, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Func<System.Threading.Tasks.Task> actual, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ThrowAsync(System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
     }
     public class ShouldAssertException : System.Exception
     {
-        public ShouldAssertException(string message) { }
-        public ShouldAssertException(string message, System.Exception innerException) { }
+        public ShouldAssertException(string? message) { }
+        public ShouldAssertException(string? message, System.Exception? innerException) { }
         public override string StackTrace { get; }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeBooleanExtensions
     {
-        public static void ShouldBeFalse(this bool actual) { }
-        public static void ShouldBeFalse(this bool actual, string customMessage) { }
-        public static void ShouldBeFalse(this bool actual, System.Func<string> customMessage) { }
-        public static void ShouldBeTrue(this bool actual) { }
-        public static void ShouldBeTrue(this bool actual, string customMessage) { }
-        public static void ShouldBeTrue(this bool actual, System.Func<string> customMessage) { }
+        public static void ShouldBeFalse([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(true)] this bool actual) { }
+        public static void ShouldBeFalse([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(true)] this bool actual, string? customMessage) { }
+        public static void ShouldBeFalse([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(true)] this bool actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeTrue([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] this bool actual) { }
+        public static void ShouldBeTrue([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] this bool actual, string? customMessage) { }
+        public static void ShouldBeTrue([System.Diagnostics.CodeAnalysis.DoesNotReturnIf(false)] this bool actual, System.Func<string?>? customMessage) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeDictionaryTestExtensions
     {
-        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key) { }
-        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string customMessage) { }
-        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, System.Func<string> customMessage) { }
-        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val) { }
-        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string customMessage) { }
-        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, System.Func<string> customMessage) { }
-        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key) { }
-        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string customMessage) { }
-        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, System.Func<string> customMessage) { }
-        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val) { }
-        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string customMessage) { }
-        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, System.Func<string> customMessage) { }
+        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key)
+            where TKey :  notnull { }
+        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage)
+            where TKey :  notnull { }
+        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, System.Func<string?>? customMessage)
+            where TKey :  notnull { }
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val)
+            where TKey :  notnull { }
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage)
+            where TKey :  notnull { }
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, System.Func<string?>? customMessage)
+            where TKey :  notnull { }
+        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key)
+            where TKey :  notnull { }
+        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage)
+            where TKey :  notnull { }
+        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, System.Func<string?>? customMessage)
+            where TKey :  notnull { }
+        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val)
+            where TKey :  notnull { }
+        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage)
+            where TKey :  notnull { }
+        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, System.Func<string?>? customMessage)
+            where TKey :  notnull { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeEnumerableTestExtensions
     {
         public static void ShouldAllBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate) { }
-        public static void ShouldAllBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string customMessage) { }
-        public static void ShouldAllBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string> customMessage) { }
+        public static void ShouldAllBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string? customMessage) { }
+        public static void ShouldAllBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<string> actual, System.Collections.Generic.IEnumerable<string> expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<string> actual, System.Collections.Generic.IEnumerable<string> expected, Shouldly.Case caseSensitivity, string customMessage) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<string> actual, System.Collections.Generic.IEnumerable<string> expected, Shouldly.Case caseSensitivity, System.Func<string> customMessage) { }
-        public static void ShouldBeEmpty<T>(this System.Collections.Generic.IEnumerable<T> actual) { }
-        public static void ShouldBeEmpty<T>(this System.Collections.Generic.IEnumerable<T> actual, string customMessage) { }
-        public static void ShouldBeEmpty<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Func<string> customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<string> actual, System.Collections.Generic.IEnumerable<string> expected, Shouldly.Case caseSensitivity, string? customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<string> actual, System.Collections.Generic.IEnumerable<string> expected, Shouldly.Case caseSensitivity, System.Func<string?>? customMessage) { }
+        public static void ShouldBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual) { }
+        public static void ShouldBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage) { }
+        public static void ShouldBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, string customMessage) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Func<string> customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, string? customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, string customMessage) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Func<string> customMessage) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T> customComparer) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T> customComparer, string customMessage) { }
-        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T> customComparer, System.Func<string> customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, string? customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Func<string?>? customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T>? customComparer) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T>? customComparer, string? customMessage) { }
+        public static void ShouldBeInOrder<T>(this System.Collections.Generic.IEnumerable<T> actual, Shouldly.SortDirection expectedSortDirection, System.Collections.Generic.IComparer<T>? customComparer, System.Func<string?>? customMessage) { }
         public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected) { }
-        public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, string customMessage) { }
-        public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, System.Func<string> customMessage) { }
+        public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, string? customMessage) { }
+        public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, System.Func<string?>? customMessage) { }
         public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual) { }
-        public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual, string customMessage) { }
-        public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Func<string> customMessage) { }
+        public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual, string? customMessage) { }
+        public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Func<string?>? customMessage) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string customMessage) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Func<string> customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string? customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Func<string?>? customMessage) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount, string customMessage) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount, System.Func<string> customMessage) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string customMessage) { }
-        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string> customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount, string? customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount, System.Func<string?>? customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string? customMessage) { }
+        public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string?>? customMessage) { }
         public static void ShouldContain(this System.Collections.Generic.IEnumerable<float> actual, float expected, double tolerance) { }
-        public static void ShouldContain(this System.Collections.Generic.IEnumerable<float> actual, float expected, double tolerance, string customMessage) { }
-        public static void ShouldContain(this System.Collections.Generic.IEnumerable<float> actual, float expected, double tolerance, System.Func<string> customMessage) { }
+        public static void ShouldContain(this System.Collections.Generic.IEnumerable<float> actual, float expected, double tolerance, string? customMessage) { }
+        public static void ShouldContain(this System.Collections.Generic.IEnumerable<float> actual, float expected, double tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldContain(this System.Collections.Generic.IEnumerable<double> actual, double expected, double tolerance) { }
-        public static void ShouldContain(this System.Collections.Generic.IEnumerable<double> actual, double expected, double tolerance, string customMessage) { }
-        public static void ShouldContain(this System.Collections.Generic.IEnumerable<double> actual, double expected, double tolerance, System.Func<string> customMessage) { }
-        public static T ShouldHaveSingleItem<T>(this System.Collections.Generic.IEnumerable<T> actual) { }
-        public static T ShouldHaveSingleItem<T>(this System.Collections.Generic.IEnumerable<T> actual, string customMessage) { }
-        public static T ShouldHaveSingleItem<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Func<string> customMessage) { }
-        public static void ShouldNotBeEmpty<T>(this System.Collections.Generic.IEnumerable<T> actual) { }
-        public static void ShouldNotBeEmpty<T>(this System.Collections.Generic.IEnumerable<T> actual, string customMessage) { }
-        public static void ShouldNotBeEmpty<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Func<string> customMessage) { }
+        public static void ShouldContain(this System.Collections.Generic.IEnumerable<double> actual, double expected, double tolerance, string? customMessage) { }
+        public static void ShouldContain(this System.Collections.Generic.IEnumerable<double> actual, double expected, double tolerance, System.Func<string?>? customMessage) { }
+        public static T ShouldHaveSingleItem<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual) { }
+        public static T ShouldHaveSingleItem<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage) { }
+        public static T ShouldHaveSingleItem<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual) { }
+        public static void ShouldNotBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage) { }
+        public static void ShouldNotBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, System.Func<string?>? customMessage) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected) { }
-        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string customMessage) { }
-        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Func<string> customMessage) { }
+        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string? customMessage) { }
+        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Func<string?>? customMessage) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate) { }
-        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string customMessage) { }
-        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string> customMessage) { }
+        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string? customMessage) { }
+        public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, System.Func<string?>? customMessage) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeNullExtensions
     {
-        public static void ShouldBeNull<T>(this T actual) { }
-        public static void ShouldBeNull<T>(this T actual, string customMessage) { }
-        public static void ShouldBeNull<T>(this T actual, System.Func<string> customMessage) { }
-        public static void ShouldNotBeNull<T>(this T actual) { }
-        public static void ShouldNotBeNull<T>(this T actual, string customMessage) { }
-        public static void ShouldNotBeNull<T>(this T actual, System.Func<string> customMessage) { }
+        public static void ShouldBeNull<T>([System.Diagnostics.CodeAnalysis.MaybeNull] this T actual) { }
+        public static void ShouldBeNull<T>([System.Diagnostics.CodeAnalysis.MaybeNull] this T actual, string? customMessage) { }
+        public static void ShouldBeNull<T>([System.Diagnostics.CodeAnalysis.MaybeNull] this T actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T actual) { }
+        public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T actual, string? customMessage) { }
+        public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T actual, System.Func<string?>? customMessage) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeStringTestExtensions
     {
-        public static void ShouldBe(this string actual, string expected) { }
-        public static void ShouldBe(this string actual, string expected, string customMessage) { }
-        public static void ShouldBe(this string actual, string expected, System.Func<string> customMessage) { }
-        public static void ShouldBe(this string actual, string expected, Shouldly.StringCompareShould options) { }
-        public static void ShouldBe(this string actual, string expected, string customMessage, Shouldly.StringCompareShould option) { }
-        public static void ShouldBe(this string actual, string expected, System.Func<string> customMessage, Shouldly.StringCompareShould options) { }
-        public static void ShouldBeNullOrEmpty(this string actual) { }
-        public static void ShouldBeNullOrEmpty(this string actual, string customMessage) { }
-        public static void ShouldBeNullOrEmpty(this string actual, System.Func<string> customMessage) { }
-        public static void ShouldBeNullOrWhiteSpace(this string actual) { }
-        public static void ShouldBeNullOrWhiteSpace(this string actual, string customMessage) { }
-        public static void ShouldBeNullOrWhiteSpace(this string actual, System.Func<string> customMessage) { }
+        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected) { }
+        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, string customMessage) { }
+        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, System.Func<string?> customMessage) { }
+        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, Shouldly.StringCompareShould options) { }
+        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, string customMessage, Shouldly.StringCompareShould option) { }
+        public static void ShouldBe([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this string? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] string? expected, System.Func<string?> customMessage, Shouldly.StringCompareShould options) { }
+        public static void ShouldBeNullOrEmpty(this string? actual) { }
+        public static void ShouldBeNullOrEmpty(this string? actual, string? customMessage) { }
+        public static void ShouldBeNullOrEmpty(this string? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeNullOrWhiteSpace(this string? actual) { }
+        public static void ShouldBeNullOrWhiteSpace(this string? actual, string? customMessage) { }
+        public static void ShouldBeNullOrWhiteSpace(this string? actual, System.Func<string?>? customMessage) { }
         public static void ShouldContain(this string actual, string expected) { }
         public static void ShouldContain(this string actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldContain(this string actual, string expected, string customMessage) { }
-        public static void ShouldContain(this string actual, string expected, string customMessage, Shouldly.Case caseSensitivity) { }
-        public static void ShouldContain(this string actual, string expected, System.Func<string> customMessage) { }
-        public static void ShouldContain(this string actual, string expected, System.Func<string> customMessage, Shouldly.Case caseSensitivity) { }
-        public static void ShouldContainWithoutWhitespace(this string actual, object expected) { }
-        public static void ShouldContainWithoutWhitespace(this string actual, object expected, string customMessage) { }
-        public static void ShouldContainWithoutWhitespace(this string actual, object expected, System.Func<string> customMessage) { }
-        public static void ShouldEndWith(this string actual, string expected) { }
-        public static void ShouldEndWith(this string actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldEndWith(this string actual, string expected, string customMessage, Shouldly.Case caseSensitivity = 1) { }
-        public static void ShouldEndWith(this string actual, string expected, System.Func<string> customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldContain(this string actual, string expected, string? customMessage) { }
+        public static void ShouldContain(this string actual, string expected, string? customMessage, Shouldly.Case caseSensitivity) { }
+        public static void ShouldContain(this string actual, string expected, System.Func<string?>? customMessage) { }
+        public static void ShouldContain(this string actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity) { }
+        public static void ShouldContainWithoutWhitespace(this string actual, object? expected) { }
+        public static void ShouldContainWithoutWhitespace(this string actual, object? expected, string? customMessage) { }
+        public static void ShouldContainWithoutWhitespace(this string actual, object? expected, System.Func<string?>? customMessage) { }
+        public static void ShouldEndWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected) { }
+        public static void ShouldEndWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, Shouldly.Case caseSensitivity) { }
+        public static void ShouldEndWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldEndWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity = 1) { }
         public static void ShouldMatch(this string actual, string regexPattern) { }
-        public static void ShouldMatch(this string actual, string regexPattern, string customMessage) { }
-        public static void ShouldMatch(this string actual, string regexPattern, System.Func<string> customMessage) { }
-        public static void ShouldNotBeNullOrEmpty(this string actual) { }
-        public static void ShouldNotBeNullOrEmpty(this string actual, string customMessage) { }
-        public static void ShouldNotBeNullOrEmpty(this string actual, System.Func<string> customMessage) { }
-        public static void ShouldNotBeNullOrWhiteSpace(this string actual) { }
-        public static void ShouldNotBeNullOrWhiteSpace(this string actual, string customMessage) { }
-        public static void ShouldNotBeNullOrWhiteSpace(this string actual, System.Func<string> customMessage) { }
+        public static void ShouldMatch(this string actual, string regexPattern, string? customMessage) { }
+        public static void ShouldMatch(this string actual, string regexPattern, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeNullOrEmpty([System.Diagnostics.CodeAnalysis.NotNull] this string? actual) { }
+        public static void ShouldNotBeNullOrEmpty([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string? customMessage) { }
+        public static void ShouldNotBeNullOrEmpty([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeNullOrWhiteSpace([System.Diagnostics.CodeAnalysis.NotNull] this string? actual) { }
+        public static void ShouldNotBeNullOrWhiteSpace([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string? customMessage) { }
+        public static void ShouldNotBeNullOrWhiteSpace([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, System.Func<string?>? customMessage) { }
         public static void ShouldNotContain(this string actual, string expected) { }
         public static void ShouldNotContain(this string actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldNotContain(this string actual, string expected, string customMessage) { }
-        public static void ShouldNotContain(this string actual, string expected, string customMessage, Shouldly.Case caseSensitivity) { }
-        public static void ShouldNotContain(this string actual, string expected, System.Func<string> customMessage) { }
-        public static void ShouldNotContain(this string actual, string expected, System.Func<string> customMessage, Shouldly.Case caseSensitivity) { }
-        public static void ShouldNotEndWith(this string actual, string expected) { }
-        public static void ShouldNotEndWith(this string actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldNotEndWith(this string actual, string expected, string customMessage, Shouldly.Case caseSensitivity = 1) { }
-        public static void ShouldNotEndWith(this string actual, string expected, System.Func<string> customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldNotContain(this string actual, string expected, string? customMessage) { }
+        public static void ShouldNotContain(this string actual, string expected, string? customMessage, Shouldly.Case caseSensitivity) { }
+        public static void ShouldNotContain(this string actual, string expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotContain(this string actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity) { }
+        public static void ShouldNotEndWith(this string? actual, string expected) { }
+        public static void ShouldNotEndWith(this string? actual, string expected, Shouldly.Case caseSensitivity) { }
+        public static void ShouldNotEndWith(this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldNotEndWith(this string? actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity = 1) { }
         public static void ShouldNotMatch(this string actual, string regexPattern) { }
-        public static void ShouldNotMatch(this string actual, string regexPattern, string customMessage) { }
-        public static void ShouldNotMatch(this string actual, string regexPattern, System.Func<string> customMessage) { }
-        public static void ShouldNotStartWith(this string actual, string expected) { }
-        public static void ShouldNotStartWith(this string actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldNotStartWith(this string actual, string expected, string customMessage, Shouldly.Case caseSensitivity = 1) { }
-        public static void ShouldNotStartWith(this string actual, string expected, System.Func<string> customMessage, Shouldly.Case caseSensitivity = 1) { }
-        public static void ShouldStartWith(this string actual, string expected) { }
-        public static void ShouldStartWith(this string actual, string expected, Shouldly.Case caseSensitivity) { }
-        public static void ShouldStartWith(this string actual, string expected, string customMessage, Shouldly.Case caseSensitivity = 1) { }
-        public static void ShouldStartWith(this string actual, string expected, System.Func<string> customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldNotMatch(this string actual, string regexPattern, string? customMessage) { }
+        public static void ShouldNotMatch(this string actual, string regexPattern, System.Func<string?>? customMessage) { }
+        public static void ShouldNotStartWith(this string? actual, string expected) { }
+        public static void ShouldNotStartWith(this string? actual, string expected, Shouldly.Case caseSensitivity) { }
+        public static void ShouldNotStartWith(this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldNotStartWith(this string? actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldStartWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected) { }
+        public static void ShouldStartWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, Shouldly.Case caseSensitivity) { }
+        public static void ShouldStartWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, string? customMessage, Shouldly.Case caseSensitivity = 1) { }
+        public static void ShouldStartWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity = 1) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeTestExtensions
     {
         public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance) { }
-        public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, string customMessage) { }
-        public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, System.Func<string> customMessage) { }
+        public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, string? customMessage) { }
+        public static void ShouldBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance) { }
-        public static void ShouldBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, string customMessage) { }
-        public static void ShouldBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, System.Func<string> customMessage) { }
+        public static void ShouldBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, string? customMessage) { }
+        public static void ShouldBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance) { }
-        public static void ShouldBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, string customMessage) { }
-        public static void ShouldBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, System.Func<string> customMessage) { }
-        public static void ShouldBe<T>(this T actual, T expected) { }
-        public static void ShouldBe<T>(this T actual, T expected, string customMessage) { }
-        public static void ShouldBe<T>(this T actual, T expected, System.Func<string> customMessage) { }
-        public static void ShouldBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, bool ignoreOrder = False) { }
-        public static void ShouldBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, bool ignoreOrder, string customMessage) { }
-        public static void ShouldBe<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, bool ignoreOrder, System.Func<string> customMessage) { }
+        public static void ShouldBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, string? customMessage) { }
+        public static void ShouldBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] T expected) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] T expected, string? customMessage) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] T expected, System.Func<string?>? customMessage) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this System.Collections.Generic.IEnumerable<T>? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] System.Collections.Generic.IEnumerable<T>? expected, bool ignoreOrder = False) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this System.Collections.Generic.IEnumerable<T>? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] System.Collections.Generic.IEnumerable<T>? expected, bool ignoreOrder, string? customMessage) { }
+        public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this System.Collections.Generic.IEnumerable<T>? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] System.Collections.Generic.IEnumerable<T>? expected, bool ignoreOrder, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance, string customMessage) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance, System.Func<string> customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance, string? customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<decimal> actual, System.Collections.Generic.IEnumerable<decimal> expected, decimal tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this float actual, float expected, double tolerance) { }
-        public static void ShouldBe(this float actual, float expected, double tolerance, string customMessage) { }
-        public static void ShouldBe(this float actual, float expected, double tolerance, System.Func<string> customMessage) { }
+        public static void ShouldBe(this float actual, float expected, double tolerance, string? customMessage) { }
+        public static void ShouldBe(this float actual, float expected, double tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<double> actual, System.Collections.Generic.IEnumerable<double> expected, double tolerance) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<double> actual, System.Collections.Generic.IEnumerable<double> expected, double tolerance, string customMessage) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<double> actual, System.Collections.Generic.IEnumerable<double> expected, double tolerance, System.Func<string> customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<double> actual, System.Collections.Generic.IEnumerable<double> expected, double tolerance, string? customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<double> actual, System.Collections.Generic.IEnumerable<double> expected, double tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this System.Collections.Generic.IEnumerable<float> actual, System.Collections.Generic.IEnumerable<float> expected, double tolerance) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<float> actual, System.Collections.Generic.IEnumerable<float> expected, double tolerance, string customMessage) { }
-        public static void ShouldBe(this System.Collections.Generic.IEnumerable<float> actual, System.Collections.Generic.IEnumerable<float> expected, double tolerance, System.Func<string> customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<float> actual, System.Collections.Generic.IEnumerable<float> expected, double tolerance, string? customMessage) { }
+        public static void ShouldBe(this System.Collections.Generic.IEnumerable<float> actual, System.Collections.Generic.IEnumerable<float> expected, double tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this double actual, double expected, double tolerance) { }
-        public static void ShouldBe(this double actual, double expected, double tolerance, string customMessage) { }
-        public static void ShouldBe(this double actual, double expected, double tolerance, System.Func<string> customMessage) { }
+        public static void ShouldBe(this double actual, double expected, double tolerance, string? customMessage) { }
+        public static void ShouldBe(this double actual, double expected, double tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance) { }
-        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, string customMessage) { }
-        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, System.Func<string> customMessage) { }
-        public static T ShouldBeAssignableTo<T>(this object actual) { }
-        public static T ShouldBeAssignableTo<T>(this object actual, string customMessage) { }
-        public static T ShouldBeAssignableTo<T>(this object actual, System.Func<string> customMessage) { }
-        public static void ShouldBeAssignableTo(this object actual, System.Type expected) { }
-        public static void ShouldBeAssignableTo(this object actual, System.Type expected, string customMessage) { }
-        public static void ShouldBeAssignableTo(this object actual, System.Type expected, System.Func<string> customMessage) { }
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected)
+        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, string? customMessage) { }
+        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, System.Func<string?>? customMessage) { }
+        public static T ShouldBeAssignableTo<T>(this object? actual) { }
+        public static T ShouldBeAssignableTo<T>(this object? actual, string? customMessage) { }
+        public static T ShouldBeAssignableTo<T>(this object? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeAssignableTo(this object? actual, System.Type expected) { }
+        public static void ShouldBeAssignableTo(this object? actual, System.Type expected, string? customMessage) { }
+        public static void ShouldBeAssignableTo(this object? actual, System.Type expected, System.Func<string?>? customMessage) { }
+        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer) { }
+        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
+        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string?>? customMessage) { }
+        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer) { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string?>? customMessage) { }
+        public static void ShouldBeGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to)
             where T : System.IComparable<T> { }
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected, string customMessage)
+        public static void ShouldBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to, string? customMessage)
             where T : System.IComparable<T> { }
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected, System.Func<string> customMessage)
+        public static void ShouldBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to, System.Func<string?>? customMessage)
             where T : System.IComparable<T> { }
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, string customMessage)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, System.Func<string> customMessage)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeInRange<T>(this T actual, T from, T to)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeInRange<T>(this T actual, T from, T to, string customMessage)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeInRange<T>(this T actual, T from, T to, System.Func<string> customMessage)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeLessThan<T>(this T actual, T expected)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeLessThan<T>(this T actual, T expected, string customMessage)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeLessThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
-        public static void ShouldBeLessThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
-        public static void ShouldBeLessThan<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
-        public static void ShouldBeLessThan<T>(this T actual, T expected, System.Func<string> customMessage)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, string customMessage)
-            where T : System.IComparable<T> { }
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer) { }
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, string customMessage) { }
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string> customMessage) { }
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, System.Func<string> customMessage)
-            where T : System.IComparable<T> { }
+        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer) { }
+        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
+        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string?>? customMessage) { }
+        public static void ShouldBeLessThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage)
+            where T : System.IComparable<T>? { }
+        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer) { }
+        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, string? customMessage) { }
+        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Collections.Generic.IComparer<T> comparer, System.Func<string?>? customMessage) { }
+        public static void ShouldBeLessThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage)
+            where T : System.IComparable<T>? { }
         public static void ShouldBeNegative(this decimal actual) { }
-        public static void ShouldBeNegative(this decimal actual, string customMessage) { }
-        public static void ShouldBeNegative(this decimal actual, System.Func<string> customMessage) { }
+        public static void ShouldBeNegative(this decimal actual, string? customMessage) { }
+        public static void ShouldBeNegative(this decimal actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeNegative(this double actual) { }
-        public static void ShouldBeNegative(this double actual, string customMessage) { }
-        public static void ShouldBeNegative(this double actual, System.Func<string> customMessage) { }
+        public static void ShouldBeNegative(this double actual, string? customMessage) { }
+        public static void ShouldBeNegative(this double actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeNegative(this float actual) { }
-        public static void ShouldBeNegative(this float actual, string customMessage) { }
-        public static void ShouldBeNegative(this float actual, System.Func<string> customMessage) { }
+        public static void ShouldBeNegative(this float actual, string? customMessage) { }
+        public static void ShouldBeNegative(this float actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeNegative(this int actual) { }
-        public static void ShouldBeNegative(this int actual, string customMessage) { }
-        public static void ShouldBeNegative(this int actual, System.Func<string> customMessage) { }
+        public static void ShouldBeNegative(this int actual, string? customMessage) { }
+        public static void ShouldBeNegative(this int actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeNegative(this long actual) { }
-        public static void ShouldBeNegative(this long actual, string customMessage) { }
-        public static void ShouldBeNegative(this long actual, System.Func<string> customMessage) { }
+        public static void ShouldBeNegative(this long actual, string? customMessage) { }
+        public static void ShouldBeNegative(this long actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeNegative(this short actual) { }
-        public static void ShouldBeNegative(this short actual, string customMessage) { }
-        public static void ShouldBeNegative(this short actual, System.Func<string> customMessage) { }
-        public static T ShouldBeOfType<T>(this object actual) { }
-        public static T ShouldBeOfType<T>(this object actual, string customMessage) { }
-        public static T ShouldBeOfType<T>(this object actual, System.Func<string> customMessage) { }
-        public static void ShouldBeOfType(this object actual, System.Type expected) { }
-        public static void ShouldBeOfType(this object actual, System.Type expected, string customMessage) { }
-        public static void ShouldBeOfType(this object actual, System.Type expected, System.Func<string> customMessage) { }
-        public static void ShouldBeOneOf<T>(this T actual, params T[] expected) { }
-        public static void ShouldBeOneOf<T>(this T actual, T[] expected, string customMessage) { }
-        public static void ShouldBeOneOf<T>(this T actual, T[] expected, System.Func<string> customMessage) { }
+        public static void ShouldBeNegative(this short actual, string? customMessage) { }
+        public static void ShouldBeNegative(this short actual, System.Func<string?>? customMessage) { }
+        public static T ShouldBeOfType<T>([System.Diagnostics.CodeAnalysis.NotNull] this object? actual) { }
+        public static T ShouldBeOfType<T>([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, string? customMessage) { }
+        public static T ShouldBeOfType<T>([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeOfType([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, System.Type expected) { }
+        public static void ShouldBeOfType([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, System.Type expected, string? customMessage) { }
+        public static void ShouldBeOfType([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, System.Type expected, System.Func<string?>? customMessage) { }
+        public static void ShouldBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, params T[] expected) { }
+        public static void ShouldBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, T[] expected, string? customMessage) { }
+        public static void ShouldBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, T[] expected, System.Func<string?>? customMessage) { }
         public static void ShouldBePositive(this decimal actual) { }
-        public static void ShouldBePositive(this decimal actual, string customMessage) { }
-        public static void ShouldBePositive(this decimal actual, System.Func<string> customMessage) { }
+        public static void ShouldBePositive(this decimal actual, string? customMessage) { }
+        public static void ShouldBePositive(this decimal actual, System.Func<string?>? customMessage) { }
         public static void ShouldBePositive(this double actual) { }
-        public static void ShouldBePositive(this double actual, string customMessage) { }
-        public static void ShouldBePositive(this double actual, System.Func<string> customMessage) { }
+        public static void ShouldBePositive(this double actual, string? customMessage) { }
+        public static void ShouldBePositive(this double actual, System.Func<string?>? customMessage) { }
         public static void ShouldBePositive(this float actual) { }
-        public static void ShouldBePositive(this float actual, string customMessage) { }
-        public static void ShouldBePositive(this float actual, System.Func<string> customMessage) { }
+        public static void ShouldBePositive(this float actual, string? customMessage) { }
+        public static void ShouldBePositive(this float actual, System.Func<string?>? customMessage) { }
         public static void ShouldBePositive(this int actual) { }
-        public static void ShouldBePositive(this int actual, string customMessage) { }
-        public static void ShouldBePositive(this int actual, System.Func<string> customMessage) { }
+        public static void ShouldBePositive(this int actual, string? customMessage) { }
+        public static void ShouldBePositive(this int actual, System.Func<string?>? customMessage) { }
         public static void ShouldBePositive(this long actual) { }
-        public static void ShouldBePositive(this long actual, string customMessage) { }
-        public static void ShouldBePositive(this long actual, System.Func<string> customMessage) { }
+        public static void ShouldBePositive(this long actual, string? customMessage) { }
+        public static void ShouldBePositive(this long actual, System.Func<string?>? customMessage) { }
         public static void ShouldBePositive(this short actual) { }
-        public static void ShouldBePositive(this short actual, string customMessage) { }
-        public static void ShouldBePositive(this short actual, System.Func<string> customMessage) { }
-        public static void ShouldBeSameAs(this object actual, object expected) { }
-        public static void ShouldBeSameAs(this object actual, object expected, string customMessage) { }
-        public static void ShouldBeSameAs(this object actual, object expected, System.Func<string> customMessage) { }
+        public static void ShouldBePositive(this short actual, string? customMessage) { }
+        public static void ShouldBePositive(this short actual, System.Func<string?>? customMessage) { }
+        public static void ShouldBeSameAs([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected) { }
+        public static void ShouldBeSameAs([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, string? customMessage) { }
+        public static void ShouldBeSameAs([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, System.Func<string?>? customMessage) { }
         public static void ShouldNotBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance) { }
-        public static void ShouldNotBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, string customMessage) { }
-        public static void ShouldNotBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, System.Func<string> customMessage) { }
+        public static void ShouldNotBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, string? customMessage) { }
+        public static void ShouldNotBe(this System.DateTime actual, System.DateTime expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldNotBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance) { }
-        public static void ShouldNotBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, string customMessage) { }
-        public static void ShouldNotBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, System.Func<string> customMessage) { }
+        public static void ShouldNotBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, string? customMessage) { }
+        public static void ShouldNotBe(this System.DateTimeOffset actual, System.DateTimeOffset expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
         public static void ShouldNotBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance) { }
-        public static void ShouldNotBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, string customMessage) { }
-        public static void ShouldNotBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, System.Func<string> customMessage) { }
-        public static void ShouldNotBe<T>(this T actual, T expected) { }
-        public static void ShouldNotBe<T>(this T actual, T expected, string customMessage) { }
-        public static void ShouldNotBe<T>(this T actual, T expected, System.Func<string> customMessage) { }
-        public static void ShouldNotBeAssignableTo<T>(this object actual) { }
-        public static void ShouldNotBeAssignableTo<T>(this object actual, string customMessage) { }
-        public static void ShouldNotBeAssignableTo<T>(this object actual, System.Func<string> customMessage) { }
-        public static void ShouldNotBeAssignableTo(this object actual, System.Type expected) { }
-        public static void ShouldNotBeAssignableTo(this object actual, System.Type expected, string customMessage) { }
-        public static void ShouldNotBeAssignableTo(this object actual, System.Type expected, System.Func<string> customMessage) { }
-        public static void ShouldNotBeInRange<T>(this T actual, T from, T to)
+        public static void ShouldNotBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, string? customMessage) { }
+        public static void ShouldNotBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected) { }
+        public static void ShouldNotBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, string? customMessage) { }
+        public static void ShouldNotBe<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeAssignableTo<T>(this object? actual) { }
+        public static void ShouldNotBeAssignableTo<T>(this object? actual, string? customMessage) { }
+        public static void ShouldNotBeAssignableTo<T>(this object? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeAssignableTo(this object? actual, System.Type expected) { }
+        public static void ShouldNotBeAssignableTo(this object? actual, System.Type expected, string? customMessage) { }
+        public static void ShouldNotBeAssignableTo(this object? actual, System.Type expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to)
             where T : System.IComparable<T> { }
-        public static void ShouldNotBeInRange<T>(this T actual, T from, T to, string customMessage)
+        public static void ShouldNotBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to, string? customMessage)
             where T : System.IComparable<T> { }
-        public static void ShouldNotBeInRange<T>(this T actual, T from, T to, System.Func<string> customMessage)
+        public static void ShouldNotBeInRange<T>([System.Diagnostics.CodeAnalysis.DisallowNull] this T actual, [System.Diagnostics.CodeAnalysis.AllowNull] T from, [System.Diagnostics.CodeAnalysis.AllowNull] T to, System.Func<string?>? customMessage)
             where T : System.IComparable<T> { }
-        public static void ShouldNotBeOfType<T>(this object actual) { }
-        public static void ShouldNotBeOfType<T>(this object actual, string customMessage) { }
-        public static void ShouldNotBeOfType<T>(this object actual, System.Func<string> customMessage) { }
-        public static void ShouldNotBeOfType(this object actual, System.Type expected) { }
-        public static void ShouldNotBeOfType(this object actual, System.Type expected, string customMessage) { }
-        public static void ShouldNotBeOfType(this object actual, System.Type expected, System.Func<string> customMessage) { }
-        public static void ShouldNotBeOneOf<T>(this T actual, params T[] expected) { }
-        public static void ShouldNotBeOneOf<T>(this T actual, T[] expected, string customMessage) { }
-        public static void ShouldNotBeOneOf<T>(this T actual, T[] expected, System.Func<string> customMessage) { }
-        public static void ShouldNotBeSameAs(this object actual, object expected) { }
-        public static void ShouldNotBeSameAs(this object actual, object expected, string customMessage) { }
-        public static void ShouldNotBeSameAs(this object actual, object expected, System.Func<string> customMessage) { }
+        public static void ShouldNotBeOfType<T>(this object? actual) { }
+        public static void ShouldNotBeOfType<T>(this object? actual, string? customMessage) { }
+        public static void ShouldNotBeOfType<T>(this object? actual, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeOfType(this object? actual, System.Type expected) { }
+        public static void ShouldNotBeOfType(this object? actual, System.Type expected, string? customMessage) { }
+        public static void ShouldNotBeOfType(this object? actual, System.Type expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, params T[] expected) { }
+        public static void ShouldNotBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, T[] expected, string? customMessage) { }
+        public static void ShouldNotBeOneOf<T>([System.Diagnostics.CodeAnalysis.AllowNull] this T actual, T[] expected, System.Func<string?>? customMessage) { }
+        public static void ShouldNotBeSameAs(this object? actual, object? expected) { }
+        public static void ShouldNotBeSameAs(this object? actual, object? expected, string? customMessage) { }
+        public static void ShouldNotBeSameAs(this object? actual, object? expected, System.Func<string?>? customMessage) { }
     }
     public class ShouldCompleteInException : Shouldly.ShouldlyTimeoutException
     {
-        public ShouldCompleteInException(string message, Shouldly.ShouldlyTimeoutException inner) { }
+        public ShouldCompleteInException(string? message, Shouldly.ShouldlyTimeoutException? inner) { }
     }
     public class ShouldMatchApprovedException : Shouldly.ShouldAssertException
     {
-        public ShouldMatchApprovedException(string message, string receivedFile, string approvedFile) { }
+        public ShouldMatchApprovedException(string? message, string? receivedFile, string? approvedFile) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldMatchApprovedTestExtensions
     {
         public static void ShouldMatchApproved(this string actual) { }
-        public static void ShouldMatchApproved(this string actual, string customMessage) { }
+        public static void ShouldMatchApproved(this string actual, string? customMessage) { }
         public static void ShouldMatchApproved(this string actual, System.Action<Shouldly.Configuration.ShouldMatchConfigurationBuilder> configureOptions) { }
         public static void ShouldMatchApproved(this string actual, string customMessage, System.Action<Shouldly.Configuration.ShouldMatchConfigurationBuilder> configureOptions) { }
-        public static void ShouldMatchApproved(this string actual, System.Func<string> customMessage, System.Action<Shouldly.Configuration.ShouldMatchConfigurationBuilder> configureOptions) { }
+        public static void ShouldMatchApproved(this string actual, System.Func<string?> customMessage, System.Action<Shouldly.Configuration.ShouldMatchConfigurationBuilder> configureOptions) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldSatisfyAllConditionsTestExtensions
     {
-        public static void ShouldSatisfyAllConditions(this object actual, params System.Action[] conditions) { }
-        public static void ShouldSatisfyAllConditions(this object actual, string customMessage, params System.Action[] conditions) { }
-        public static void ShouldSatisfyAllConditions(this object actual, System.Func<string> customMessage, params System.Action[] conditions) { }
+        public static void ShouldSatisfyAllConditions(this object? actual, params System.Action[] conditions) { }
+        public static void ShouldSatisfyAllConditions(this object? actual, string? customMessage, params System.Action[] conditions) { }
+        public static void ShouldSatisfyAllConditions(this object? actual, System.Func<string?>? customMessage, params System.Action[] conditions) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldThrowAsyncExtensions
     {
         public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task, string customMessage)
+        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task, string? customMessage)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task, System.Func<string> customMessage)
+        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Threading.Tasks.Task task, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Threading.Tasks.Task task, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Threading.Tasks.Task task, string customMessage, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Threading.Tasks.Task task, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Threading.Tasks.Task task, string? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Threading.Tasks.Task task, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Func<System.Threading.Tasks.Task> actual)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Func<System.Threading.Tasks.Task> actual, string customMessage)
+        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
             where TException : System.Exception { }
-        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string> customMessage)
+        public static System.Threading.Tasks.Task<TException> ShouldThrowAsync<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, string customMessage, System.Type exceptionType) { }
-        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Threading.Tasks.Task<System.Exception> ShouldThrowAsync(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldThrowExtensions
     {
         public static void ShouldNotThrow(this System.Action action) { }
-        public static void ShouldNotThrow(this System.Action action, string customMessage) { }
-        public static void ShouldNotThrow(this System.Action action, System.Func<string> customMessage) { }
+        public static void ShouldNotThrow(this System.Action action, string? customMessage) { }
+        public static void ShouldNotThrow(this System.Action action, System.Func<string?>? customMessage) { }
         public static T ShouldNotThrow<T>(this System.Func<T> action) { }
-        public static T ShouldNotThrow<T>(this System.Func<T> action, string customMessage) { }
-        public static T ShouldNotThrow<T>(this System.Func<T> action, System.Func<string> customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Func<T> action, string? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Func<T> action, System.Func<string?>? customMessage) { }
         public static TException ShouldThrow<TException>(this System.Action actual)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Action actual, string customMessage)
+        public static TException ShouldThrow<TException>(this System.Action actual, string? customMessage)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Action actual, System.Func<string> customMessage)
+        public static TException ShouldThrow<TException>(this System.Action actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Func<object> actual)
+        public static TException ShouldThrow<TException>(this System.Func<object?> actual)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Func<object> actual, string customMessage)
+        public static TException ShouldThrow<TException>(this System.Func<object?> actual, string? customMessage)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Func<object> actual, System.Func<string> customMessage)
+        public static TException ShouldThrow<TException>(this System.Func<object?> actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Exception ShouldThrow(this System.Action actual, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Action actual, string customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Action actual, System.Func<string> customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<object> actual, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<object> actual, string customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<object> actual, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Action actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Action actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<object?> actual, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<object?> actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<object?> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldThrowTaskExtensions
     {
         public static void ShouldNotThrow(this System.Threading.Tasks.Task action) { }
-        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, string customMessage) { }
-        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.Func<string> customMessage) { }
+        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, string? customMessage) { }
+        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.Func<string?>? customMessage) { }
         public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action) { }
-        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, string customMessage) { }
-        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.Func<string> customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, string? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.Func<string?>? customMessage) { }
         public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action) { }
-        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, string customMessage) { }
-        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.Func<string> customMessage) { }
+        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, string? customMessage) { }
+        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.Func<string?>? customMessage) { }
         public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter) { }
-        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, string customMessage) { }
-        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, System.Func<string> customMessage) { }
+        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static void ShouldNotThrow(this System.Threading.Tasks.Task action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter) { }
-        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, string customMessage) { }
-        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, System.Func<string> customMessage) { }
+        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static void ShouldNotThrow(this System.Func<System.Threading.Tasks.Task> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action) { }
-        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, string customMessage) { }
-        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.Func<string> customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, string? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.Func<string?>? customMessage) { }
         public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter) { }
-        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, string customMessage) { }
-        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, System.Func<string> customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Threading.Tasks.Task<T> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter) { }
-        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, string customMessage) { }
-        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, System.Func<string> customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, string? customMessage) { }
+        public static T ShouldNotThrow<T>(this System.Func<System.Threading.Tasks.Task<T>> action, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage) { }
         public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, string customMessage)
+        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, string? customMessage)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.Func<string> customMessage)
+        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, string customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, string customMessage)
+        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string> customMessage)
+        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, string customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string customMessage)
+        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string> customMessage)
+        public static TException ShouldThrow<TException>(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Threading.Tasks.Task actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
         public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string customMessage)
+        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage)
             where TException : System.Exception { }
-        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string> customMessage)
+        public static TException ShouldThrow<TException>(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage)
             where TException : System.Exception { }
         public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string customMessage, System.Type exceptionType) { }
-        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string> customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, string? customMessage, System.Type exceptionType) { }
+        public static System.Exception ShouldThrow(this System.Func<System.Threading.Tasks.Task> actual, System.TimeSpan timeoutAfter, System.Func<string?>? customMessage, System.Type exceptionType) { }
     }
     public static class ShouldlyConfiguration
     {
@@ -623,7 +635,7 @@ namespace Shouldly
     public class ShouldlyTimeoutException : System.TimeoutException
     {
         public ShouldlyTimeoutException() { }
-        public ShouldlyTimeoutException(string message, Shouldly.ShouldlyTimeoutException inner) { }
+        public ShouldlyTimeoutException(string? message, Shouldly.ShouldlyTimeoutException? inner) { }
         public override string StackTrace { get; }
     }
     public enum SortDirection
@@ -651,10 +663,10 @@ namespace Shouldly.Configuration
     public class DiffToolConfig
     {
         public DiffToolConfig() { }
-        public string LinuxPath { get; set; }
-        public string MacPath { get; set; }
-        public string WindowsPath { get; set; }
-        public string ResolvePath() { }
+        public string? LinuxPath { get; set; }
+        public string? MacPath { get; set; }
+        public string? WindowsPath { get; set; }
+        public string? ResolvePath() { }
     }
     public class DiffToolConfiguration
     {
@@ -682,7 +694,7 @@ namespace Shouldly.Configuration
         public DoNotLaunchWhenTypeIsLoaded(string typeName) { }
         public bool ShouldNotLaunch() { }
     }
-    public delegate string FilenameGenerator(Shouldly.Configuration.TestMethodInfo testMethodInfo, string descriminator, string fileType, string fileExtension);
+    public delegate string FilenameGenerator(Shouldly.Configuration.TestMethodInfo testMethodInfo, string? descriminator, string fileType, string fileExtension);
     public class FindMethodUsingAttribute<T> : Shouldly.Configuration.ITestMethodFinder
         where T : System.Attribute
     {
@@ -734,14 +746,14 @@ namespace Shouldly.Configuration
     {
         public ShouldMatchConfiguration() { }
         public ShouldMatchConfiguration(Shouldly.Configuration.ShouldMatchConfiguration initialConfig) { }
-        public string ApprovalFileSubFolder { get; set; }
-        public string FileExtension { get; set; }
-        public string FilenameDescriminator { get; set; }
-        public Shouldly.Configuration.FilenameGenerator FilenameGenerator { get; set; }
+        public string? ApprovalFileSubFolder { get; set; }
+        public string? FileExtension { get; set; }
+        public string? FilenameDescriminator { get; set; }
+        public Shouldly.Configuration.FilenameGenerator? FilenameGenerator { get; set; }
         public bool PreventDiff { get; set; }
-        public System.Func<string, string> Scrubber { get; set; }
+        public System.Func<string, string>? Scrubber { get; set; }
         public Shouldly.StringCompareShould StringCompareOptions { get; set; }
-        public Shouldly.Configuration.ITestMethodFinder TestMethodFinder { get; set; }
+        public Shouldly.Configuration.ITestMethodFinder? TestMethodFinder { get; set; }
     }
     public class ShouldMatchConfigurationBuilder
     {
@@ -763,9 +775,9 @@ namespace Shouldly.Configuration
     public class TestMethodInfo
     {
         public TestMethodInfo(System.Diagnostics.StackFrame callingFrame) { }
-        public string DeclaringTypeName { get; }
-        public string MethodName { get; }
-        public string SourceFileDirectory { get; }
+        public string? DeclaringTypeName { get; }
+        public string? MethodName { get; }
+        public string? SourceFileDirectory { get; }
     }
 }
 namespace Shouldly.ShouldlyExtensionMethods
@@ -774,10 +786,10 @@ namespace Shouldly.ShouldlyExtensionMethods
     public static class ShouldHaveEnumExtensions
     {
         public static void ShouldHaveFlag(this System.Enum actual, System.Enum expectedFlag) { }
-        public static void ShouldHaveFlag(this System.Enum actual, System.Enum expectedFlag, string customMessage) { }
-        public static void ShouldHaveFlag(this System.Enum actual, System.Enum expectedFlag, System.Func<string> customMessage) { }
+        public static void ShouldHaveFlag(this System.Enum actual, System.Enum expectedFlag, string? customMessage) { }
+        public static void ShouldHaveFlag(this System.Enum actual, System.Enum expectedFlag, System.Func<string?>? customMessage) { }
         public static void ShouldNotHaveFlag(this System.Enum actual, System.Enum expectedFlag) { }
-        public static void ShouldNotHaveFlag(this System.Enum actual, System.Enum expectedFlag, string customMessage) { }
-        public static void ShouldNotHaveFlag(this System.Enum actual, System.Enum expectedFlag, System.Func<string> customMessage) { }
+        public static void ShouldNotHaveFlag(this System.Enum actual, System.Enum expectedFlag, string? customMessage) { }
+        public static void ShouldNotHaveFlag(this System.Enum actual, System.Enum expectedFlag, System.Func<string?>? customMessage) { }
     }
 }

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -747,13 +747,13 @@ namespace Shouldly.Configuration
         public ShouldMatchConfiguration() { }
         public ShouldMatchConfiguration(Shouldly.Configuration.ShouldMatchConfiguration initialConfig) { }
         public string? ApprovalFileSubFolder { get; set; }
-        public string? FileExtension { get; set; }
+        public string FileExtension { get; set; }
         public string? FilenameDescriminator { get; set; }
-        public Shouldly.Configuration.FilenameGenerator? FilenameGenerator { get; set; }
+        public Shouldly.Configuration.FilenameGenerator FilenameGenerator { get; set; }
         public bool PreventDiff { get; set; }
         public System.Func<string, string>? Scrubber { get; set; }
         public Shouldly.StringCompareShould StringCompareOptions { get; set; }
-        public Shouldly.Configuration.ITestMethodFinder? TestMethodFinder { get; set; }
+        public Shouldly.Configuration.ITestMethodFinder TestMethodFinder { get; set; }
     }
     public class ShouldMatchConfigurationBuilder
     {

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.cs
@@ -1,3 +1,5 @@
+using PublicApiGenerator;
+
 namespace Shouldly.Tests.ConventionTests
 {
     public class ApprovePublicApi
@@ -5,7 +7,11 @@ namespace Shouldly.Tests.ConventionTests
         [IgnoreOnAppVeyorLinuxFact]
         public void ShouldlyApi()
         {
-            var publicApi = PublicApiGenerator.ApiGenerator.GeneratePublicApi(typeof(Should).Assembly, null,false);
+            var publicApi = typeof(Should).Assembly.GeneratePublicApi(new ApiGeneratorOptions
+            {
+                IncludeAssemblyAttributes = false
+            });
+
             publicApi.ShouldMatchApproved(b => b.WithFileExtension("cs"));
         }
     }

--- a/src/Shouldly.Tests/ConventionTests/ShouldThrowMethod.cs
+++ b/src/Shouldly.Tests/ConventionTests/ShouldThrowMethod.cs
@@ -30,7 +30,7 @@ namespace Shouldly.Tests.ConventionTests
             return pt1.FormatType() == pt2.FormatType();
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;

--- a/src/Shouldly.Tests/Dictionaries/ShouldContainKeyAndValue.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldContainKeyAndValue.cs
@@ -158,7 +158,7 @@ Additional Info:
         [Fact]
         public void ValueIsNullShouldFail()
         {
-            var dictionaryWithNullValue = new Dictionary<MyThing, MyThing>
+            var dictionaryWithNullValue = new Dictionary<MyThing, MyThing?>
             {
                 {ThingKey, null}
             };

--- a/src/Shouldly.Tests/Dictionaries/ShouldNotContainValueForKey.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldNotContainValueForKey.cs
@@ -156,7 +156,7 @@ Additional Info:
         [Fact]
         public void ValueIsNullShouldFail()
         {
-            var dictionary = new Dictionary<MyThing, MyThing>
+            var dictionary = new Dictionary<MyThing, MyThing?>
             {
                 {ThingKey, null}
             };

--- a/src/Shouldly.Tests/DynamicShould/HavePropertyNonDynamicScenario.cs
+++ b/src/Shouldly.Tests/DynamicShould/HavePropertyNonDynamicScenario.cs
@@ -7,7 +7,7 @@ namespace Shouldly.Tests.DynamicShould
     {
         class Foo
         {
-            public string Bar { get; set; }
+            public string? Bar { get; set; }
         }
 
         [Fact]

--- a/src/Shouldly.Tests/InternalTests/DifferenceHighlighterHelpersTests.cs
+++ b/src/Shouldly.Tests/InternalTests/DifferenceHighlighterHelpersTests.cs
@@ -151,9 +151,10 @@ namespace Shouldly.Tests.InternalTests
                 return _description;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
-                return _description == ((EqualType)obj)._description;
+                return obj is EqualType other
+                    && _description == other._description;
             }
 
             public override int GetHashCode()

--- a/src/Shouldly.Tests/InternalTests/EqualityComparerTests.cs
+++ b/src/Shouldly.Tests/InternalTests/EqualityComparerTests.cs
@@ -6,7 +6,7 @@ namespace Shouldly.Tests.InternalTests
 {
     public class EqualityComparerTests
     {
-        /* 
+        /*
          * Code heavily influenced by code from xunit assertion tests
          * at https://github.com/xunit/xunit/blob/master/test/test.xunit2.assert/Asserts/EqualityAssertsTests.cs
          */
@@ -53,7 +53,7 @@ namespace Shouldly.Tests.InternalTests
         {
             var eq1 = new SpyEquatable();
             var eq2 = new SpyEquatable();
-            
+
             eq1.ShouldBe(eq2);
             eq2.EqualsCalled.ShouldBe(true);
             eq2.EqualsOther.ShouldBeSameAs(eq1);
@@ -61,7 +61,7 @@ namespace Shouldly.Tests.InternalTests
 
         class NonComparableObject
         {
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return true;
             }
@@ -74,7 +74,7 @@ namespace Shouldly.Tests.InternalTests
 
         class SpyComparable : IComparable
         {
-            public int CompareTo(object obj)
+            public int CompareTo(object? obj)
             {
                 return 0;
             }
@@ -94,7 +94,7 @@ namespace Shouldly.Tests.InternalTests
         public class SpyEquatable : IEquatable<SpyEquatable>
         {
             public bool EqualsCalled;
-            public SpyEquatable EqualsOther;
+            public SpyEquatable? EqualsOther;
 
             public bool Equals(SpyEquatable other)
             {

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/DocsExample.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/DocsExample.cs
@@ -26,9 +26,9 @@ namespace Shouldly.Tests.ShouldBe.EnumerableType
 
         class Person
         {
-            public string Name { get; set; }
+            public string? Name { get; set; }
 
-            public override string ToString()
+            public override string? ToString()
             {
                 return Name;
             }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderOnNonNullableTypesScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderOnNonNullableTypesScenario.cs
@@ -85,7 +85,7 @@ Additional Info:
                 return identity == other.identity;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 if (ReferenceEquals(null, obj)) return false;
                 return obj is NonNullableType && Equals((NonNullableType) obj);

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderWhenItemsAreNotComparableScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderWhenItemsAreNotComparableScenario.cs
@@ -82,14 +82,14 @@ Additional Info:
                 this.identity = identity;
             }
 
-            protected bool Equals(YourAverageNonComparableType other)
+            protected bool Equals(YourAverageNonComparableType? other)
             {
                 if (ReferenceEquals(null, other)) return false;
                 if (ReferenceEquals(this, other)) return true;
                 return string.Equals(identity, other.identity);
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return Equals(obj as YourAverageNonComparableType);
             }

--- a/src/Shouldly.Tests/ShouldBe/ShouldBeEnumerableTypeScenarios.cs
+++ b/src/Shouldly.Tests/ShouldBe/ShouldBeEnumerableTypeScenarios.cs
@@ -172,7 +172,7 @@ Additional Info:
         [Fact]
         public void ActualIsNullScenario()
         {
-            IEnumerable<int> something = null;
+            IEnumerable<int>? something = null;
             // ReSharper disable once ExpressionIsAlwaysNull
             Verify.ShouldFail(() =>
 something.ShouldBe(new[] { 1, 2, 3 }, "Some additional context"),

--- a/src/Shouldly.Tests/ShouldBe/ShouldBeScenarios.cs
+++ b/src/Shouldly.Tests/ShouldBe/ShouldBeScenarios.cs
@@ -171,7 +171,7 @@ Additional Info:
         [Fact]
         public void ActualIsNullScenario()
         {
-            string nullString = null;
+            string? nullString = null;
 
             // ReSharper disable once ExpressionIsAlwaysNull
             Verify.ShouldFail(() =>
@@ -421,7 +421,7 @@ Additional Info:
             public bool EqualsResult { private get; set; }
 
             // ReSharper disable once CSharpWarnings::CS0659
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return EqualsResult;
             }

--- a/src/Shouldly.Tests/ShouldBeAssignableTo/NullIsAssignableToTypeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeAssignableTo/NullIsAssignableToTypeScenario.cs
@@ -10,7 +10,7 @@ namespace Shouldly.Tests.ShouldBeAssignableTo
         [Fact]
         public void ShouldThrowWhenNullPassedToShouldBeAssignableValueType()
         {
-            MyThing myThing = null;            
+            MyThing? myThing = null;
             // ReSharper disable once ExpressionIsAlwaysNull
             Verify.ShouldFail(() =>
             myThing.ShouldBeAssignableTo<int>("Some additional context"),
@@ -38,7 +38,7 @@ Additional Info:
         [Fact]
         public void ShouldPass()
         {
-            MyThing myThing = null;
+            MyThing? myThing = null;
             myThing.ShouldBeAssignableTo<MyBase>("Some additional context");
         }
     }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
@@ -6,9 +6,9 @@ namespace Shouldly.Tests.ShouldBeEquivalentTo
     public class FakeObject
     {
         public int Id { get; set; }
-        public string Name { get; set; }
-        public FakeObject Child { get; set; }
-        public ICollection<string> Colors { get; set; }
-        public IEnumerable Adjectives { get; set; }
+        public string? Name { get; set; }
+        public FakeObject? Child { get; set; }
+        public ICollection<string>? Colors { get; set; }
+        public IEnumerable? Adjectives { get; set; }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/NullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/NullScenario.cs
@@ -8,7 +8,7 @@ namespace Shouldly.Tests.ShouldBeEquivalentTo
         [Fact]
         public void ShouldFailWhenActualIsNull()
         {
-            string subject = null;
+            string? subject = null;
             Verify.ShouldFail(() =>
 subject.ShouldBeEquivalentTo("Hello", "Some additional context"),
 
@@ -72,7 +72,7 @@ Additional Info:
         [Fact]
         public void ShouldPassWhenBothAreNull()
         {
-            string subject = null;
+            string? subject = null;
             subject.ShouldBeEquivalentTo(null);
         }
     }

--- a/src/Shouldly.Tests/ShouldBeGreaterThan/StringVsNullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeGreaterThan/StringVsNullScenario.cs
@@ -9,10 +9,10 @@ namespace Shouldly.Tests.ShouldBeGreaterThan
         public void StringVsNullScenarioShouldFail()
         {
             Verify.ShouldFail(() =>
-((string)null).ShouldBeGreaterThan("b", "Some additional context"),
+((string?)null).ShouldBeGreaterThan("b", "Some additional context"),
 
 errorWithSource:
-@"(string)null
+@"(string?)null
     should be greater than
 ""b""
     but was

--- a/src/Shouldly.Tests/ShouldBeLessThan/StringVsNullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeLessThan/StringVsNullScenario.cs
@@ -35,7 +35,7 @@ Additional Info:
         [Fact]
         public void ShouldPass()
         {
-            ((string)null).ShouldBeLessThan("b");
+            ((string?)null).ShouldBeLessThan("b");
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeNull/NotNullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeNull/NotNullScenario.cs
@@ -8,7 +8,7 @@ namespace Shouldly.Tests.ShouldBeNull
         [Fact]
         public void NotNullScenarioShouldFail()
         {
-            string myNullRef = null;
+            string? myNullRef = null;
             // ReSharper disable once ExpressionIsAlwaysNull
             Verify.ShouldFail(() =>
 myNullRef.ShouldNotBeNull("Some additional context"),

--- a/src/Shouldly.Tests/ShouldBeNull/NullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeNull/NullScenario.cs
@@ -31,7 +31,7 @@ Additional Info:
         [Fact]
         public void ShouldPass()
         {
-            ((string)null).ShouldBeNull();
+            ((string?)null).ShouldBeNull();
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeOfType/ActualIsNullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeOfType/ActualIsNullScenario.cs
@@ -9,7 +9,7 @@ namespace Shouldly.Tests.ShouldBeOfType
         [Fact]
         public void ActualIsNullScenarioShouldFail()
         {
-            MyThing myThing = null;
+            MyThing? myThing = null;
             // ReSharper disable once ExpressionIsAlwaysNull
             Verify.ShouldFail(() =>
 myThing.ShouldBeOfType<MyBase>("Some additional context"),

--- a/src/Shouldly.Tests/ShouldContain/PredicateObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/PredicateObjectScenario.cs
@@ -13,7 +13,7 @@ namespace Shouldly.Tests.ShouldContain
             var c = new object();
 
             Verify.ShouldFail(() =>
-new[] { a, b, c }.ShouldContain(o => o.GetType().FullName.Equals(""), "Some additional context"),
+new[] { a, b, c }.ShouldContain(o => o.GetType().FullName!.Equals(""), "Some additional context"),
 
 errorWithSource:
 @"new[] { a, b, c }
@@ -40,7 +40,7 @@ Additional Info:
             var a = new object();
             var b = new object();
             var c = new object();
-            new[] { a, b, c }.ShouldContain(o => o.GetType().FullName.Equals("System.Object"));
+            new[] { a, b, c }.ShouldContain(o => o.GetType().FullName!.Equals("System.Object"));
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
+++ b/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
@@ -107,8 +107,8 @@ Actual Code    | 70   111  111  ",
         public void NoDiffToolsFound()
         {
             var diffTools = ShouldlyConfiguration.DiffTools.GetType()
-                .GetField("_diffTools", BindingFlags.Instance | BindingFlags.NonPublic);
-            var diffToolsCollection = (List<DiffTool>)diffTools.GetValue(ShouldlyConfiguration.DiffTools);
+                .GetField("_diffTools", BindingFlags.Instance | BindingFlags.NonPublic)!;
+            var diffToolsCollection = (List<DiffTool>)diffTools.GetValue(ShouldlyConfiguration.DiffTools)!;
             var currentDiffTools = new List<DiffTool>(diffToolsCollection);
 
             try
@@ -129,7 +129,7 @@ In the meantime use 'ShouldlyConfiguration.DiffTools.RegisterDiffTool()' to add 
         public void IgnoresLineEndingsByDefault()
         {
             var stacktrace = new StackTrace(true);
-            var sourceFileDir = Path.GetDirectoryName(stacktrace.GetFrame(0).GetFileName());
+            var sourceFileDir = Path.GetDirectoryName(stacktrace.GetFrame(0)!.GetFileName())!;
             var approved = Path.Combine(sourceFileDir, "ShouldMatchApprovedScenarios.IgnoresLineEndingsByDefault.approved.txt");
             File.WriteAllText(approved, "Different\nStyle\nLine\nBreaks");
 

--- a/src/Shouldly.Tests/ShouldNotBeOfType/NullScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBeOfType/NullScenario.cs
@@ -3,13 +3,13 @@
 namespace Shouldly.Tests.ShouldNotBeOfType
 {
     public class NullIsNotOfType
-   
+
     {
 
     [Fact]
         public void AndShouldNotThrow()
         {
-            object o = null;
+            object? o = null;
             o.ShouldNotBeOfType<int>("Some additional context");
         }
 

--- a/src/Shouldly.Tests/ShouldNotContain/PredicateObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/PredicateObjectScenario.cs
@@ -13,7 +13,7 @@ namespace Shouldly.Tests.ShouldNotContain
             var b = new object();
             var c = new object();
             Verify.ShouldFail(() =>
-new[] { a, b, c }.ShouldNotContain(o => o.GetType().FullName.Equals("System.Object"),
+new[] { a, b, c }.ShouldNotContain(o => o.GetType().FullName!.Equals("System.Object"),
                 "Some additional context"),
 
 errorWithSource:
@@ -41,7 +41,7 @@ Additional Info:
             var a = new Object();
             var b = new Object();
             var c = new Object();
-            new[] { a, b, c }.ShouldNotContain(o => o.GetType().FullName.Equals(""));
+            new[] { a, b, c }.ShouldNotContain(o => o.GetType().FullName!.Equals(""));
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
@@ -51,5 +51,31 @@ Additional Info:
 
             task.ShouldNotThrow();
         }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void ShouldHandleAggregateExceptionWithNoInnerExceptions(bool withSynchronizationContext)
+        {
+            var func = new Func<Task>(() => throw new AggregateException("Message from thrown exception"));
+
+            if (!withSynchronizationContext)
+                SynchronizationContext.SetSynchronizationContext(null);
+
+            Verify.ShouldFail(
+                () => func.ShouldNotThrow(),
+                errorWithSource:
+@"Task `func`
+    should not throw but threw
+System.AggregateException
+    with message
+""Message from thrown exception""",
+                errorWithoutSource:
+@"Task
+    should not throw but threw
+System.AggregateException
+    with message
+""Message from thrown exception""");
+        }
     }
 }

--- a/src/Shouldly.Tests/ShouldNotThrow/NestedAwaitsDoNotDeadlockScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/NestedAwaitsDoNotDeadlockScenario.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace Shouldly.Tests.ShouldNotThrow
 {
     public class NestedAwaitsDoNotDeadlockScenario
-   
+
     {
 
     [Fact]
@@ -17,12 +17,12 @@ namespace Shouldly.Tests.ShouldNotThrow
             var synchronizationContext = new SynchronizationContext();
             SynchronizationContext.SetSynchronizationContext(synchronizationContext);
             SynchronizationContext.Current.ShouldNotBe(null);
-            
-            var syncFunc1 = new Func<Task<object>>(() =>
+
+            var syncFunc1 = new Func<Task<object?>>(() =>
             {
                 SynchronizationContext.Current.ShouldBe(null);
 
-                var taskCompletionSource = new TaskCompletionSource<object>();
+                var taskCompletionSource = new TaskCompletionSource<object?>();
                 taskCompletionSource.SetResult(null);
                 return taskCompletionSource.Task;
             });
@@ -32,7 +32,7 @@ namespace Shouldly.Tests.ShouldNotThrow
             {
                 SynchronizationContext.Current.ShouldBe(null);
 
-                var taskCompletionSource = new TaskCompletionSource<object>();
+                var taskCompletionSource = new TaskCompletionSource<object?>();
                 taskCompletionSource.SetResult(null);
                 return taskCompletionSource.Task;
             });

--- a/src/Shouldly.Tests/ShouldThrow/FuncOfTaskWhichThrowsDirectlyScenario.cs
+++ b/src/Shouldly.Tests/ShouldThrow/FuncOfTaskWhichThrowsDirectlyScenario.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Shouldly.Tests.Strings;
+using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -36,19 +38,53 @@ namespace Shouldly.Tests.ShouldThrow
             var task = new Func<Task>(() => { throw new TimeoutException(); });
             task.ShouldThrow(typeof(TimeoutException));
         }
-        
+
         [Fact]
         public void ShouldPassTimeoutExceptionAsync()
         {
             var task = new Func<Task>(async () => { throw new TimeoutException(); });
             task.ShouldThrow<TimeoutException>();
         }
-       
+
         [Fact]
         public void ShouldPassTimeoutExceptionAsync_ExceptionTypePassedIn()
         {
             var task = new Func<Task>(async () => { throw new TimeoutException(); });
             task.ShouldThrow(typeof(TimeoutException));
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void ShouldHandleAggregateExceptionWithNoInnerExceptions(bool withSynchronizationContext, bool useGenericOverload)
+        {
+            var func = new Func<Task>(() => throw new AggregateException());
+
+            if (!withSynchronizationContext)
+                SynchronizationContext.SetSynchronizationContext(null);
+
+            Verify.ShouldFail(
+                () =>
+                {
+                    if (useGenericOverload)
+                        func.ShouldThrow<InvalidOperationException>();
+                    else
+                        func.ShouldThrow(typeof(InvalidOperationException));
+                },
+                errorWithSource:
+@"Task `func`
+    should throw
+System.InvalidOperationException
+    but threw
+System.AggregateException",
+                errorWithoutSource:
+@"Task
+    should throw
+System.InvalidOperationException
+    but threw
+System.AggregateException");
         }
     }
 }

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="PublicApiGenerator" Version="9.0.0" />
+    <PackageReference Include="PublicApiGenerator" Version="9.2.0" />
     <PackageReference Include="TestStack.ConventionTests" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="PublicApiGenerator" Version="10.0.0-beta3" />
+    <PackageReference Include="PublicApiGenerator" Version="10.0.0" />
     <PackageReference Include="TestStack.ConventionTests" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net472;</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
     <Optimize>false</Optimize>
     <DebugType Condition=" '$(OS)' == 'Windows_NT' ">full</DebugType>
   </PropertyGroup>

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="PublicApiGenerator" Version="8.0.1" />
+    <PackageReference Include="PublicApiGenerator" Version="9.0.0" />
     <PackageReference Include="TestStack.ConventionTests" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="PublicApiGenerator" Version="9.2.0" />
+    <PackageReference Include="PublicApiGenerator" Version="10.0.0-beta3" />
     <PackageReference Include="TestStack.ConventionTests" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/src/Shouldly.Tests/StackTraceTests.ExceptionThrower.cs
+++ b/src/Shouldly.Tests/StackTraceTests.ExceptionThrower.cs
@@ -23,7 +23,7 @@ namespace Shouldly.Tests
                     ExceptionType.Name + " thrown directly";
             }
 
-            public Exception Catch()
+            public Exception? Catch()
             {
                 // Don’t rely on a framework for this in case of the outside chance that the framework manipulates the stack trace.
                 try

--- a/src/Shouldly.Tests/StackTraceTests.cs
+++ b/src/Shouldly.Tests/StackTraceTests.cs
@@ -12,9 +12,9 @@ namespace Shouldly.Tests
         [MemberData(nameof(ExceptionThrowers))]
         public static void Top_stack_frame_is_user_code(ExceptionThrower exceptionThrower)
         {
-            var exception = exceptionThrower.Catch();
+            var exception = exceptionThrower.Catch()!;
 
-            var stackTraceLines = exception.StackTrace.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            var stackTraceLines = exception.StackTrace!.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
 
             stackTraceLines.First().ShouldContain(exceptionThrower.ThrowingAction.Method.Name);
         }
@@ -23,11 +23,11 @@ namespace Shouldly.Tests
         [MemberData(nameof(ExceptionThrowers))]
         public static void Stack_trace_is_trimmed_the_same_as_default_exception_stack_traces(ExceptionThrower exceptionThrower)
         {
-            var shouldlyException = exceptionThrower.Catch();
-            var defaultException = new ExceptionThrower(typeof(Exception), false, () => throw new Exception()).Catch();
+            var shouldlyException = exceptionThrower.Catch()!;
+            var defaultException = new ExceptionThrower(typeof(Exception), false, () => throw new Exception()).Catch()!;
 
-            var shouldlyEndingWhitespace = GetEndingWhitespace(shouldlyException.StackTrace);
-            var defaultEndingWhitespace = GetEndingWhitespace(defaultException.StackTrace);
+            var shouldlyEndingWhitespace = GetEndingWhitespace(shouldlyException.StackTrace!);
+            var defaultEndingWhitespace = GetEndingWhitespace(defaultException.StackTrace!);
 
             shouldlyEndingWhitespace.ShouldBe(defaultEndingWhitespace);
         }

--- a/src/Shouldly.Tests/Strings/DetailedDifference/CaseInsensitive/NullScenario.cs
+++ b/src/Shouldly.Tests/Strings/DetailedDifference/CaseInsensitive/NullScenario.cs
@@ -7,7 +7,7 @@ namespace Shouldly.Tests.Strings.DetailedDifference.CaseInsensitive
         [Fact]
         public static void ShouldNotShowDifferenceWhenActualIsMissing()
         {
-            var str = (string)null;
+            var str = (string?)null;
             Verify.ShouldFail(() =>
 str.ShouldBe("null", StringCompareShould.IgnoreCase),
 

--- a/src/Shouldly.Tests/Strings/DetailedDifference/CaseSensitive/NullScenario.cs
+++ b/src/Shouldly.Tests/Strings/DetailedDifference/CaseSensitive/NullScenario.cs
@@ -7,7 +7,7 @@ namespace Shouldly.Tests.Strings.DetailedDifference.CaseSensitive
         [Fact]
         public static void ShouldNotShowDifferenceWhenActualIsMissing()
         {
-            var str = (string)null;
+            var str = (string?)null;
             Verify.ShouldFail(() =>
 str.ShouldBe("null"),
 

--- a/src/Shouldly.Tests/Strings/ShouldBeEmpty/ActualIsNull.cs
+++ b/src/Shouldly.Tests/Strings/ShouldBeEmpty/ActualIsNull.cs
@@ -7,7 +7,8 @@ namespace Shouldly.Tests.Strings.ShouldBeEmpty
         [Fact]
         public void ActualIsNullShouldFail()
         {
-            var str = ((string)null);
+            var str = (string?)null;
+
             Verify.ShouldFail(() =>
 str.ShouldBeEmpty("Some additional context"),
 

--- a/src/Shouldly.Tests/Strings/ShouldBeNullOrEmpty.cs
+++ b/src/Shouldly.Tests/Strings/ShouldBeNullOrEmpty.cs
@@ -43,7 +43,7 @@ Additional Info:
         [Fact]
         public void ShouldPass()
         {
-            ((string)null).ShouldBeNullOrEmpty();
+            ((string?)null).ShouldBeNullOrEmpty();
             string.Empty.ShouldBeNullOrEmpty();
         }
     }

--- a/src/Shouldly.Tests/Strings/ShouldBeNullOrWhitespace.cs
+++ b/src/Shouldly.Tests/Strings/ShouldBeNullOrWhitespace.cs
@@ -3,7 +3,7 @@
 namespace Shouldly.Tests.Strings
 {
     public class ShouldBeNullOrWhiteSpace
-   
+
     {
 
     [Fact]
@@ -13,7 +13,7 @@ namespace Shouldly.Tests.Strings
             () =>
 "a".ShouldBeNullOrWhiteSpace("Some additional context"),
 
-errorWithSource: 
+errorWithSource:
 @"""a""
     should be null or white space
 
@@ -54,7 +54,7 @@ Additional Info:
         [Fact]
         public void NullShouldPass()
         {
-            ((string)null).ShouldBeNullOrWhiteSpace();
+            ((string?)null).ShouldBeNullOrWhiteSpace();
         }
 
         [Fact]

--- a/src/Shouldly.Tests/Strings/ShouldContainWithoutWhitespace.cs
+++ b/src/Shouldly.Tests/Strings/ShouldContainWithoutWhitespace.cs
@@ -37,5 +37,22 @@ Additional Info:
         {
             "Fun   with space   and \"quotes\"".ShouldContainWithoutWhitespace("Fun with space and 'quotes'");
         }
+
+        [Fact]
+        public void ShouldExpectUppercaseNullTextWhenExpectedIsNull()
+        {
+            "NULL".ShouldContainWithoutWhitespace(null);
+        }
+
+        [Fact]
+        public void ShouldExpectUppercaseNullTextWhenExpectedIsInstanceWithNullToString()
+        {
+            "NULL".ShouldContainWithoutWhitespace(new InstanceWithNullToString());
+        }
+
+        private sealed class InstanceWithNullToString
+        {
+            public override string? ToString() => null;
+        }
     }
 }

--- a/src/Shouldly.Tests/Strings/Verify.cs
+++ b/src/Shouldly.Tests/Strings/Verify.cs
@@ -8,12 +8,12 @@ namespace Shouldly.Tests.Strings
     {
         static readonly Regex MatchGetHashCode = new Regex("\\(\\d{5,8}\\)");
 
-        public static void ShouldFail(Action action, string errorWithSource, string errorWithoutSource, Func<string, string> messageScrubber = null)
+        public static void ShouldFail(Action action, string errorWithSource, string errorWithoutSource, Func<string, string>? messageScrubber = null)
         {
             if (messageScrubber == null)
                 messageScrubber = v =>
                 {
-                    
+
                     var msg = MatchGetHashCode.Replace(v, "(000000)");
                     return msg;
                 };

--- a/src/Shouldly.Tests/TestHelpers/CustomComparerClass.cs
+++ b/src/Shouldly.Tests/TestHelpers/CustomComparerClass.cs
@@ -6,8 +6,8 @@ namespace Shouldly.Tests.TestHelpers
     {
         public int Compare(T x, T y)
         {
-            Custom x1 = x as Custom;
-            Custom x2 = y as Custom;
+            Custom x1 = (Custom)(object)x!;
+            Custom x2 = (Custom)(object)y!;
             if (x1.Val == x2.Val)
                 return 0;
             return x1.Val > x2.Val ? 1 : -1;

--- a/src/Shouldly.Tests/TestHelpers/Strange.cs
+++ b/src/Shouldly.Tests/TestHelpers/Strange.cs
@@ -5,7 +5,7 @@ namespace Shouldly.Tests.TestHelpers
 {
     internal class Strange : IEnumerable<Strange>
     {
-        readonly string _thing;
+        readonly string? _thing;
 
         public Strange()
         {
@@ -36,7 +36,7 @@ namespace Shouldly.Tests.TestHelpers
             return string.Equals(_thing, other._thing);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;

--- a/src/Shouldly.Tests/TestHelpers/UseCultureAttribute.cs
+++ b/src/Shouldly.Tests/TestHelpers/UseCultureAttribute.cs
@@ -17,8 +17,8 @@ namespace Shouldly.Tests.TestHelpers
         private readonly Lazy<CultureInfo> _culture;
         private readonly Lazy<CultureInfo> _uiCulture;
 
-        private CultureInfo _originalCulture;
-        private CultureInfo _originalUiCulture;
+        private CultureInfo? _originalCulture;
+        private CultureInfo? _originalUiCulture;
 
         /// <summary>
         /// Replaces the culture and UI culture of the current thread with
@@ -78,8 +78,8 @@ namespace Shouldly.Tests.TestHelpers
         /// <param name="methodUnderTest">The method under test</param>
         public override void After(MethodInfo methodUnderTest)
         {
-            Thread.CurrentThread.CurrentCulture = _originalCulture;
-            Thread.CurrentThread.CurrentUICulture = _originalUiCulture;
+            Thread.CurrentThread.CurrentCulture = _originalCulture!;
+            Thread.CurrentThread.CurrentUICulture = _originalUiCulture!;
         }
     }
 }

--- a/src/Shouldly.Tests/TestHelpers/Widget.cs
+++ b/src/Shouldly.Tests/TestHelpers/Widget.cs
@@ -5,11 +5,11 @@ namespace Shouldly.Tests.TestHelpers
     public class Widget
     {
         public bool Enabled { get; set; }
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         public override string ToString()
         {
             return String.Format("Name({0}) Enabled({1})", Name, Enabled);
-        }    
+        }
     }
 }

--- a/src/Shouldly.sln
+++ b/src/Shouldly.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26228.12
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29326.143
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{70055B25-BE01-4932-84F1-A0BE47A93BFC}"
 	ProjectSection(SolutionItems) = preProject
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\build.ps1 = ..\build.ps1
 		..\deploy.cake = ..\deploy.cake
 		..\deploy.ps1 = ..\deploy.ps1
+		Directory.Build.props = Directory.Build.props
 		..\GitVersionConfig.yaml = ..\GitVersionConfig.yaml
 		..\global.json = ..\global.json
 		..\mkdocs.yml = ..\mkdocs.yml
@@ -53,5 +54,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B0D6A39B-FF04-4482-8D01-B8A590A3158B}
 	EndGlobalSection
 EndGlobal

--- a/src/Shouldly/App_Packages/ExpressionStringBuilder.0.10.0/ExpressionStringBuilder.cs
+++ b/src/Shouldly/App_Packages/ExpressionStringBuilder.0.10.0/ExpressionStringBuilder.cs
@@ -27,7 +27,7 @@ namespace ExpressionToString
         /// <param name="expression">The expression to format</param>
         /// <param name="trimLongArgumentList">If true will replace large (>3) argument lists with an ellipsis</param>
         /// <returns></returns>
-        public static string ToString(Expression expression, bool trimLongArgumentList = false)
+        public static string ToString(Expression? expression, bool trimLongArgumentList = false)
         {
             var visitor = new ExpressionStringBuilder(trimLongArgumentList);
             visitor.Visit(expression);
@@ -122,7 +122,7 @@ namespace ExpressionToString
                 {
                     if (node.Value is bool)
                     {
-                        Out(node.Value.ToString().ToLower());
+                        Out(node.Value.ToString()?.ToLower());
                     }
                     else
                     {
@@ -282,7 +282,7 @@ namespace ExpressionToString
             }
         }
 
-        private void Out(string s)
+        private void Out(string? s)
         {
             builder.Append(s);
         }

--- a/src/Shouldly/App_Packages/JetBrainsAnnotations/JetBrainsAnnotations.cs
+++ b/src/Shouldly/App_Packages/JetBrainsAnnotations/JetBrainsAnnotations.cs
@@ -153,12 +153,12 @@ internal sealed class InvokerParameterNameAttribute : Attribute { }
 internal sealed class NotifyPropertyChangedInvocatorAttribute : Attribute
   {
     public NotifyPropertyChangedInvocatorAttribute() { }
-    public NotifyPropertyChangedInvocatorAttribute(string parameterName)
+    public NotifyPropertyChangedInvocatorAttribute(string? parameterName)
     {
       ParameterName = parameterName;
     }
 
-    public string ParameterName { get; private set; }
+    public string? ParameterName { get; private set; }
   }
 
   /// <summary>
@@ -197,7 +197,7 @@ internal sealed class NotifyPropertyChangedInvocatorAttribute : Attribute
   /// // A method that returns null if the parameter is null,
   /// // and not null if the parameter is not null
   /// [ContractAnnotation("null => null; notnull => notnull")]
-  /// public object Transform(object data) 
+  /// public object Transform(object data)
   /// </code></item>
   /// <item><code>
   /// [ContractAnnotation("s:null=>false; =>true,result:notnull; =>false, result:null")]
@@ -377,12 +377,12 @@ internal enum ImplicitUseTargetFlags
 internal sealed class PublicAPIAttribute : Attribute
   {
     public PublicAPIAttribute() { }
-    public PublicAPIAttribute([NotNull] string comment)
+    public PublicAPIAttribute([NotNull] string? comment)
     {
       Comment = comment;
     }
 
-    public string Comment { get; private set; }
+    public string? Comment { get; private set; }
   }
 
   /// <summary>
@@ -415,12 +415,12 @@ internal sealed class PureAttribute : Attribute { }
 internal sealed class PathReferenceAttribute : Attribute
   {
     public PathReferenceAttribute() { }
-    public PathReferenceAttribute([PathReference] string basePath)
+    public PathReferenceAttribute([PathReference] string? basePath)
     {
       BasePath = basePath;
     }
 
-    public string BasePath { get; private set; }
+    public string? BasePath { get; private set; }
   }
 
   /// <summary>
@@ -484,7 +484,7 @@ internal sealed class MacroAttribute : Attribute
     /// Allows specifying a macro that will be executed for a <see cref="SourceTemplateAttribute">source template</see>
     /// parameter when the template is expanded.
     /// </summary>
-    public string Expression { get; set; }
+    public string? Expression { get; set; }
 
     /// <summary>
     /// Allows specifying which occurrence of the target parameter becomes editable when the template is deployed.
@@ -500,7 +500,7 @@ internal sealed class MacroAttribute : Attribute
     /// Identifies the target parameter of a <see cref="SourceTemplateAttribute">source template</see> if the
     /// <see cref="MacroAttribute"/> is applied on a template method.
     /// </summary>
-    public string Target { get; set; }
+    public string? Target { get; set; }
   }
 
   [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
@@ -579,12 +579,12 @@ internal sealed class AspMvcViewLocationFormatAttribute : Attribute
 internal sealed class AspMvcActionAttribute : Attribute
   {
     public AspMvcActionAttribute() { }
-    public AspMvcActionAttribute(string anonymousProperty)
+    public AspMvcActionAttribute(string? anonymousProperty)
     {
       AnonymousProperty = anonymousProperty;
     }
 
-    public string AnonymousProperty { get; private set; }
+    public string? AnonymousProperty { get; private set; }
   }
 
   /// <summary>
@@ -596,12 +596,12 @@ internal sealed class AspMvcActionAttribute : Attribute
 internal sealed class AspMvcAreaAttribute : Attribute
   {
     public AspMvcAreaAttribute() { }
-    public AspMvcAreaAttribute(string anonymousProperty)
+    public AspMvcAreaAttribute(string? anonymousProperty)
     {
       AnonymousProperty = anonymousProperty;
     }
 
-    public string AnonymousProperty { get; private set; }
+    public string? AnonymousProperty { get; private set; }
   }
 
   /// <summary>
@@ -614,12 +614,12 @@ internal sealed class AspMvcAreaAttribute : Attribute
 internal sealed class AspMvcControllerAttribute : Attribute
   {
     public AspMvcControllerAttribute() { }
-    public AspMvcControllerAttribute(string anonymousProperty)
+    public AspMvcControllerAttribute(string? anonymousProperty)
     {
       AnonymousProperty = anonymousProperty;
     }
 
-    public string AnonymousProperty { get; private set; }
+    public string? AnonymousProperty { get; private set; }
   }
 
   /// <summary>
@@ -653,7 +653,7 @@ internal sealed class AspMvcSupressViewErrorAttribute : Attribute { }
 
   /// <summary>
   /// ASP.NET MVC attribute. Indicates that a parameter is an MVC display template.
-  /// Use this attribute for custom wrappers similar to 
+  /// Use this attribute for custom wrappers similar to
   /// <c>System.Web.Mvc.Html.DisplayExtensions.DisplayForModel(HtmlHelper, String)</c>.
   /// </summary>
   [AttributeUsage(AttributeTargets.Parameter)]
@@ -702,12 +702,12 @@ internal sealed class AspMvcActionSelectorAttribute : Attribute { }
 internal sealed class HtmlElementAttributesAttribute : Attribute
   {
     public HtmlElementAttributesAttribute() { }
-    public HtmlElementAttributesAttribute(string name)
+    public HtmlElementAttributesAttribute(string? name)
     {
       Name = name;
     }
 
-    public string Name { get; private set; }
+    public string? Name { get; private set; }
   }
 
   [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Field | AttributeTargets.Property)]
@@ -723,7 +723,7 @@ internal sealed class HtmlAttributeValueAttribute : Attribute
 
   /// <summary>
   /// Razor attribute. Indicates that a parameter or a method is a Razor section.
-  /// Use this attribute for custom wrappers similar to 
+  /// Use this attribute for custom wrappers similar to
   /// <c>System.Web.WebPages.WebPageBase.RenderSection(String)</c>.
   /// </summary>
   [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Method)]
@@ -758,7 +758,7 @@ internal enum CollectionAccessType
 
   /// <summary>
   /// Indicates that the marked method is assertion method, i.e. it halts control flow if
-  /// one of the conditions is satisfied. To set the condition, mark one of the parameters with 
+  /// one of the conditions is satisfied. To set the condition, mark one of the parameters with
   /// <see cref="AssertionConditionAttribute"/> attribute.
   /// </summary>
   [AttributeUsage(AttributeTargets.Method)]

--- a/src/Shouldly/CallContext.cs
+++ b/src/Shouldly/CallContext.cs
@@ -6,23 +6,23 @@ namespace Shouldly
 {
     internal static class CallContext
     {
-        private static ConcurrentDictionary<string, AsyncLocal<object>> state = new ConcurrentDictionary<string, AsyncLocal<object>>();
+        private static ConcurrentDictionary<string, AsyncLocal<object?>> state = new ConcurrentDictionary<string, AsyncLocal<object?>>();
 
         /// <summary>
         /// Stores a given object and associates it with the specified name.
         /// </summary>
         /// <param name="name">The name with which to associate the new item in the call context.</param>
         /// <param name="data">The object to store in the call context.</param>
-        public static void LogicalSetData(string name, object data) =>
-            state.GetOrAdd(name, _ => new AsyncLocal<object>()).Value = data;
+        public static void LogicalSetData(string name, object? data) =>
+            state.GetOrAdd(name, _ => new AsyncLocal<object?>()).Value = data;
 
         /// <summary>
         /// Retrieves an object with the specified name from the <see cref="CallContext"/>.
         /// </summary>
         /// <param name="name">The name of the item in the call context.</param>
         /// <returns>The object in the call context associated with the specified name, or <see langword="null"/> if not found.</returns>
-        public static object LogicalGetData(string name) =>
-            state.TryGetValue(name, out AsyncLocal<object> data) ? data.Value : null;
+        public static object? LogicalGetData(string name) =>
+            state.TryGetValue(name, out AsyncLocal<object?>? data) ? data.Value : null;
     }
 }
 #endif

--- a/src/Shouldly/Configuration/DiffTool.cs
+++ b/src/Shouldly/Configuration/DiffTool.cs
@@ -8,13 +8,13 @@ namespace Shouldly.Configuration
 {
     public class DiffToolConfig
     {
-        public string WindowsPath { get; set; }
+        public string? WindowsPath { get; set; }
 
-        public string MacPath { get; set; }
+        public string? MacPath { get; set; }
 
-        public string LinuxPath { get; set; }
+        public string? LinuxPath { get; set; }
 
-        public string ResolvePath()
+        public string? ResolvePath()
         {
             if (ShouldlyEnvironmentContext.IsWindows())
                 return WindowsPath;
@@ -29,7 +29,7 @@ namespace Shouldly.Configuration
 
     public class DiffTool
     {
-        private readonly string _path;
+        private readonly string? _path;
         private readonly ArgumentGenerator _argGenerator;
 
         public delegate string ArgumentGenerator(string received, string approved, bool approvedExists);
@@ -53,7 +53,7 @@ namespace Shouldly.Configuration
             Process.Start(_path, _argGenerator(receivedPath, approvedPath, approvedExists));
         }
 
-        private static string Discover(string path)
+        private static string? Discover(string? path)
         {
             if (path == null)
                 return null;
@@ -91,11 +91,11 @@ namespace Shouldly.Configuration
     Environment.GetEnvironmentVariable("ProgramW6432")
 }
 .Where(p => p != null)
-.Select(pf => Path.Combine(pf, path))
+.Select(pf => Path.Combine(pf!, path))
 .FirstOrDefault(File.Exists);
         }
 
-        private static string GetFullPath(string fileName)
+        private static string? GetFullPath(string fileName)
         {
             if (File.Exists(fileName))
                 return Path.GetFullPath(fileName);
@@ -112,7 +112,7 @@ namespace Shouldly.Configuration
                 .FirstOrDefault(File.Exists);
         }
 
-        private static string TryCombine(string fileName, string path)
+        private static string? TryCombine(string fileName, string path)
         {
             try
             {

--- a/src/Shouldly/Configuration/DiffToolConfiguration.cs
+++ b/src/Shouldly/Configuration/DiffToolConfiguration.cs
@@ -16,9 +16,9 @@ namespace Shouldly.Configuration
 
         public DiffToolConfiguration()
         {
-            _diffTools = typeof (KnownDiffTools).GetFields().Select(f => (DiffTool) f.GetValue(KnownDiffTools)).ToList();
+            _diffTools = typeof (KnownDiffTools).GetFields().Select(f => (DiffTool) f.GetValue(KnownDiffTools)!).ToList();
             _knownShouldNotLaunchDiffToolReasons = typeof (KnownDoNotLaunchStrategies).GetFields()
-                .Select(f => (IShouldNotLaunchDiffTool) f.GetValue(KnownDoNotLaunchStrategies)).ToList();
+                .Select(f => (IShouldNotLaunchDiffTool) f.GetValue(KnownDoNotLaunchStrategies)!).ToList();
         }
 
         public void RegisterDiffTool(DiffTool diffTool)
@@ -54,7 +54,7 @@ namespace Shouldly.Configuration
             var diffTool = _diffToolPriority.FirstOrDefault(d => d.Exists());
             if (diffTool == null)
                 diffTool = _diffTools.FirstOrDefault(d => d.Exists());
-            
+
             if (diffTool == null)
             {
                 throw new ShouldAssertException(@"Cannot find a difftool to use, please open an issue or a PR to add support for your difftool.

--- a/src/Shouldly/Configuration/FindMethodUsingAttribute.cs
+++ b/src/Shouldly/Configuration/FindMethodUsingAttribute.cs
@@ -1,7 +1,6 @@
 #if ShouldMatchApproved
 using System;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Shouldly.Configuration
 {
@@ -9,16 +8,15 @@ namespace Shouldly.Configuration
     {
         public TestMethodInfo GetTestMethodInfo(StackTrace stackTrace, int startAt = 0)
         {
-            var i = startAt;
-            StackFrame callingFrame;
-            do
+            for (var i = startAt; stackTrace.GetFrame(i) is { } frame; i++)
             {
-                callingFrame = stackTrace.GetFrame(i++)
-                    ?? throw new Exception($"Cannot find method in call stack with attribute {typeof(T).FullName}.");
+                if (frame.GetMethod() is { } method && method.IsDefined(typeof(T), inherit: true))
+                {
+                    return new TestMethodInfo(frame);
+                }
+            }
 
-            } while (!callingFrame.GetMethod().GetCustomAttributes(typeof(T), true).Any());
-
-            return new TestMethodInfo(callingFrame);
+            throw new InvalidOperationException($"Cannot find a method in the stack trace with attribute {typeof(T).FullName}.");
         }
     }
 }

--- a/src/Shouldly/Configuration/FindMethodUsingAttribute.cs
+++ b/src/Shouldly/Configuration/FindMethodUsingAttribute.cs
@@ -13,11 +13,9 @@ namespace Shouldly.Configuration
             StackFrame callingFrame;
             do
             {
-                if (i >= stackTrace.FrameCount)
-                {
-                    throw new Exception($"Cannot find method in call stack with attribute {typeof(T).FullName}");
-                }
-                callingFrame = stackTrace.GetFrame(i++);
+                callingFrame = stackTrace.GetFrame(i++)
+                    ?? throw new Exception($"Cannot find method in call stack with attribute {typeof(T).FullName}.");
+
             } while (!callingFrame.GetMethod().GetCustomAttributes(typeof(T), true).Any());
 
             return new TestMethodInfo(callingFrame);

--- a/src/Shouldly/Configuration/FirstNonShouldlyMethodFinder.cs
+++ b/src/Shouldly/Configuration/FirstNonShouldlyMethodFinder.cs
@@ -1,6 +1,6 @@
 #if ShouldMatchApproved
+using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
@@ -13,7 +13,7 @@ namespace Shouldly.Configuration
 
         /// <summary>
         /// Increasing the offset will move past the first non-shouldly method
-        /// 
+        ///
         /// Anonymous methods are not counted in the offset.
         /// This is useful when you have created a reusable method which is calling ShouldMatchApproved
         /// </summary>
@@ -21,20 +21,23 @@ namespace Shouldly.Configuration
 
         public TestMethodInfo GetTestMethodInfo(StackTrace stackTrace, int startAt = 0)
         {
-            var i = startAt;
-            StackFrame callingFrame;
-            do
+            for (var i = startAt; stackTrace.GetFrame(i) is { } frame; i++)
             {
-                callingFrame = stackTrace.GetFrame(i++);
-            } while (callingFrame.GetMethod().IsShouldlyMethod() || IsCompilerGenerated(callingFrame.GetMethod()));
+                if (frame.GetMethod() is { } method && !method.IsShouldlyMethod() && !IsCompilerGenerated(method))
+                {
+                    var callingFrame = stackTrace.GetFrame(i + Offset)
+                        ?? throw new InvalidOperationException("There is no stack frame at the specified offset from the first non-Shouldly stack frame.");
 
-            callingFrame = stackTrace.GetFrame(i + Offset - 1);
-            return new TestMethodInfo(callingFrame);
+                    return new TestMethodInfo(callingFrame);
+                }
+            }
+
+            throw new InvalidOperationException("Cannot find a non-Shouldly method in the stack trace.");
         }
 
         static bool IsCompilerGenerated(MethodBase method)
         {
-            return method.GetCustomAttributes(typeof(CompilerGeneratedAttribute), true).Any() || AnonMethod.IsMatch(method.Name);
+            return method.IsDefined(typeof(CompilerGeneratedAttribute), inherit: true) || AnonMethod.IsMatch(method.Name);
         }
     }
 }

--- a/src/Shouldly/Configuration/ShouldMatchConfiguration.cs
+++ b/src/Shouldly/Configuration/ShouldMatchConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿#if ShouldMatchApproved
 using System;
-using System.Diagnostics.CodeAnalysis;
 
 namespace Shouldly.Configuration
 {
@@ -18,25 +17,23 @@ namespace Shouldly.Configuration
             StringCompareOptions = initialConfig.StringCompareOptions;
             FilenameDescriminator = initialConfig.FilenameDescriminator;
             PreventDiff = initialConfig.PreventDiff;
-            FileExtension = initialConfig.FileExtension!;
-            TestMethodFinder = initialConfig.TestMethodFinder!;
+            FileExtension = initialConfig.FileExtension;
+            TestMethodFinder = initialConfig.TestMethodFinder;
             ApprovalFileSubFolder = initialConfig.ApprovalFileSubFolder;
             Scrubber = initialConfig.Scrubber;
-            FilenameGenerator = initialConfig.FilenameGenerator!;
+            FilenameGenerator = initialConfig.FilenameGenerator;
         }
 
-        public StringCompareShould StringCompareOptions { get; set; }
+        public StringCompareShould StringCompareOptions { get; set; } = StringCompareShould.IgnoreLineEndings;
         public string? FilenameDescriminator { get; set; }
         public bool PreventDiff { get; set; }
 
         /// <summary>
         /// File extension without the .
         /// </summary>
-        [DisallowNull]
-        public string? FileExtension { get; set; }
+        public string FileExtension { get; set; } = "txt";
 
-        [DisallowNull]
-        public ITestMethodFinder? TestMethodFinder { get; set; }
+        public ITestMethodFinder TestMethodFinder { get; set; } = new FirstNonShouldlyMethodFinder();
         public string? ApprovalFileSubFolder { get; set; }
 
         /// <summary>
@@ -46,8 +43,9 @@ namespace Shouldly.Configuration
         /// </summary>
         public Func<string, string>? Scrubber { get; set; }
 
-        [DisallowNull]
-        public FilenameGenerator? FilenameGenerator { get; set; }
+        public FilenameGenerator FilenameGenerator { get; set; } =
+            (testMethodInfo, descriminator, type, extension)
+                => $"{testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}{descriminator}.{type}.{extension}";
     }
 }
 

--- a/src/Shouldly/Configuration/ShouldMatchConfiguration.cs
+++ b/src/Shouldly/Configuration/ShouldMatchConfiguration.cs
@@ -1,10 +1,11 @@
 ﻿#if ShouldMatchApproved
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Shouldly.Configuration
 {
     public delegate string FilenameGenerator(
-        TestMethodInfo testMethodInfo, string descriminator, string fileType, string fileExtension);
+        TestMethodInfo testMethodInfo, string? descriminator, string fileType, string fileExtension);
 
     public class ShouldMatchConfiguration
     {
@@ -17,33 +18,36 @@ namespace Shouldly.Configuration
             StringCompareOptions = initialConfig.StringCompareOptions;
             FilenameDescriminator = initialConfig.FilenameDescriminator;
             PreventDiff = initialConfig.PreventDiff;
-            FileExtension = initialConfig.FileExtension;
-            TestMethodFinder = initialConfig.TestMethodFinder;
+            FileExtension = initialConfig.FileExtension!;
+            TestMethodFinder = initialConfig.TestMethodFinder!;
             ApprovalFileSubFolder = initialConfig.ApprovalFileSubFolder;
             Scrubber = initialConfig.Scrubber;
-            FilenameGenerator = initialConfig.FilenameGenerator;
+            FilenameGenerator = initialConfig.FilenameGenerator!;
         }
 
         public StringCompareShould StringCompareOptions { get; set; }
-        public string FilenameDescriminator { get; set; }
+        public string? FilenameDescriminator { get; set; }
         public bool PreventDiff { get; set; }
 
         /// <summary>
         /// File extension without the .
         /// </summary>
-        public string FileExtension { get; set; }
+        [DisallowNull]
+        public string? FileExtension { get; set; }
 
-        public ITestMethodFinder TestMethodFinder { get; set; }
-        public string ApprovalFileSubFolder { get; set; }
+        [DisallowNull]
+        public ITestMethodFinder? TestMethodFinder { get; set; }
+        public string? ApprovalFileSubFolder { get; set; }
 
         /// <summary>
         /// Scrubbers allow you to alter the received document before comparing it to approved.
-        /// 
+        ///
         /// This is useful for replacing dates or dynamic data with fixed data
         /// </summary>
-        public Func<string, string> Scrubber { get; set; }
+        public Func<string, string>? Scrubber { get; set; }
 
-        public FilenameGenerator FilenameGenerator { get; set; }
+        [DisallowNull]
+        public FilenameGenerator? FilenameGenerator { get; set; }
     }
 }
 

--- a/src/Shouldly/Configuration/TestMethodInfo.cs
+++ b/src/Shouldly/Configuration/TestMethodInfo.cs
@@ -12,11 +12,11 @@ namespace Shouldly.Configuration
         {
             SourceFileDirectory = Path.GetDirectoryName(callingFrame.GetFileName());
             var realMethod = GetRealMethod(callingFrame.GetMethod());
-            MethodName = realMethod.Name;
-            DeclaringTypeName = realMethod.DeclaringType?.Name;
+            MethodName = realMethod?.Name;
+            DeclaringTypeName = realMethod?.DeclaringType?.Name;
         }
 
-        static MethodBase GetRealMethod(MethodBase method)
+        static MethodBase? GetRealMethod(MethodBase method)
         {
             var declaringType = method.DeclaringType;
             if (declaringType == null || declaringType.IsByRef)
@@ -36,7 +36,7 @@ namespace Shouldly.Configuration
                 return method;
             }
             var trueMethodName = declaringType.Name.TrimStart('<').Split('>').First();
-            MethodInfo methodInfo;
+            MethodInfo? methodInfo;
             var bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
             try
             {
@@ -54,13 +54,13 @@ namespace Shouldly.Configuration
         static bool ContainsAttribute(object[] attributes, string attributeName)
         {
             {
-                return attributes.Any(a => a.GetType().FullName.StartsWith(attributeName));
+                return attributes.Any(a => a.GetType().FullName?.StartsWith(attributeName) ?? false);
             }
         }
 
-        public string SourceFileDirectory { get; private set; }
-        public string MethodName { get; private set; }
-        public string DeclaringTypeName { get; private set; }
+        public string? SourceFileDirectory { get; private set; }
+        public string? MethodName { get; private set; }
+        public string? DeclaringTypeName { get; private set; }
     }
 }
 #endif

--- a/src/Shouldly/Configuration/TestMethodInfo.cs
+++ b/src/Shouldly/Configuration/TestMethodInfo.cs
@@ -1,4 +1,5 @@
 #if ShouldMatchApproved
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -11,51 +12,54 @@ namespace Shouldly.Configuration
         public TestMethodInfo(StackFrame callingFrame)
         {
             SourceFileDirectory = Path.GetDirectoryName(callingFrame.GetFileName());
-            var realMethod = GetRealMethod(callingFrame.GetMethod());
-            MethodName = realMethod?.Name;
-            DeclaringTypeName = realMethod?.DeclaringType?.Name;
+
+            var method = callingFrame.GetMethod();
+            var originalMethodInfo = GetOriginalMethodInfoForStateMachineMethod(method);
+
+            MethodName = originalMethodInfo?.MethodName ?? method?.Name;
+            DeclaringTypeName = (originalMethodInfo?.DeclaringType ?? method?.DeclaringType)?.Name;
         }
 
-        static MethodBase? GetRealMethod(MethodBase method)
+        private readonly struct OriginalMethodInfo
         {
-            var declaringType = method.DeclaringType;
-            if (declaringType == null || declaringType.IsByRef)
+            public OriginalMethodInfo(string methodName, Type declaringType)
             {
-                return method;
+                MethodName = methodName;
+                DeclaringType = declaringType;
             }
-            if (!ContainsAttribute(declaringType.GetCustomAttributes(false), "System.Runtime.CompilerServices.CompilerGeneratedAttribute"))
-            {
-                return method;
-            }
-            if (declaringType.GetInterface("System.Runtime.CompilerServices.IAsyncStateMachine") == null)
-            {
-                return method;
-            }
-            if (!declaringType.Name.Contains("<") || !declaringType.Name.Contains(">"))
-            {
-                return method;
-            }
-            var trueMethodName = declaringType.Name.TrimStart('<').Split('>').First();
-            MethodInfo? methodInfo;
-            var bindingFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
-            try
-            {
-                methodInfo = declaringType.DeclaringType.GetMethod(trueMethodName, bindingFlags);
-            }
-            catch (AmbiguousMatchException)
-            {
-                //TODO: Should this throw??
-                //var message = string.Format("Could not derive root method for async method '{0}' since there are multiple methods named '{1}'.", method.Name, trueMethodName);
-                return method;
-            }
-            return methodInfo;
+
+            public string MethodName { get; }
+            public Type DeclaringType { get; }
         }
 
-        static bool ContainsAttribute(object[] attributes, string attributeName)
+        static OriginalMethodInfo? GetOriginalMethodInfoForStateMachineMethod(MethodBase? method)
         {
+            if (method?.DeclaringType is { IsByRef: false } declaringType
+                && declaringType.DeclaringType is { } originalMethodDeclaringType
+                && ContainsAttribute(declaringType, "System.Runtime.CompilerServices.CompilerGeneratedAttribute")
+                && declaringType.GetInterface("System.Runtime.CompilerServices.IAsyncStateMachine") is object)
             {
-                return attributes.Any(a => a.GetType().FullName?.StartsWith(attributeName) ?? false);
+                var stateMachineTypeName = declaringType.Name;
+                var openingAngleBracket = stateMachineTypeName.IndexOf('<');
+                if (openingAngleBracket != -1)
+                {
+                    var closingAngleBracket = stateMachineTypeName.IndexOf('>', openingAngleBracket + 1);
+                    if (closingAngleBracket != -1)
+                    {
+                        var originalMethodName = stateMachineTypeName.Substring(openingAngleBracket + 1, closingAngleBracket - (openingAngleBracket + 1));
+
+                        return new OriginalMethodInfo(originalMethodName, originalMethodDeclaringType);
+                    }
+                }
             }
+
+            return null;
+        }
+
+        static bool ContainsAttribute(MemberInfo member, string attributeName)
+        {
+            return member.CustomAttributes.Any(a =>
+                a.AttributeType.FullName?.StartsWith(attributeName, StringComparison.Ordinal) ?? false);
         }
 
         public string? SourceFileDirectory { get; private set; }

--- a/src/Shouldly/Configuration/VisualStudioDiffTool.cs
+++ b/src/Shouldly/Configuration/VisualStudioDiffTool.cs
@@ -39,7 +39,7 @@ namespace Shouldly.Configuration
             and limitations under the License.
          */
         // https://github.com/approvals/ApprovalTests.Net/blob/master/ApprovalTests/Reporters/VisualStudioReporter.cs
-        private static string GetPath()
+        private static string? GetPath()
         {
             Process process;
             try
@@ -84,7 +84,7 @@ namespace Shouldly.Configuration
         // https://github.com/approvals/ApprovalTests.Net/blob/master/ApprovalTests/Utilities/ParentProcessUtils.cs
         static class ParentProcessUtils
         {
-            public static Process GetParentProcess(Process currentProcess)
+            public static Process? GetParentProcess(Process currentProcess)
             {
                 return ParentProcess(currentProcess);
             }
@@ -94,7 +94,7 @@ namespace Shouldly.Configuration
                 return GetSelfAndAncestors(Process.GetCurrentProcess());
             }
 
-            static IEnumerable<Process> GetSelfAndAncestors(Process self)
+            static IEnumerable<Process> GetSelfAndAncestors(Process? self)
             {
                 var processIds = new HashSet<int>();
 
@@ -115,7 +115,7 @@ namespace Shouldly.Configuration
             }
 
 
-            private static Process ParentProcess(Process process)
+            private static Process? ParentProcess(Process process)
             {
                 var parentPid = 0;
                 var processPid = process.Id;

--- a/src/Shouldly/DifferenceHighlighting/DifferenceHighlighter.cs
+++ b/src/Shouldly/DifferenceHighlighting/DifferenceHighlighter.cs
@@ -13,7 +13,7 @@ namespace Shouldly.DifferenceHighlighting
         /// Compares an actual value against an expected one and creates
         /// a string with the differences highlighted
         /// </summary>
-        public static string HighlightDifferences(IShouldlyAssertionContext context)
+        public static string? HighlightDifferences(IShouldlyAssertionContext context)
         {
             var validDifferenceHighlighter = GetDifferenceHighlighterFor(context);
 
@@ -30,7 +30,7 @@ namespace Shouldly.DifferenceHighlighting
             return GetDifferenceHighlighterFor(context) != null;
         }
 
-        static IDifferenceHighlighter GetDifferenceHighlighterFor(IShouldlyAssertionContext context)
+        static IDifferenceHighlighter? GetDifferenceHighlighterFor(IShouldlyAssertionContext context)
         {
             return _differenceHighlighters.FirstOrDefault(x => x.CanProcess(context));
         }

--- a/src/Shouldly/DifferenceHighlighting/EnumerableDifferenceHighlighter.cs
+++ b/src/Shouldly/DifferenceHighlighting/EnumerableDifferenceHighlighter.cs
@@ -14,7 +14,7 @@ namespace Shouldly.DifferenceHighlighting
         private const int MaxElementsToShow = 1000;
         private readonly ItemDifferenceHighlighter _itemDifferenceHighlighter;
 
-        public EnumerableDifferenceHighlighter() 
+        public EnumerableDifferenceHighlighter()
         {
             _itemDifferenceHighlighter = new ItemDifferenceHighlighter();
         }
@@ -28,7 +28,7 @@ namespace Shouldly.DifferenceHighlighting
                    && !(context.Actual is string);
         }
 
-        public string HighlightDifferences(IShouldlyAssertionContext context)
+        public string? HighlightDifferences(IShouldlyAssertionContext context)
         {
             var actual = context.Actual as IEnumerable;
             var expected = context.Expected as IEnumerable;
@@ -68,7 +68,7 @@ namespace Shouldly.DifferenceHighlighting
             return returnMessage.Append("]").ToString();
         }
 
-        private string GetComparedItemString(IEnumerable<object> actualList, IEnumerable<object> expectedList, int itemPosition)
+        private string? GetComparedItemString(IEnumerable<object> actualList, IEnumerable<object> expectedList, int itemPosition)
         {
             if (expectedList.Count() <= itemPosition)
             {

--- a/src/Shouldly/DifferenceHighlighting/IDifferenceHighlighter.cs
+++ b/src/Shouldly/DifferenceHighlighting/IDifferenceHighlighter.cs
@@ -6,6 +6,6 @@ namespace Shouldly.DifferenceHighlighting
     internal interface IDifferenceHighlighter
     {
         bool CanProcess(IShouldlyAssertionContext context);
-        string HighlightDifferences(IShouldlyAssertionContext context);
+        string? HighlightDifferences(IShouldlyAssertionContext context);
     }
 }

--- a/src/Shouldly/DifferenceHighlighting/IStringDifferenceHighlighter.cs
+++ b/src/Shouldly/DifferenceHighlighting/IStringDifferenceHighlighter.cs
@@ -2,6 +2,6 @@
 {
     interface IStringDifferenceHighlighter
     {
-        string HighlightDifferences(string expected, string actual);
+        string? HighlightDifferences(string? expected, string? actual);
     }
 }

--- a/src/Shouldly/DifferenceHighlighting/ItemDifferenceHighlighter.cs
+++ b/src/Shouldly/DifferenceHighlighting/ItemDifferenceHighlighter.cs
@@ -4,7 +4,7 @@ namespace Shouldly.DifferenceHighlighting
     {
         public const string HighlightCharacter = "*";
 
-        public string HighlightItem(string item)
+        public string HighlightItem(string? item)
         {
             return HighlightCharacter + item + HighlightCharacter;
         }

--- a/src/Shouldly/DifferenceHighlighting/StringDifferenceHighlighter.cs
+++ b/src/Shouldly/DifferenceHighlighting/StringDifferenceHighlighter.cs
@@ -13,12 +13,12 @@ namespace Shouldly.DifferenceHighlighting
         readonly Case _sensitivity;
         readonly Func<string, string> _transform;
 
-        public StringDifferenceHighlighter(Case sensitivity, Func<string, string> transform = null)
+        public StringDifferenceHighlighter(Case sensitivity, Func<string, string>? transform = null)
         {
             _sensitivity = sensitivity;
             _transform = transform ?? (s => s);
         }
-        public string HighlightDifferences(string expected, string actual)
+        public string? HighlightDifferences(string? expected, string? actual)
         {
             if (expected == null || actual == null) return null;
 

--- a/src/Shouldly/Internals/AssertionFactories/StringShouldBeAssertionFactory.cs
+++ b/src/Shouldly/Internals/AssertionFactories/StringShouldBeAssertionFactory.cs
@@ -8,7 +8,7 @@ namespace Shouldly.Internals.AssertionFactories
 {
     internal static class StringShouldBeAssertionFactory
     {
-        public static IAssertion Create(string expected, string actual, StringCompareShould options, [CallerMemberName] string shouldlyMethod = null)
+        public static IAssertion Create(string? expected, string? actual, StringCompareShould options, [CallerMemberName] string shouldlyMethod = null!)
         {
             List<string> optionsList = new List<string>();
             if ((options & StringCompareShould.IgnoreLineEndings) != 0)
@@ -19,7 +19,7 @@ namespace Shouldly.Internals.AssertionFactories
             }
 
             Case sensitivity;
-            Func<string, string, bool> stringComparer;
+            Func<string?, string?, bool> stringComparer;
             if ((options & StringCompareShould.IgnoreCase) == 0)
             {
                 sensitivity = Case.Sensitive;

--- a/src/Shouldly/Internals/Assertions/IAssertion.cs
+++ b/src/Shouldly/Internals/Assertions/IAssertion.cs
@@ -3,6 +3,6 @@
     internal interface IAssertion
     {
         bool IsSatisfied();
-        string GenerateMessage(string customMessage);
+        string? GenerateMessage(string? customMessage);
     }
 }

--- a/src/Shouldly/Internals/Assertions/StringShouldBeAssertion.cs
+++ b/src/Shouldly/Internals/Assertions/StringShouldBeAssertion.cs
@@ -5,17 +5,17 @@ namespace Shouldly.Internals.Assertions
 {
     internal class StringShouldBeAssertion : IAssertion
     {
-        readonly string _expected;
-        readonly string _actual;
-        readonly Func<string, string, bool> _compare;
+        readonly string? _expected;
+        readonly string? _actual;
+        readonly Func<string?, string?, bool> _compare;
         readonly ICodeTextGetter _codeTextGetter;
         readonly IStringDifferenceHighlighter _diffHighlighter;
         readonly string _options;
         readonly string _shouldlyMethod;
 
         public StringShouldBeAssertion(
-            string expected, string actual,
-            Func<string, string, bool> compare,
+            string? expected, string? actual,
+            Func<string?, string?, bool> compare,
             ICodeTextGetter codeTextGetter,
             IStringDifferenceHighlighter diffHighlighter,
             string options,
@@ -30,7 +30,7 @@ namespace Shouldly.Internals.Assertions
             _shouldlyMethod = shouldlyMethod;
         }
 
-        public string GenerateMessage(string customMessage)
+        public string? GenerateMessage(string? customMessage)
         {
             var codeText = _codeTextGetter.GetCodeText(_actual);
             var withOption = string.IsNullOrEmpty(_options) ? null : $" with options: {_options}";

--- a/src/Shouldly/Internals/EqualityComparer.cs
+++ b/src/Shouldly/Internals/EqualityComparer.cs
@@ -1,12 +1,13 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using NUnit.Framework.Constraints;
 
 namespace Shouldly
 {
-    /* 
+    /*
      * Code heavily influenced by code from xunit assert equality comparer
      * at https://github.com/xunit/xunit/blob/master/src/xunit2.assert/Asserts/Sdk/AssertEqualityComparer.cs
      */
@@ -17,13 +18,13 @@ namespace Shouldly
 
         readonly Func<IEqualityComparer> _innerComparerFactory;
 
-        public EqualityComparer(IEqualityComparer innerComparer = null)
+        public EqualityComparer(IEqualityComparer? innerComparer = null)
         {
             // Use a thunk to delay evaluation of DefaultInnerComparer
             _innerComparerFactory = () => innerComparer ?? DefaultInnerComparer;
         }
 
-        public bool Equals(T x, T y)
+        public bool Equals([AllowNull] T x, [AllowNull] T y)
         {
             var type = typeof (T);
 
@@ -33,10 +34,10 @@ namespace Shouldly
             // Null?
             if (!type.IsValueType() || (type.IsGenericType() && type.GetGenericTypeDefinition().IsAssignableFrom(NullableType)))
             {
-                if (object.Equals(x, default(T)))
-                    return object.Equals(y, default(T));
+                if (object.Equals(x, null))
+                    return object.Equals(y, null);
 
-                if (object.Equals(y, default(T)))
+                if (object.Equals(y, null))
                     return false;
             }
 
@@ -91,7 +92,7 @@ namespace Shouldly
             return object.Equals(x, y);
         }
 
-        public int GetHashCode(T obj)
+        public int GetHashCode([DisallowNull] T obj)
             => throw new NotImplementedException();
     }
 }

--- a/src/Shouldly/Internals/EqualityComparerAdapter.cs
+++ b/src/Shouldly/Internals/EqualityComparerAdapter.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace Shouldly
 {
-    /* 
+    /*
      * Code heavily influenced by code from xunit assert equality comparer adapter
      * at https://github.com/xunit/xunit/blob/master/src/xunit2.assert/Asserts/Sdk/AssertEqualityComparerAdapter.cs
      */
@@ -18,9 +18,9 @@ namespace Shouldly
             _innerComparer = innerComparer;
         }
 
-        public new bool Equals(object x, object y)
+        public new bool Equals(object? x, object? y)
         {
-            return _innerComparer.Equals((T) x, (T) y);
+            return _innerComparer.Equals((T)x!, (T)y!);
         }
 
         public int GetHashCode(object obj)

--- a/src/Shouldly/Internals/ICodeTextGetter.cs
+++ b/src/Shouldly/Internals/ICodeTextGetter.cs
@@ -3,9 +3,9 @@
     internal interface ICodeTextGetter
     {
 #if StackTrace
-        string GetCodeText(object actual, System.Diagnostics.StackTrace stackTrace = null);
+        string? GetCodeText(object? actual, System.Diagnostics.StackTrace? stackTrace = null);
 #else
-        string GetCodeText(object actual);
+        string? GetCodeText(object? actual);
 #endif
     }
 }

--- a/src/Shouldly/Internals/IShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/IShouldlyAssertionContext.cs
@@ -7,13 +7,13 @@ namespace Shouldly
     internal interface IShouldlyAssertionContext
     {
         string ShouldMethod { get; set; }
-        string CodePart { get; set; }
-        string FileName { get; set; }
+        string? CodePart { get; set; }
+        string? FileName { get; set; }
         int? LineNumber { get; set; }
-        object Key { get; set; }
-        object Expected { get; set; }
-        object Actual { get; set; }
-        object Tolerance { get; set; }
+        object? Key { get; set; }
+        object? Expected { get; set; }
+        object? Actual { get; set; }
+        object? Tolerance { get; set; }
         TimeSpan? Timeout { get; set; }
         bool IgnoreOrder { get; set; }
 
@@ -26,14 +26,14 @@ namespace Shouldly
         bool HasRelevantKey { get; set; }
 
         bool IsNegatedAssertion { get; }
-        string CustomMessage { get; set; }
+        string? CustomMessage { get; set; }
         Case? CaseSensitivity { get; set; }
         bool CodePartMatchesActual { get; }
-        Expression Filter { get; set; }
+        Expression? Filter { get; set; }
         int? MatchCount { get; set; }
         SortDirection SortDirection { get; set; }
         int OutOfOrderIndex { get; set; }
-        object OutOfOrderObject { get; set; }
-        IEnumerable<string> Path { get; set; }
+        object? OutOfOrderObject { get; set; }
+        IEnumerable<string>? Path { get; set; }
     }
 }

--- a/src/Shouldly/Internals/Is.cs
+++ b/src/Shouldly/Internals/Is.cs
@@ -260,7 +260,7 @@ namespace Shouldly
             }
         }
 
-        public static bool GreaterThanOrEqualTo<T>(IComparable<T>? comparable, [AllowNull] T expected)
+        public static bool GreaterThanOrEqualTo<T>([AllowNull] T comparable, [AllowNull] T expected) where T : IComparable<T>?
         {
             return Compare(comparable, expected) >= 0;
         }
@@ -270,7 +270,7 @@ namespace Shouldly
             return Compare(actual, expected, comparer) >= 0;
         }
 
-        public static bool LessThanOrEqualTo<T>(IComparable<T>? comparable, [AllowNull] T expected)
+        public static bool LessThanOrEqualTo<T>([AllowNull] T comparable, [AllowNull] T expected) where T : IComparable<T>?
         {
             return Compare(comparable, expected) <= 0;
         }
@@ -280,7 +280,7 @@ namespace Shouldly
             return Compare(actual, expected, comparer) <= 0;
         }
 
-        public static bool GreaterThan<T>(IComparable<T>? comparable, [AllowNull] T expected)
+        public static bool GreaterThan<T>([AllowNull] T comparable, [AllowNull] T expected) where T : IComparable<T>?
         {
             return Compare(comparable, expected) > 0;
         }
@@ -290,7 +290,7 @@ namespace Shouldly
             return Compare(actual, expected, comparer) > 0;
         }
 
-        public static bool LessThan<T>(IComparable<T>? comparable, [AllowNull] T expected)
+        public static bool LessThan<T>([AllowNull] T comparable, [AllowNull] T expected) where T : IComparable<T>?
         {
             return Compare(comparable, expected) < 0;
         }
@@ -304,7 +304,8 @@ namespace Shouldly
         {
             return comparer.Compare(actual, expected);
         }
-        static decimal Compare<T>(IComparable<T>? comparable, [AllowNull] T expected)
+
+        static decimal Compare<T>([AllowNull] T comparable, [AllowNull] T expected) where T : IComparable<T>?
         {
             if (!typeof(T).IsValueType())
             {
@@ -316,7 +317,7 @@ namespace Shouldly
                 // ReSharper restore CompareNonConstrainedGenericWithNull
             }
 
-            return comparable.CompareTo(expected);
+            return comparable!.CompareTo(expected);
         }
     }
 }

--- a/src/Shouldly/Internals/Is.cs
+++ b/src/Shouldly/Internals/Is.cs
@@ -1,20 +1,21 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace Shouldly
 {
     internal static class Is
     {
-        public static bool InRange<T>(T comparable, T @from, T to) where T : IComparable<T>
+        public static bool InRange<T>([DisallowNull] T comparable, [AllowNull] T @from, [AllowNull] T to) where T : IComparable<T>
         {
             return comparable.CompareTo(from) >= 0 && comparable.CompareTo(to) <= 0;
         }
 
-        public static bool Same(object actual, object expected)
+        public static bool Same(object? actual, object? expected)
         {
             if (actual == null && expected == null)
                 return true;
@@ -24,22 +25,22 @@ namespace Shouldly
             return ReferenceEquals(actual, expected);
         }
 
-        public static bool Equal<T>(T expected, T actual)
+        public static bool Equal<T>([AllowNull] T expected, [AllowNull] T actual)
         {
             return Equal(expected, actual, GetEqualityComparer<T>());
         }
 
-        public static bool Equal<T>(T expected, T actual, IEqualityComparer<T> comparer)
+        public static bool Equal<T>([AllowNull] T expected, [AllowNull] T actual, IEqualityComparer<T> comparer)
         {
             return comparer.Equals(actual, expected);
         }
 
-        static IEqualityComparer<T> GetEqualityComparer<T>(IEqualityComparer innerComparer = null)
+        static IEqualityComparer<T> GetEqualityComparer<T>(IEqualityComparer? innerComparer = null)
         {
             return new EqualityComparer<T>(innerComparer);
         }
 
-        public static bool Equal<T>(IEnumerable<T> actual, IEnumerable<T> expected)
+        public static bool Equal<T>(IEnumerable<T>? actual, IEnumerable<T>? expected)
         {
             if (actual == null && expected == null)
                 return true;
@@ -64,11 +65,11 @@ namespace Shouldly
             }
         }
 
-        public static bool EqualIgnoreOrder<T>(IEnumerable<T> actual, IEnumerable<T> expected)
+        public static bool EqualIgnoreOrder<T>(IEnumerable<T>? actual, IEnumerable<T>? expected)
         {
             if (actual == null && expected == null)
                 return true;
-            
+
             if (actual == null || expected == null)
                 return false;
 
@@ -171,9 +172,9 @@ namespace Shouldly
             return (actual - expected).Duration() < tolerance;
         }
 
-        public static bool InstanceOf(object o, Type expected)
+        public static bool InstanceOf(object? o, Type expected)
         {
-            return o != null ? expected.IsInstanceOfType(o) : false; 
+            return o != null ? expected.IsInstanceOfType(o) : false;
         }
 
         public static bool StringMatchingRegex(string actual, string regexPattern)
@@ -181,7 +182,7 @@ namespace Shouldly
             return Regex.IsMatch(actual, regexPattern);
         }
 
-        public static bool StringContainingIgnoreCase(string actual, string expected)
+        public static bool StringContainingIgnoreCase(string? actual, string expected)
         {
             if (actual == null)
                 return false;
@@ -189,7 +190,7 @@ namespace Shouldly
             return actual.IndexOf(expected, StringComparison.OrdinalIgnoreCase) != -1;
         }
 
-        public static bool StringContainingUsingCaseSensitivity(string actual, string expected)
+        public static bool StringContainingUsingCaseSensitivity(string? actual, string expected)
         {
             if (actual == null)
                 return false;
@@ -198,7 +199,7 @@ namespace Shouldly
         }
 
 
-        public static bool EndsWithUsingCaseSensitivity(string actual, string expected, Case caseSensitivity)
+        public static bool EndsWithUsingCaseSensitivity(string? actual, string expected, Case caseSensitivity)
         {
             if (actual == null)
                 return false;
@@ -211,7 +212,7 @@ namespace Shouldly
             return actual.EndsWith(expected);
         }
 
-        public static bool StringStartingWithUsingCaseSensitivity(string actual, string expected, Case caseSensitivity)
+        public static bool StringStartingWithUsingCaseSensitivity(string? actual, string expected, Case caseSensitivity)
         {
             if (actual == null)
                 return false;
@@ -224,7 +225,7 @@ namespace Shouldly
             return actual.StartsWith(expected);
         }
 
-        public static bool StringEqualWithCaseSensitivity(string actual, string expected, Case caseSensitivity)
+        public static bool StringEqualWithCaseSensitivity(string? actual, string? expected, Case caseSensitivity)
         {
             if (caseSensitivity == Case.Insensitive)
             {
@@ -259,51 +260,51 @@ namespace Shouldly
             }
         }
 
-        public static bool GreaterThanOrEqualTo<T>(IComparable<T> comparable, T expected)
+        public static bool GreaterThanOrEqualTo<T>(IComparable<T>? comparable, [AllowNull] T expected)
         {
             return Compare(comparable, expected) >= 0;
         }
 
-        public static bool GreaterThanOrEqualTo<T>(T actual, T expected, IComparer<T> comparer)
+        public static bool GreaterThanOrEqualTo<T>([AllowNull] T actual, [AllowNull] T expected, IComparer<T> comparer)
         {
             return Compare(actual, expected, comparer) >= 0;
         }
 
-        public static bool LessThanOrEqualTo<T>(IComparable<T> comparable, T expected)
+        public static bool LessThanOrEqualTo<T>(IComparable<T>? comparable, [AllowNull] T expected)
         {
             return Compare(comparable, expected) <= 0;
         }
 
-        public static bool LessThanOrEqualTo<T>(T actual, T expected, IComparer<T> comparer)
+        public static bool LessThanOrEqualTo<T>([AllowNull] T actual, [AllowNull] T expected, IComparer<T> comparer)
         {
             return Compare(actual, expected, comparer) <= 0;
         }
 
-        public static bool GreaterThan<T>(IComparable<T> comparable, T expected)
+        public static bool GreaterThan<T>(IComparable<T>? comparable, [AllowNull] T expected)
         {
             return Compare(comparable, expected) > 0;
         }
 
-        public static bool GreaterThan<T>(T actual, T expected, IComparer<T> comparer)
+        public static bool GreaterThan<T>([AllowNull] T actual, [AllowNull] T expected, IComparer<T> comparer)
         {
             return Compare(actual, expected, comparer) > 0;
         }
 
-        public static bool LessThan<T>(IComparable<T> comparable, T expected)
+        public static bool LessThan<T>(IComparable<T>? comparable, [AllowNull] T expected)
         {
             return Compare(comparable, expected) < 0;
         }
 
-        public static bool LessThan<T>(T actual, T expected, IComparer<T> comparer)
+        public static bool LessThan<T>([AllowNull] T actual, [AllowNull] T expected, IComparer<T> comparer)
         {
             return Compare(actual, expected, comparer) < 0;
         }
 
-        static decimal Compare<T>(T actual, T expected, IComparer<T> comparer)
+        static decimal Compare<T>([AllowNull] T actual, [AllowNull] T expected, IComparer<T> comparer)
         {
             return comparer.Compare(actual, expected);
         }
-        static decimal Compare<T>(IComparable<T> comparable, T expected)
+        static decimal Compare<T>(IComparable<T>? comparable, [AllowNull] T expected)
         {
             if (!typeof(T).IsValueType())
             {

--- a/src/Shouldly/Internals/Numerics.cs
+++ b/src/Shouldly/Internals/Numerics.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Shouldly;
 
 namespace NUnit.Framework.Constraints
@@ -14,7 +15,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="obj">The object to check</param>
         /// <returns>true if the object is a numeric type</returns>
-        public static bool IsNumericType(Object obj)
+        public static bool IsNumericType([NotNullWhen(true)] object? obj)
         {
             return IsFloatingPointNumeric(obj) || IsFixedPointNumeric(obj);
         }
@@ -25,7 +26,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="obj">The object to check</param>
         /// <returns>true if the object is a floating point numeric type</returns>
-        public static bool IsFloatingPointNumeric(Object obj)
+        public static bool IsFloatingPointNumeric([NotNullWhen(true)] object? obj)
         {
             if (null != obj)
             {
@@ -41,7 +42,7 @@ namespace NUnit.Framework.Constraints
         /// </summary>
         /// <param name="obj">The object to check</param>
         /// <returns>true if the object is a fixed point numeric type</returns>
-        public static bool IsFixedPointNumeric(Object obj)
+        public static bool IsFixedPointNumeric([NotNullWhen(true)] object? obj)
         {
             if (null != obj)
             {
@@ -98,7 +99,7 @@ namespace NUnit.Framework.Constraints
             if (double.IsNaN(expected) && double.IsNaN(actual))
                 return true;
 
-            // Handle infinity specially since subtracting two infinite values gives 
+            // Handle infinity specially since subtracting two infinite values gives
             // NaN and the following test fails. mono also needs NaN to be handled
             // specially although ms.net could use either method. Also, handle
             // situation where no tolerance is used.
@@ -137,7 +138,7 @@ namespace NUnit.Framework.Constraints
             if (float.IsNaN(expected) && float.IsNaN(actual))
                 return true;
 
-            // handle infinity specially since subtracting two infinite values gives 
+            // handle infinity specially since subtracting two infinite values gives
             // NaN and the following test fails. mono also needs NaN to be handled
             // specially although ms.net could use either method.
             if (float.IsInfinity(expected) || float.IsNaN(expected) || float.IsNaN(actual))

--- a/src/Shouldly/Internals/ObjectEqualityComparer.cs
+++ b/src/Shouldly/Internals/ObjectEqualityComparer.cs
@@ -1,11 +1,13 @@
-﻿namespace Shouldly
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Shouldly
 {
 #if Serializable
     [System.Serializable]
 #endif
     class ObjectEqualityComparer<T> : System.Collections.Generic.EqualityComparer<T>
     {
-        public override bool Equals(T x, T y)
+        public override bool Equals([AllowNull] T x, [AllowNull] T y)
         {
             if (x != null)
             {
@@ -14,7 +16,7 @@
             return y == null;
         }
 
-        public override int GetHashCode(T obj)
+        public override int GetHashCode([AllowNull] T obj)
         {
             if (obj == null)
             {
@@ -23,7 +25,7 @@
             return obj.GetHashCode();
         }
 
-        public override bool Equals(object obj) => obj is ObjectEqualityComparer<T>;
+        public override bool Equals(object? obj) => obj is ObjectEqualityComparer<T>;
 
         public override int GetHashCode()
         {

--- a/src/Shouldly/Internals/ShouldThrowAssertionContext.cs
+++ b/src/Shouldly/Internals/ShouldThrowAssertionContext.cs
@@ -4,7 +4,7 @@ namespace Shouldly
 {
     internal class ShouldThrowAssertionContext : ShouldlyAssertionContext
     {
-        public string ExceptionMessage { get; private set; }
+        public string? ExceptionMessage { get; private set; }
 
         public bool IsAsync { get; private set; }
 
@@ -12,10 +12,10 @@ namespace Shouldly
         /// <summary>
         /// Only pass stacktrace if asynchronous
         /// </summary>
-        internal ShouldThrowAssertionContext(object expected, object actual = null, string exceptionMessage = null,
+        internal ShouldThrowAssertionContext(object? expected, object? actual = null, string? exceptionMessage = null,
             bool isAsync = false,
-            System.Diagnostics.StackTrace stackTrace = null,
-            [CallerMemberName] string shouldlyMethod = null) : base(shouldlyMethod, expected, actual, stackTrace)
+            System.Diagnostics.StackTrace? stackTrace = null,
+            [CallerMemberName] string shouldlyMethod = null!) : base(shouldlyMethod, expected, actual, stackTrace)
         {
             ExceptionMessage = exceptionMessage;
             IsAsync = isAsync;
@@ -24,9 +24,9 @@ namespace Shouldly
         /// <summary>
         /// Only pass stacktrace if asynchronous
         /// </summary>
-        internal ShouldThrowAssertionContext(object expected, object actual = null, string exceptionMessage = null,
+        internal ShouldThrowAssertionContext(object? expected, object? actual = null, string? exceptionMessage = null,
             bool isAsync = false,
-            [CallerMemberName] string shouldlyMethod = null) : base(shouldlyMethod, expected, actual)
+            [CallerMemberName] string shouldlyMethod = null!) : base(shouldlyMethod, expected, actual)
         {
             ExceptionMessage = exceptionMessage;
             IsAsync = isAsync;

--- a/src/Shouldly/Internals/ShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/ShouldlyAssertionContext.cs
@@ -8,14 +8,14 @@ namespace Shouldly
     internal class ShouldlyAssertionContext : IShouldlyAssertionContext
     {
         public string ShouldMethod { get; set; }
-        public string CodePart { get; set; }
-        public string FileName { get; set; }
+        public string? CodePart { get; set; }
+        public string? FileName { get; set; }
         public int? LineNumber { get; set; }
 
-        public object Key { get; set; }
-        public object Expected { get; set; }
-        public object Actual { get; set; }
-        public object Tolerance { get; set; }
+        public object? Key { get; set; }
+        public object? Expected { get; set; }
+        public object? Actual { get; set; }
+        public object? Tolerance { get; set; }
         public Case? CaseSensitivity { get; set; }
         public bool CodePartMatchesActual { get { return CodePart == Actual.ToStringAwesomely(); } }
         public TimeSpan? Timeout { get; set; }
@@ -31,18 +31,18 @@ namespace Shouldly
         public bool HasRelevantKey { get; set; }
 
         public bool IsNegatedAssertion => ShouldMethod.Contains("Not");
-        public string CustomMessage { get; set; }
-        public Expression Filter { get; set; }
+        public string? CustomMessage { get; set; }
+        public Expression? Filter { get; set; }
         public int? MatchCount { get; set; }
         public SortDirection SortDirection { get; set; }
         public int OutOfOrderIndex { get; set; }
-        public object OutOfOrderObject { get; set; }
-        public IEnumerable<string> Path { get; set; }
+        public object? OutOfOrderObject { get; set; }
+        public IEnumerable<string>? Path { get; set; }
 
 #if StackTrace
         internal ShouldlyAssertionContext(
-            string shouldlyMethod, object expected = null, object actual = null,
-            System.Diagnostics.StackTrace stackTrace = null)
+            string shouldlyMethod, object? expected = null, object? actual = null,
+            System.Diagnostics.StackTrace? stackTrace = null)
         {
             var actualCodeGetter = new ActualCodeTextGetter();
             Expected = expected;
@@ -54,7 +54,7 @@ namespace Shouldly
             LineNumber = actualCodeGetter.LineNumber;
         }
 #else
-        internal ShouldlyAssertionContext(string shouldlyMethod, object expected = null, object actual = null)
+        internal ShouldlyAssertionContext(string shouldlyMethod, object? expected = null, object? actual = null)
         {
             var actualCodeGetter = new ActualCodeTextGetter();
             Expected = expected;

--- a/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
+++ b/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
@@ -17,6 +17,20 @@ namespace Shouldly
             return method.DeclaringType.GetCustomAttributes(typeof(ShouldlyMethodsAttribute), true).Any()
                || (method.DeclaringType.DeclaringType != null && method.DeclaringType.DeclaringType.GetCustomAttributes(typeof(ShouldlyMethodsAttribute), true).Any());
         }
+
+        /// <summary>
+        /// Required to support the <see cref="DynamicShould.HaveProperty"/> method that takes in a <see
+        /// langword="dynamic"/> as a parameter. Having a method that takes a dynamic really stuffs up the stack trace
+        /// because the runtime binder has to inject a whole heap of methods. Our normal way of just taking the next
+        /// frame doesn't work. The following two lines seem to work for now, but this feels like a hack. The conditions
+        /// to be able to walk up stack trace until we get to the calling method might have to be updated regularly as
+        /// we find more scenarios. Alternately, it could be replaced with a more robust implementation.
+        /// </summary>
+        internal static bool IsSystemDynamicMachinery(this MethodBase method)
+        {
+            return method.DeclaringType is null
+                || (method.DeclaringType.FullName?.StartsWith("System.Dynamic", StringComparison.Ordinal) ?? false);
+        }
 #endif
 
         internal static void AssertAwesomely<T>(

--- a/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
+++ b/src/Shouldly/Internals/ShouldlyCoreExtensions.cs
@@ -13,7 +13,7 @@ namespace Shouldly
         {
             if (method.DeclaringType == null)
                 return false;
-            
+
             return method.DeclaringType.GetCustomAttributes(typeof(ShouldlyMethodsAttribute), true).Any()
                || (method.DeclaringType.DeclaringType != null && method.DeclaringType.DeclaringType.GetCustomAttributes(typeof(ShouldlyMethodsAttribute), true).Any());
         }
@@ -21,9 +21,9 @@ namespace Shouldly
 
         internal static void AssertAwesomely<T>(
             this T actual, Func<T, bool> specifiedConstraint,
-            object originalActual, object originalExpected,
-            [InstantHandle] Func<string> customMessage = null,
-            [CallerMemberName] string shouldlyMethod = null)
+            object? originalActual, object? originalExpected,
+            [InstantHandle] Func<string?>? customMessage = null,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             if (customMessage == null)
                 customMessage = () => null;
@@ -40,10 +40,10 @@ namespace Shouldly
         }
 
         internal static void AssertAwesomelyWithCaseSensitivity<T>(
-            this T actual, Func<T, bool> specifiedConstraint, 
-            object originalActual, object originalExpected, 
-            Case caseSensitivity, Func<string> customMessage = null,
-            [CallerMemberName] string shouldlyMethod = null)
+            this T actual, Func<T, bool> specifiedConstraint,
+            object? originalActual, object? originalExpected,
+            Case caseSensitivity, Func<string?>? customMessage = null,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             try
             {
@@ -60,9 +60,9 @@ namespace Shouldly
 
         internal static void AssertAwesomelyIgnoringOrder<T>(
             this T actual, Func<T, bool> specifiedConstraint,
-            object originalActual, object originalExpected,
-            Func<string> customMessage = null,
-            [CallerMemberName] string shouldlyMethod = null)
+            object? originalActual, object? originalExpected,
+            Func<string?>? customMessage = null,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             if (customMessage == null)
                 customMessage = () => null;
@@ -81,9 +81,9 @@ namespace Shouldly
 
         internal static void AssertAwesomely<T>(
             this T actual, Func<T, bool> specifiedConstraint,
-            object originalActual, object originalExpected, object tolerance,
-            [InstantHandle] Func<string> customMessage = null,
-            [CallerMemberName] string shouldlyMethod = null)
+            object? originalActual, object? originalExpected, object tolerance,
+            [InstantHandle] Func<string?>? customMessage = null,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             if (customMessage == null)
                 customMessage = () => null;
@@ -102,9 +102,9 @@ namespace Shouldly
 
         internal static void AssertAwesomely<T>(
             this T actual, Func<T, bool> specifiedConstraint,
-            object originalActual, object originalExpected, Case caseSensitivity,
-            [InstantHandle] Func<string> customMessage = null,
-            [CallerMemberName] string shouldlyMethod = null)
+            object? originalActual, object? originalExpected, Case caseSensitivity,
+            [InstantHandle] Func<string?>? customMessage = null,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             if (customMessage == null)
                 customMessage = () => null;

--- a/src/Shouldly/Internals/SourceCodeTextGetter.cs
+++ b/src/Shouldly/Internals/SourceCodeTextGetter.cs
@@ -11,7 +11,7 @@ namespace Shouldly.Internals
 #if !StackTrace
     internal class ActualCodeTextGetter : ICodeTextGetter
     {
-        public string GetCodeText(object actual)
+        public string? GetCodeText(object? actual)
         {
             return actual.ToStringAwesomely();
         }
@@ -20,14 +20,14 @@ namespace Shouldly.Internals
     internal class ActualCodeTextGetter : ICodeTextGetter
     {
         bool _determinedOriginatingFrame;
-        string _shouldMethod;
+        string? _shouldMethod;
 
-        public StackFrame ShouldlyFrame { get; private set; }
+        public StackFrame? ShouldlyFrame { get; private set; }
         public int ShouldlyFrameIndex { get; private set; }
-        public string FileName { get; private set; }
+        public string? FileName { get; private set; }
         public int LineNumber { get; private set; }
 
-        public string GetCodeText(object actual, StackTrace stackTrace)
+        public string? GetCodeText(object? actual, StackTrace? stackTrace)
         {
             if (ShouldlyConfiguration.IsSourceDisabledInErrors())
                 return actual.ToStringAwesomely();
@@ -35,7 +35,7 @@ namespace Shouldly.Internals
             return GetCodePart();
         }
 
-        void ParseStackTrace(StackTrace trace)
+        void ParseStackTrace(StackTrace? trace)
         {
             var stackTrace = trace ?? new StackTrace(true);
             var i = 0;
@@ -54,7 +54,7 @@ namespace Shouldly.Internals
                 // Required to support the DynamicShould.HaveProperty method that takes in a dynamic as a parameter.
                 // Having a method that takes a dynamic really stuffs up the stack trace because the runtime binder
                 // has to inject a whole heap of methods. Our normal way of just taking the next frame doesn't work.
-                // The following two lines seem to work for now, but this feels like a hack. The conditions to be able to 
+                // The following two lines seem to work for now, but this feels like a hack. The conditions to be able to
                 // walk up stack trace until we get to the calling method might have to be updated regularly as we find more
                 // scenarios. Alternately, it could be replaced with a more robust implementation.
                 while (currentFrame.GetMethod().DeclaringType == null ||
@@ -84,7 +84,7 @@ namespace Shouldly.Internals
             {
                 var codeLines = string.Join("\n", File.ReadAllLines(FileName).Skip(LineNumber).ToArray());
 
-                var indexOf = codeLines.IndexOf(_shouldMethod);
+                var indexOf = codeLines.IndexOf(_shouldMethod!);
                 if (indexOf > 0)
                     codePart = codeLines.Substring(0, indexOf - 1).Trim();
 
@@ -107,7 +107,7 @@ namespace Shouldly.Internals
         {
             var indexOfParameters =
                 indexOfMethod +
-                _shouldMethod.Length;
+                _shouldMethod!.Length;
 
             var parameterString = codeLines.Substring(indexOfParameters);
             // Remove generic parameter if need be

--- a/src/Shouldly/Internals/SourceCodeTextGetter.cs
+++ b/src/Shouldly/Internals/SourceCodeTextGetter.cs
@@ -22,8 +22,7 @@ namespace Shouldly.Internals
         bool _determinedOriginatingFrame;
         string? _shouldMethod;
 
-        public StackFrame? ShouldlyFrame { get; private set; }
-        public int ShouldlyFrameIndex { get; private set; }
+        public int ShouldlyFrameOffset { get; private set; }
         public string? FileName { get; private set; }
         public int LineNumber { get; private set; }
 
@@ -35,45 +34,35 @@ namespace Shouldly.Internals
             return GetCodePart();
         }
 
-        void ParseStackTrace(StackTrace? trace)
+        void ParseStackTrace(StackTrace? stackTrace)
         {
-            var stackTrace = trace ?? new StackTrace(true);
-            var i = 0;
-            var currentFrame = stackTrace.GetFrame(i);
+            stackTrace ??= new StackTrace(fNeedFileInfo: true);
 
-            if (currentFrame == null) throw new Exception("Unable to find test method");
+            var frames =
+                from index in Enumerable.Range(0, stackTrace.FrameCount)
+                let frame = stackTrace.GetFrame(index)!
+                let method = frame.GetMethod()
+                where method is object && !method.IsSystemDynamicMachinery()
+                select new { index, frame, method };
 
-            ShouldlyFrame = default;
-            while (ShouldlyFrame == null || currentFrame.GetMethod().IsShouldlyMethod())
-            {
-                if (currentFrame.GetMethod().IsShouldlyMethod())
-                    ShouldlyFrame = currentFrame;
+            var shouldlyFrame = frames
+                .SkipWhile(f => !f.method.IsShouldlyMethod())
+                .TakeWhile(f => f.method.IsShouldlyMethod())
+                .LastOrDefault()
+                ?? throw new InvalidOperationException("The stack trace did not contain a Shouldly method.");
 
-                currentFrame = stackTrace.GetFrame(++i);
+            var originatingFrame = frames
+                .FirstOrDefault(f => f.index > shouldlyFrame.index)
+                ?? throw new InvalidOperationException("The stack trace did not contain the caller of the Shouldly method.");
 
-                // Required to support the DynamicShould.HaveProperty method that takes in a dynamic as a parameter.
-                // Having a method that takes a dynamic really stuffs up the stack trace because the runtime binder
-                // has to inject a whole heap of methods. Our normal way of just taking the next frame doesn't work.
-                // The following two lines seem to work for now, but this feels like a hack. The conditions to be able to
-                // walk up stack trace until we get to the calling method might have to be updated regularly as we find more
-                // scenarios. Alternately, it could be replaced with a more robust implementation.
-                while (currentFrame.GetMethod().DeclaringType == null ||
-                        currentFrame.GetMethod().DeclaringType.FullName.StartsWith("System.Dynamic"))
-                {
-                    currentFrame = stackTrace.GetFrame(++i);
-                }
-            }
+            ShouldlyFrameOffset = originatingFrame.index;
 
-            var originatingFrame = currentFrame;
-            ShouldlyFrameIndex = i - 1;
-
-            var fileName = originatingFrame.GetFileName();
+            var fileName = originatingFrame.frame.GetFileName();
             _determinedOriginatingFrame = fileName != null && File.Exists(fileName);
-            _shouldMethod = ShouldlyFrame.GetMethod().Name;
+            _shouldMethod = shouldlyFrame.method.Name;
             FileName = fileName;
-            LineNumber = originatingFrame.GetFileLineNumber() - 1;
+            LineNumber = originatingFrame.frame.GetFileLineNumber() - 1;
         }
-
 
         string GetCodePart()
         {

--- a/src/Shouldly/Internals/StackTraceHelpers.cs
+++ b/src/Shouldly/Internals/StackTraceHelpers.cs
@@ -1,6 +1,7 @@
 ﻿#if StackTrace
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
 
@@ -8,7 +9,7 @@ namespace Shouldly.Internals
 {
     internal static class StackTraceHelpers
     {
-        public static string GetStackTrace(Exception exception, ref string cachedValue)
+        public static string GetStackTrace(Exception exception, [NotNull] ref string? cachedValue)
         {
             if (cachedValue == null)
             {
@@ -26,8 +27,8 @@ namespace Shouldly.Internals
 
             for (var startIndex = 0; startIndex < stackTrace.FrameCount; startIndex++)
             {
-                var frame = stackTrace.GetFrame(startIndex);
-                if (frame.GetMethod().DeclaringType?.Assembly != shouldlyAssembly)
+                var frame = stackTrace.GetFrame(startIndex)!;
+                if (frame.GetMethod()?.DeclaringType?.Assembly != shouldlyAssembly)
                 {
                     if (startIndex == 0)
                     {
@@ -40,7 +41,7 @@ namespace Shouldly.Internals
 
                         for (var i = 0; i < lines.Length; i++)
                         {
-                            var line = new StackTrace(stackTrace.GetFrame(i + startIndex)).ToString();
+                            var line = new StackTrace(stackTrace.GetFrame(i + startIndex)!).ToString();
                             if (i == lines.Length - 1) line = line.TrimEnd();
                             lines[i] = line;
                             neededCapacity += line.Length;

--- a/src/Shouldly/Internals/StringHelpers.cs
+++ b/src/Shouldly/Internals/StringHelpers.cs
@@ -10,7 +10,7 @@ namespace Shouldly
 {
     internal static class StringHelpers
     {
-        internal static string ToStringAwesomely(this object value)
+        internal static string? ToStringAwesomely(this object? value)
         {
             if (value == null)
                 return "null";
@@ -73,8 +73,8 @@ namespace Shouldly
             }
 
             if (type.IsGenericType() && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>)){
-                var key = type.GetProperty("Key").GetValue(value, null);
-                var v = type.GetProperty("Value").GetValue(value, null);
+                var key = type.GetProperty("Key")!.GetValue(value, null);
+                var v = type.GetProperty("Value")!.GetValue(value, null);
                 return $"[{key.ToStringAwesomely()} => {v.ToStringAwesomely()}]";
             }
 
@@ -170,24 +170,24 @@ namespace Shouldly
             return c.ToString();
         }
 
-        internal static bool IsNullOrWhiteSpace(this string s)
+        internal static bool IsNullOrWhiteSpace(this string? s)
         {
             return string.IsNullOrWhiteSpace(s);
         }
 
-        internal static string NormalizeLineEndings(this string s)
+        internal static string? NormalizeLineEndings(this string? s)
         {
             return s == null ? null : Regex.Replace(s, @"\r\n?", "\n");
         }
 
-        static string CommaDelimited<T>(this IEnumerable<T> enumerable) where T : class
+        static string CommaDelimited<T>(this IEnumerable<T> enumerable) where T : class?
         {
             return enumerable.DelimitWith(", ");
         }
 
-        static string DelimitWith<T>(this IEnumerable<T> enumerable, string separator) where T : class
+        static string DelimitWith<T>(this IEnumerable<T> enumerable, string? separator) where T : class?
         {
-            return string.Join(separator, enumerable.Select(i => Equals(i, default(T)) ? null : i.ToString()).ToArray());
+            return string.Join(separator, enumerable.Select(i => Equals(i, null) ? null : i.ToString()).ToArray());
         }
 
         static string ToStringAwesomely(this Enum value)
@@ -198,6 +198,6 @@ namespace Shouldly
         static string ToStringAwesomely(this DateTime value)
         {
             return value.ToString("o");
-        }        
+        }
     }
 }

--- a/src/Shouldly/Internals/TaskExtensions.cs
+++ b/src/Shouldly/Internals/TaskExtensions.cs
@@ -22,7 +22,7 @@ namespace Shouldly
                 case TaskStatus.RanToCompletion:
                     var castedSource = source as Task<TResult>;
                     proxy.TrySetResult(castedSource == null
-                        ? default // source is a Task
+                        ? default! // source is a Task
                         : castedSource.Result); // source is a Task<TResult>
                     break;
             }

--- a/src/Shouldly/Internals/TaskExtensions.cs
+++ b/src/Shouldly/Internals/TaskExtensions.cs
@@ -14,7 +14,7 @@ namespace Shouldly
             switch (source.Status)
             {
                 case TaskStatus.Faulted:
-                    proxy.TrySetException(source.Exception);
+                    proxy.TrySetException(source.Exception!);
                     break;
                 case TaskStatus.Canceled:
                     proxy.TrySetCanceled();

--- a/src/Shouldly/MessageGenerators/DictionaryShouldContainKeyAndValueMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryShouldContainKeyAndValueMessageGenerator.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace Shouldly.MessageGenerators
@@ -14,6 +15,9 @@ namespace Shouldly.MessageGenerators
 
         public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
+            Debug.Assert(context.Actual is IDictionary);
+            Debug.Assert(context.Key is object);
+
             const string format =
 @"{0}
     should contain key
@@ -31,7 +35,7 @@ namespace Shouldly.MessageGenerators
             if (keyExists)
             {
                 var actualValueString = dictionary[context.Key].ToStringAwesomely();
-                var valueString = 
+                var valueString =
 $@"    but value was
 {actualValueString}";
                 return string.Format(format, codePart, keyValue, expectedValue, valueString);

--- a/src/Shouldly/MessageGenerators/DictionaryShouldNotContainValueForKeyMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryShouldNotContainValueForKeyMessageGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 
 namespace Shouldly.MessageGenerators
@@ -15,6 +16,9 @@ namespace Shouldly.MessageGenerators
 
         public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
+            Debug.Assert(context.Actual is IDictionary);
+            Debug.Assert(context.Key is object);
+
             const string format =
 @"{0}
     should not contain key

--- a/src/Shouldly/MessageGenerators/DynamicShouldMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DynamicShouldMessageGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -17,6 +18,8 @@ namespace Shouldly.MessageGenerators
 
         public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
+            Debug.Assert(context.Expected is object);
+
             var propertyName = context.Expected;
 
             var testFileName = context.FileName;
@@ -28,12 +31,12 @@ namespace Shouldly.MessageGenerators
                 var dynamicObjectName = DynamicObjectNameExtractor.Match(codeLine).Groups["dynamicObjectName"];
 
                 const string format = @"Dynamic object ""{0}"" should contain property ""{1}"" but does not.";
-                return string.Format(format, dynamicObjectName.ToString().Trim(), propertyName.ToString().Trim());
+                return string.Format(format, dynamicObjectName.ToString().Trim(), propertyName.ToString()?.Trim());
             }
             else
             {
                 const string format = @"Dynamic object should contain property ""{0}"" but does not.";
-                return string.Format(format, propertyName.ToString().Trim());
+                return string.Format(format, propertyName.ToString()?.Trim());
             }
         }
     }

--- a/src/Shouldly/MessageGenerators/ShouldBeIgnoringOrderMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeIgnoringOrderMessageGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using System.Diagnostics;
 using System.Linq;
 
 namespace Shouldly.MessageGenerators
@@ -12,6 +13,9 @@ namespace Shouldly.MessageGenerators
 
         public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
+            Debug.Assert(context.Expected is IEnumerable);
+            Debug.Assert(context.Actual is IEnumerable);
+
             var expected = ((IEnumerable)context.Expected).Cast<object>().ToArray();
             var actual = ((IEnumerable)context.Actual).Cast<object>().ToArray();
             var codePart = context.CodePart;

--- a/src/Shouldly/MessageGenerators/ShouldSatisfyAllConditionsMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldSatisfyAllConditionsMessageGenerator.cs
@@ -15,7 +15,7 @@ namespace Shouldly.MessageGenerators
         public override string GenerateErrorMessage(IShouldlyAssertionContext context)
         {
             var codePart = context.CodePart;
-            var expectedValue = context.Expected.ToString();
+            var expectedValue = context.Expected?.ToString();
 
             return
 $@"{codePart}

--- a/src/Shouldly/On.cs
+++ b/src/Shouldly/On.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading;
+
+namespace Shouldly
+{
+    internal static class On
+    {
+        public static IDisposable Dispose(Action action) => new OnDisposeAction(action);
+
+        private sealed class OnDisposeAction : IDisposable
+        {
+            private Action? action;
+
+            public OnDisposeAction(Action action)
+            {
+                this.action = action;
+            }
+
+            public void Dispose() => Interlocked.Exchange(ref action, null)?.Invoke();
+        }
+    }
+}

--- a/src/Shouldly/ShouldAssertException.cs
+++ b/src/Shouldly/ShouldAssertException.cs
@@ -10,16 +10,16 @@ namespace Shouldly
     public class ShouldAssertException : Exception
 #pragma warning restore 618
     {
-        public ShouldAssertException(string message) : base(message)
+        public ShouldAssertException(string? message) : base(message)
         {
         }
 
-        public ShouldAssertException(string message, Exception innerException) : base(message, innerException)
+        public ShouldAssertException(string? message, Exception? innerException) : base(message, innerException)
         {
         }
 
 #if StackTrace
-        private string stackTrace;
+        private string? stackTrace;
 
         public override string StackTrace => StackTraceHelpers.GetStackTrace(this, ref stackTrace);
 #endif

--- a/src/Shouldly/ShouldCompleteInException.cs
+++ b/src/Shouldly/ShouldCompleteInException.cs
@@ -4,7 +4,7 @@ namespace Shouldly
 {
     public class ShouldCompleteInException : ShouldlyTimeoutException // Need to do this to not break existing API
     {
-        public ShouldCompleteInException(string message, ShouldlyTimeoutException inner) : base(message, inner)
+        public ShouldCompleteInException(string? message, ShouldlyTimeoutException? inner) : base(message, inner)
         {
         }
     }

--- a/src/Shouldly/ShouldMatchApprovedException.cs
+++ b/src/Shouldly/ShouldMatchApprovedException.cs
@@ -2,12 +2,12 @@ namespace Shouldly
 {
     public class ShouldMatchApprovedException : ShouldAssertException
     {
-        public ShouldMatchApprovedException(string message, string receivedFile, string approvedFile) : base(
+        public ShouldMatchApprovedException(string? message, string? receivedFile, string? approvedFile) : base(
             GenerateMessage(message, receivedFile, approvedFile))
         {
         }
 
-        private static string GenerateMessage(string message, string receivedFile, string approvedFile)
+        private static string GenerateMessage(string? message, string? receivedFile, string? approvedFile)
         {
             var msg = @"To approve the changes run this command:";
 
@@ -21,7 +21,7 @@ copy /Y ""{receivedFile}"" ""{approvedFile}""";
                 msg += $@"
 cp ""{receivedFile}"" ""{approvedFile}""";
             }
-           
+
             msg += $@"
 ----------------------------
 

--- a/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
+++ b/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
@@ -12,17 +12,17 @@ namespace Shouldly
     {
         public static void HaveProperty(dynamic dynamicTestObject, string propertyName)
         {
-            Func<string> customMessage = () => null;
+            Func<string?> customMessage = () => null;
             HaveProperty(dynamicTestObject, propertyName, customMessage);
         }
 
-        public static void HaveProperty(dynamic dynamicTestObject, string propertyName, string customMessage)
+        public static void HaveProperty(dynamic dynamicTestObject, string propertyName, string? customMessage)
         {
-            Func<string> message = () => customMessage;
+            Func<string?> message = () => customMessage;
             HaveProperty(dynamicTestObject, propertyName, message);
         }
 
-        public static void HaveProperty(dynamic dynamicTestObject, string propertyName, [InstantHandle] Func<string> customMessage)
+        public static void HaveProperty(dynamic dynamicTestObject, string propertyName, [InstantHandle] Func<string?>? customMessage)
         {
             if (dynamicTestObject is IDynamicMetaObjectProvider)
             {
@@ -34,7 +34,7 @@ namespace Shouldly
                 }
             }
             else
-            { 
+            {
                 var dynamicAsObject = (object)dynamicTestObject;
                 var properties = dynamicAsObject.GetType().GetProperties();
                 if (!properties.Select(x => x.Name).Contains(propertyName))

--- a/src/Shouldly/ShouldStaticClasses/ShouldCompleteInExtensions.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldCompleteInExtensions.cs
@@ -15,11 +15,11 @@ namespace Shouldly
                         TaskScheduler.Default);
             CompleteIn(actual, timeout, () => null);
         }
-        public static void CompleteIn(Action action, TimeSpan timeout, string customMessage)
+        public static void CompleteIn(Action action, TimeSpan timeout, string? customMessage)
         {
             CompleteIn(action, timeout, () => customMessage);
         }
-        public static void CompleteIn(Action action, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
+        public static void CompleteIn(Action action, TimeSpan timeout, [InstantHandle] Func<string?>? customMessage)
         {
             var actual = Task.Factory.StartNew(action, CancellationToken.None, TaskCreationOptions.None,
                         TaskScheduler.Default);
@@ -31,11 +31,11 @@ namespace Shouldly
         {
             return CompleteIn(function, timeout, () => null);
         }
-        public static T CompleteIn<T>(Func<T> function, TimeSpan timeout, string customMessage)
+        public static T CompleteIn<T>(Func<T> function, TimeSpan timeout, string? customMessage)
         {
             return CompleteIn(function, timeout, () => customMessage);
         }
-        public static T CompleteIn<T>(Func<T> function, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
+        public static T CompleteIn<T>(Func<T> function, TimeSpan timeout, [InstantHandle] Func<string?>? customMessage)
         {
             var actual = Task.Factory.StartNew(function, CancellationToken.None, TaskCreationOptions.None,
                         TaskScheduler.Default);
@@ -48,11 +48,11 @@ namespace Shouldly
         {
             CompleteIn(actual, timeout, () => null);
         }
-        public static void CompleteIn(Func<Task> actual, TimeSpan timeout, string customMessage)
+        public static void CompleteIn(Func<Task> actual, TimeSpan timeout, string? customMessage)
         {
             CompleteIn(actual, timeout, () => customMessage);
         }
-        public static void CompleteIn(Func<Task> actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
+        public static void CompleteIn(Func<Task> actual, TimeSpan timeout, [InstantHandle] Func<string?>? customMessage)
         {
             CompleteIn(actual(), timeout, customMessage, "Task");
         }
@@ -62,11 +62,11 @@ namespace Shouldly
         {
             return CompleteIn(actual, timeout, () => null);
         }
-        public static T CompleteIn<T>(Func<Task<T>> actual, TimeSpan timeout, string customMessage)
+        public static T CompleteIn<T>(Func<Task<T>> actual, TimeSpan timeout, string? customMessage)
         {
             return CompleteIn(actual, timeout, () => customMessage);
         }
-        public static T CompleteIn<T>(Func<Task<T>> actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
+        public static T CompleteIn<T>(Func<Task<T>> actual, TimeSpan timeout, [InstantHandle] Func<string?>? customMessage)
         {
             return CompleteIn(actual(), timeout, customMessage, "Task");
         }
@@ -76,11 +76,11 @@ namespace Shouldly
         {
             CompleteIn(actual, timeout, () => null);
         }
-        public static void CompleteIn(Task actual, TimeSpan timeout, string customMessage)
+        public static void CompleteIn(Task actual, TimeSpan timeout, string? customMessage)
         {
             CompleteIn(actual, timeout, () => customMessage);
         }
-        public static void CompleteIn(Task actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
+        public static void CompleteIn(Task actual, TimeSpan timeout, [InstantHandle] Func<string?>? customMessage)
         {
             CompleteIn(actual, timeout, customMessage, "Task");
         }
@@ -91,23 +91,23 @@ namespace Shouldly
             CompleteIn(actual, timeout, () => null);
             return actual.Result;
         }
-        public static T CompleteIn<T>(Task<T> actual, TimeSpan timeout, string customMessage)
+        public static T CompleteIn<T>(Task<T> actual, TimeSpan timeout, string? customMessage)
         {
             CompleteIn(actual, timeout, () => customMessage);
             return actual.Result;
         }
-        public static T CompleteIn<T>(Task<T> actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage)
+        public static T CompleteIn<T>(Task<T> actual, TimeSpan timeout, [InstantHandle] Func<string?>? customMessage)
         {
             return CompleteIn(actual, timeout, customMessage, "Task");
         }
 
-        private static T CompleteIn<T>(Task<T> actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage, string what)
+        private static T CompleteIn<T>(Task<T> actual, TimeSpan timeout, [InstantHandle] Func<string?>? customMessage, string what)
         {
             CompleteIn((Task)actual, timeout, customMessage, what);
             return actual.Result;
         }
 
-        private static void CompleteIn(Task actual, TimeSpan timeout, [InstantHandle] Func<string> customMessage, string what)
+        private static void CompleteIn(Task actual, TimeSpan timeout, [InstantHandle] Func<string?>? customMessage, string what)
         {
             try
             {
@@ -119,7 +119,7 @@ namespace Shouldly
                 if (flattened.InnerExceptions.Count != 1)
                     throw;
 
-                var inner = flattened.InnerException;
+                var inner = flattened.InnerException!;
                 // When exception is a timeout exception we can provide a better error, otherwise rethrow
                 if (inner is ShouldlyTimeoutException exception)
                 {

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrow.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrow.cs
@@ -14,16 +14,16 @@ namespace Shouldly
         {
             return Throw<TException>(actual, () => null);
         }
-        public static TException Throw<TException>([InstantHandle] Action actual, string customMessage) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Action actual, string? customMessage) where TException : Exception
         {
             return Throw<TException>(actual, () => customMessage);
         }
-        public static TException Throw<TException>([InstantHandle] Action actual, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Action actual, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return ThrowInternal<TException>(actual, customMessage);
         }
-        internal static TException ThrowInternal<TException>([InstantHandle] Action actual, [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null) where TException : Exception
+        internal static TException ThrowInternal<TException>([InstantHandle] Action actual, [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!) where TException : Exception
         {
             try
             {
@@ -46,16 +46,16 @@ namespace Shouldly
         {
             return Throw(actual, () => null, exceptionType);
         }
-        public static Exception Throw([InstantHandle] Action actual, string customMessage, Type exceptionType)
+        public static Exception Throw([InstantHandle] Action actual, string? customMessage, Type exceptionType)
         {
             return Throw(actual, () => customMessage, exceptionType);
         }
-        public static Exception Throw([InstantHandle] Action actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception Throw([InstantHandle] Action actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return ThrowInternal(actual, customMessage, exceptionType);
         }
-        internal static Exception ThrowInternal([InstantHandle] Action actual, [InstantHandle] Func<string> customMessage, Type exceptionType,
-            [CallerMemberName] string shouldlyMethod = null)
+        internal static Exception ThrowInternal([InstantHandle] Action actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             try
             {
@@ -75,20 +75,20 @@ namespace Shouldly
         }
 
         /*** Should.Throw(Func<T>) ***/
-        public static TException Throw<TException>([InstantHandle] Func<object> actual) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Func<object?> actual) where TException : Exception
         {
             return Throw<TException>(actual, () => null);
         }
-        public static TException Throw<TException>([InstantHandle] Func<object> actual, string customMessage) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Func<object?> actual, string? customMessage) where TException : Exception
         {
             return Throw<TException>(actual, () => customMessage);
         }
-        public static TException Throw<TException>([InstantHandle] Func<object> actual, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Func<object?> actual, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return ThrowInternal<TException>(actual, customMessage);
         }
-        internal static TException ThrowInternal<TException>([InstantHandle] Func<object> actual, [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null) where TException : Exception
+        internal static TException ThrowInternal<TException>([InstantHandle] Func<object?> actual, [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!) where TException : Exception
         {
             try
             {
@@ -107,20 +107,20 @@ namespace Shouldly
         }
 
         /*** Should.Throw(Func<T>) ***/
-        public static Exception Throw([InstantHandle] Func<object> actual, Type exceptionType)
+        public static Exception Throw([InstantHandle] Func<object?> actual, Type exceptionType)
         {
             return Throw(actual, () => null, exceptionType);
         }
-        public static Exception Throw([InstantHandle] Func<object> actual, string customMessage, Type exceptionType)
+        public static Exception Throw([InstantHandle] Func<object?> actual, string? customMessage, Type exceptionType)
         {
             return Throw(actual, () => customMessage, exceptionType);
         }
-        public static Exception Throw([InstantHandle] Func<object> actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception Throw([InstantHandle] Func<object?> actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return ThrowInternal(actual, customMessage, exceptionType);
         }
-        internal static Exception ThrowInternal([InstantHandle] Func<object> actual, [InstantHandle] Func<string> customMessage, Type exceptionType,
-            [CallerMemberName] string shouldlyMethod = null)
+        internal static Exception ThrowInternal([InstantHandle] Func<object?> actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             try
             {
@@ -144,16 +144,16 @@ namespace Shouldly
         {
             NotThrow(action, () => null);
         }
-        public static void NotThrow([InstantHandle] Action action, string customMessage)
+        public static void NotThrow([InstantHandle] Action action, string? customMessage)
         {
             NotThrow(action, () => customMessage);
         }
-        public static void NotThrow([InstantHandle] Action action, [InstantHandle] Func<string> customMessage)
+        public static void NotThrow([InstantHandle] Action action, [InstantHandle] Func<string?>? customMessage)
         {
             NotThrowInternal(action, customMessage);
         }
-        internal static void NotThrowInternal([InstantHandle] Action action, [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+        internal static void NotThrowInternal([InstantHandle] Action action, [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             try
             {
@@ -170,11 +170,11 @@ namespace Shouldly
         {
             return NotThrow(action, () => null);
         }
-        public static T NotThrow<T>([InstantHandle] Func<T> action, string customMessage)
+        public static T NotThrow<T>([InstantHandle] Func<T> action, string? customMessage)
         {
             return NotThrow(action, () => customMessage);
         }
-        public static T NotThrow<T>([InstantHandle] Func<T> action, [InstantHandle] Func<string> customMessage)
+        public static T NotThrow<T>([InstantHandle] Func<T> action, [InstantHandle] Func<string?>? customMessage)
         {
             return NotThrowInternal(action, customMessage);
         }
@@ -182,8 +182,8 @@ namespace Shouldly
         /// <summary>
         /// Used to differentiate between the extension methods and the static methods
         /// </summary>
-        internal static T NotThrowInternal<T>([InstantHandle] Func<T> action, [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+        internal static T NotThrowInternal<T>([InstantHandle] Func<T> action, [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             try
             {

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
@@ -13,11 +13,11 @@ namespace Shouldly
         {
             return Throw<TException>(actual, () => null);
         }
-        public static TException Throw<TException>(Task actual, string customMessage) where TException : Exception
+        public static TException Throw<TException>(Task actual, string? customMessage) where TException : Exception
         {
             return Throw<TException>(actual, () => customMessage);
         }
-        public static TException Throw<TException>(Task actual, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException Throw<TException>(Task actual, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return Throw<TException>(() => actual, customMessage);
         }
@@ -27,11 +27,11 @@ namespace Shouldly
         {
             return Throw(actual, () => null, exceptionType);
         }
-        public static Exception Throw(Task actual, string customMessage, Type exceptionType)
+        public static Exception Throw(Task actual, string? customMessage, Type exceptionType)
         {
             return Throw(actual, () => customMessage, exceptionType);
         }
-        public static Exception Throw(Task actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception Throw(Task actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return Throw(() => actual, customMessage, exceptionType);
         }
@@ -41,11 +41,11 @@ namespace Shouldly
         {
             return Throw<TException>(actual, () => null);
         }
-        public static TException Throw<TException>([InstantHandle] Func<Task> actual, string customMessage) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Func<Task> actual, string? customMessage) where TException : Exception
         {
             return Throw<TException>(actual, () => customMessage);
         }
-        public static TException Throw<TException>([InstantHandle] Func<Task> actual, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Func<Task> actual, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return Throw<TException>(actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
         }
@@ -55,11 +55,11 @@ namespace Shouldly
         {
             return Throw(actual, () => null, exceptionType);
         }
-        public static Exception Throw([InstantHandle] Func<Task> actual, string customMessage, Type exceptionType)
+        public static Exception Throw([InstantHandle] Func<Task> actual, string? customMessage, Type exceptionType)
         {
             return Throw(actual, () => customMessage, exceptionType);
         }
-        public static Exception Throw([InstantHandle] Func<Task> actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception Throw([InstantHandle] Func<Task> actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return Throw(actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage, exceptionType);
         }
@@ -69,11 +69,11 @@ namespace Shouldly
         {
             return Throw<TException>(actual, timeoutAfter, () => null);            
         }
-        public static TException Throw<TException>(Task actual, TimeSpan timeoutAfter, string customMessage) where TException : Exception
+        public static TException Throw<TException>(Task actual, TimeSpan timeoutAfter, string? customMessage) where TException : Exception
         {
             return Throw<TException>(actual, timeoutAfter, () => customMessage);
         }
-        public static TException Throw<TException>(Task actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException Throw<TException>(Task actual, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return Throw<TException>(() => actual, timeoutAfter, customMessage);
         }
@@ -83,11 +83,11 @@ namespace Shouldly
         {
             return Throw(actual, timeoutAfter, () => null, exceptionType);            
         }
-        public static Exception Throw(Task actual, TimeSpan timeoutAfter, string customMessage, Type exceptionType)
+        public static Exception Throw(Task actual, TimeSpan timeoutAfter, string? customMessage, Type exceptionType)
         {
             return Throw(actual, timeoutAfter, () => customMessage, exceptionType);
         }
-        public static Exception Throw(Task actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception Throw(Task actual, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return Throw(() => actual, timeoutAfter, customMessage, exceptionType);
         }
@@ -97,18 +97,18 @@ namespace Shouldly
         {
             return Throw<TException>(actual, timeoutAfter, () => null);
         }
-        public static TException Throw<TException>([InstantHandle] Func<Task> actual, TimeSpan timeoutAfter, string customMessage) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Func<Task> actual, TimeSpan timeoutAfter, string? customMessage) where TException : Exception
         {
             return Throw<TException>(actual, timeoutAfter, () => customMessage);
         }
-        public static TException Throw<TException>([InstantHandle] Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException Throw<TException>([InstantHandle] Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return ThrowInternal<TException>(actual, timeoutAfter, customMessage);
         }
         internal static TException ThrowInternal<TException>(
             [InstantHandle] Func<Task> actual, TimeSpan timeoutAfter,
-            [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null) where TException : Exception
+            [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!) where TException : Exception
         {
             try
             {
@@ -138,20 +138,20 @@ namespace Shouldly
         {
             return Throw(actual, timeoutAfter, () => null, exceptionType);
         }
-        public static Exception Throw([InstantHandle] Func<Task> actual, TimeSpan timeoutAfter, string customMessage, Type exceptionType)
+        public static Exception Throw([InstantHandle] Func<Task> actual, TimeSpan timeoutAfter, string? customMessage, Type exceptionType)
         {
             return Throw(actual, timeoutAfter, () => customMessage, exceptionType);
         }
-        public static Exception Throw([InstantHandle] Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception Throw([InstantHandle] Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return ThrowInternal(actual, timeoutAfter, customMessage, exceptionType);
         }
 
         internal static Exception ThrowInternal(
             [InstantHandle] Func<Task> actual, TimeSpan timeoutAfter,
-            [InstantHandle] Func<string> customMessage,
+            [InstantHandle] Func<string?>? customMessage,
             Type exceptionType,
-            [CallerMemberName] string shouldlyMethod = null)
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             try
             {
@@ -183,11 +183,11 @@ namespace Shouldly
         {
             NotThrow(action, () => null);
         }
-        public static void NotThrow(Task action, string customMessage)
+        public static void NotThrow(Task action, string? customMessage)
         {
             NotThrow(action, () => customMessage);
         }
-        public static void NotThrow(Task action, [InstantHandle] Func<string> customMessage)
+        public static void NotThrow(Task action, [InstantHandle] Func<string?>? customMessage)
         {
             NotThrow(() => action, customMessage);
         }
@@ -197,11 +197,11 @@ namespace Shouldly
         {
             return NotThrow(action, () => null);
         }
-        public static T NotThrow<T>(Task<T> action, string customMessage)
+        public static T NotThrow<T>(Task<T> action, string? customMessage)
         {
             return NotThrow(action, () => customMessage);
         }
-        public static T NotThrow<T>(Task<T> action, [InstantHandle] Func<string> customMessage)
+        public static T NotThrow<T>(Task<T> action, [InstantHandle] Func<string?>? customMessage)
         {
             return NotThrow(() => action, customMessage);
         }
@@ -211,11 +211,11 @@ namespace Shouldly
         {
             NotThrow(action, () => null);
         }
-        public static void NotThrow([InstantHandle] Func<Task> action, string customMessage)
+        public static void NotThrow([InstantHandle] Func<Task> action, string? customMessage)
         {
             NotThrow(action, () => customMessage);
         }
-        public static void NotThrow([InstantHandle] Func<Task> action, [InstantHandle] Func<string> customMessage)
+        public static void NotThrow([InstantHandle] Func<Task> action, [InstantHandle] Func<string?>? customMessage)
         {
             NotThrow(action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
         }
@@ -225,11 +225,11 @@ namespace Shouldly
         {
             NotThrow(action, timeoutAfter, () => null);
         }
-        public static void NotThrow(Task action, TimeSpan timeoutAfter, string customMessage)
+        public static void NotThrow(Task action, TimeSpan timeoutAfter, string? customMessage)
         {
             NotThrow(action, timeoutAfter, () => customMessage);
         }
-        public static void NotThrow(Task action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
+        public static void NotThrow(Task action, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage)
         {
             NotThrow(() => action, timeoutAfter, customMessage);
         }
@@ -239,18 +239,18 @@ namespace Shouldly
         {
             NotThrow(action, timeoutAfter, () => null);
         }
-        public static void NotThrow([InstantHandle] Func<Task> action, TimeSpan timeoutAfter, string customMessage)
+        public static void NotThrow([InstantHandle] Func<Task> action, TimeSpan timeoutAfter, string? customMessage)
         {
             NotThrow(action, timeoutAfter, () => customMessage);
         }
-        public static void NotThrow([InstantHandle] Func<Task> action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
+        public static void NotThrow([InstantHandle] Func<Task> action, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage)
         {
             NotThrowInternal(action, timeoutAfter, customMessage);
         }
         internal static void NotThrowInternal(
             [InstantHandle] Func<Task> action, TimeSpan timeoutAfter,
-            [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+            [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             try
             {
@@ -275,11 +275,11 @@ namespace Shouldly
         {
             return NotThrow(action, () => null);  
         }
-        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, string customMessage)
+        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, string? customMessage)
         {
             return NotThrow(action, () => customMessage);
         }
-        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, [InstantHandle] Func<string> customMessage)
+        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, [InstantHandle] Func<string?>? customMessage)
         {
             return NotThrow(action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
         }
@@ -289,11 +289,11 @@ namespace Shouldly
         {
             return NotThrow(action, timeoutAfter, () => null);
         }
-        public static T NotThrow<T>(Task<T> action, TimeSpan timeoutAfter, string customMessage)
+        public static T NotThrow<T>(Task<T> action, TimeSpan timeoutAfter, string? customMessage)
         {
             return NotThrow(action, timeoutAfter, () => customMessage);
         }
-        public static T NotThrow<T>(Task<T> action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
+        public static T NotThrow<T>(Task<T> action, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage)
         {
             return NotThrow(() => action, timeoutAfter, customMessage);
         }
@@ -303,18 +303,18 @@ namespace Shouldly
         {
             return NotThrow(action, timeoutAfter, () => null);
         }
-        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, TimeSpan timeoutAfter, string customMessage)
+        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, TimeSpan timeoutAfter, string? customMessage)
         {
             return NotThrow(action, timeoutAfter, () => customMessage);
         }
-        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
+        public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage)
         {
             return NotThrowInternal(action, timeoutAfter, customMessage);
         }
         internal static T NotThrowInternal<T>(
             [InstantHandle] Func<Task<T>> action, TimeSpan timeoutAfter,
-            [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+            [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             try
             {
@@ -341,7 +341,7 @@ namespace Shouldly
             }
         }
 
-        private static void RunAndWait(Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
+        private static void RunAndWait(Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage)
         {
             // Drop the sync context so continuations will not post to it, causing a deadlock
             if (SynchronizationContext.Current != null)
@@ -355,7 +355,7 @@ namespace Shouldly
             }
         }
 
-        private static TException HandleAggregateException<TException>(AggregateException e, [InstantHandle] Func<string> customMessage) where TException : Exception
+        private static TException HandleAggregateException<TException>(AggregateException e, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             var innerException = e.InnerException;
             if (innerException is TException)
@@ -364,7 +364,7 @@ namespace Shouldly
             throw new ShouldAssertException(new ExpectedActualShouldlyMessage(typeof(TException), innerException.GetType(), customMessage).ToString());
         }
 
-        private static Exception HandleAggregateException(AggregateException e, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        private static Exception HandleAggregateException(AggregateException e, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             var innerException = e.InnerException;
             if (innerException.GetType() == exceptionType)

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
@@ -67,7 +67,7 @@ namespace Shouldly
         /*** Should.Throw(Task, TimeSpan) ***/
         public static TException Throw<TException>(Task actual, TimeSpan timeoutAfter) where TException : Exception
         {
-            return Throw<TException>(actual, timeoutAfter, () => null);            
+            return Throw<TException>(actual, timeoutAfter, () => null);
         }
         public static TException Throw<TException>(Task actual, TimeSpan timeoutAfter, string? customMessage) where TException : Exception
         {
@@ -81,7 +81,7 @@ namespace Shouldly
         /*** Should.Throw(Task, TimeSpan) ***/
         public static Exception Throw(Task actual, TimeSpan timeoutAfter, Type exceptionType)
         {
-            return Throw(actual, timeoutAfter, () => null, exceptionType);            
+            return Throw(actual, timeoutAfter, () => null, exceptionType);
         }
         public static Exception Throw(Task actual, TimeSpan timeoutAfter, string? customMessage, Type exceptionType)
         {
@@ -118,12 +118,10 @@ namespace Shouldly
             {
                 throw;
             }
-            catch (AggregateException e)
-            {
-                return HandleAggregateException<TException>(e, customMessage);
-            }
             catch (Exception e)
             {
+                e = (e as AggregateException)?.InnerException ?? e;
+
                 if (e is TException)
                     return (TException)e;
 
@@ -161,12 +159,10 @@ namespace Shouldly
             {
                 throw;
             }
-            catch (AggregateException e)
-            {
-                return HandleAggregateException(e, customMessage, exceptionType);
-            }
             catch (Exception e)
             {
+                e = (e as AggregateException)?.InnerException ?? e;
+
                 if (e.GetType() == exceptionType)
                 {
                     return e;
@@ -260,12 +256,10 @@ namespace Shouldly
             {
                 throw;
             }
-            catch (AggregateException ex)
-            {
-                throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.InnerException.GetType(), ex.InnerException.Message, customMessage, shouldlyMethod).ToString());
-            }
             catch (Exception ex)
             {
+                ex = (ex as AggregateException)?.InnerException ?? ex;
+
                 throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.GetType(), ex.Message, customMessage, shouldlyMethod).ToString());
             }
         }
@@ -273,7 +267,7 @@ namespace Shouldly
         /*** Should.NotThrow(Func<Task<T>>) ***/
         public static T NotThrow<T>([InstantHandle] Func<Task<T>> action)
         {
-            return NotThrow(action, () => null);  
+            return NotThrow(action, () => null);
         }
         public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, string? customMessage)
         {
@@ -331,12 +325,10 @@ namespace Shouldly
             {
                 throw;
             }
-            catch (AggregateException ex)
-            {
-                throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.InnerException.GetType(), ex.InnerException.Message, customMessage, shouldlyMethod).ToString());
-            }
             catch (Exception ex)
             {
+                ex = (ex as AggregateException)?.InnerException ?? ex;
+
                 throw new ShouldAssertException(new TaskShouldlyThrowMessage(ex.GetType(), ex.Message, customMessage, shouldlyMethod).ToString());
             }
         }
@@ -353,15 +345,6 @@ namespace Shouldly
             {
                 CompleteIn(actual, timeoutAfter, customMessage);
             }
-        }
-
-        private static TException HandleAggregateException<TException>(AggregateException e, [InstantHandle] Func<string?>? customMessage) where TException : Exception
-        {
-            var innerException = e.InnerException;
-            if (innerException is TException)
-                return (TException)innerException;
-
-            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(typeof(TException), innerException.GetType(), customMessage).ToString());
         }
 
         private static Exception HandleAggregateException(AggregateException e, [InstantHandle] Func<string?>? customMessage, Type exceptionType)

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
@@ -313,13 +313,10 @@ namespace Shouldly
             try
             {
                 // Drop the sync context so continuations will not post to it, causing a deadlock
-                if (SynchronizationContext.Current != null)
+                using (Utils.WithSynchronizationContext(null))
                 {
-                    return CompleteIn(Task.Factory.StartNew(action, CancellationToken.None, TaskCreationOptions.None,
-                        TaskScheduler.Default).Unwrap(), timeoutAfter, customMessage);
+                    return CompleteIn(action, timeoutAfter, customMessage);
                 }
-
-                return CompleteIn(action, timeoutAfter, customMessage);
             }
             catch (ShouldlyTimeoutException)
             {
@@ -336,12 +333,7 @@ namespace Shouldly
         private static void RunAndWait(Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage)
         {
             // Drop the sync context so continuations will not post to it, causing a deadlock
-            if (SynchronizationContext.Current != null)
-            {
-                CompleteIn(Task.Factory.StartNew(actual, CancellationToken.None, TaskCreationOptions.None,
-                    TaskScheduler.Default).Unwrap(), timeoutAfter, customMessage);
-            }
-            else
+            using (Utils.WithSynchronizationContext(null))
             {
                 CompleteIn(actual, timeoutAfter, customMessage);
             }

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
@@ -339,9 +339,11 @@ namespace Shouldly
             }
         }
 
-        private static Exception HandleAggregateException(AggregateException e, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
+        private static Exception HandleTaskAggregateException(AggregateException exceptionFromTask, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
-            var innerException = e.InnerException;
+            var innerException = exceptionFromTask.InnerException
+                ?? throw new ArgumentException("The specified exception is not from Task.Exception or it would have at least one inner exception.", nameof(exceptionFromTask));
+
             if (innerException.GetType() == exceptionType)
                 return innerException;
 

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
@@ -160,7 +160,7 @@ namespace Shouldly
                     if (t.Exception == null)
                         throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(exceptionType, customMessage, stackTrace).ToString());
 
-                    return HandleAggregateException(t.Exception, customMessage, exceptionType);
+                    return HandleTaskAggregateException(t.Exception, customMessage, exceptionType);
                 }
 
                 if (t.IsCanceled)
@@ -177,7 +177,7 @@ namespace Shouldly
                     if (t.Exception == null)
                         throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, customMessage).ToString());
 
-                    return HandleAggregateException(t.Exception, customMessage, exceptionType);
+                    return HandleTaskAggregateException(t.Exception, customMessage, exceptionType);
                 }
 
                 if (t.IsCanceled)

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
@@ -12,11 +12,11 @@ namespace Shouldly
         {
             return ThrowAsync<TException>(task, () => null);
         }
-        public static Task<TException> ThrowAsync<TException>(Task task, string customMessage) where TException : Exception
+        public static Task<TException> ThrowAsync<TException>(Task task, string? customMessage) where TException : Exception
         {
             return ThrowAsync<TException>(task, () => customMessage);
         }
-        public static Task<TException> ThrowAsync<TException>(Task task, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static Task<TException> ThrowAsync<TException>(Task task, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return ThrowAsync<TException>(() => task, customMessage);
         }
@@ -25,11 +25,11 @@ namespace Shouldly
         {
             return ThrowAsync(task, () => null, exceptionType);
         }
-        public static Task<Exception> ThrowAsync(Task task, string customMessage, Type exceptionType)
+        public static Task<Exception> ThrowAsync(Task task, string? customMessage, Type exceptionType)
         {
             return ThrowAsync(task, () => customMessage, exceptionType);
         }
-        public static Task<Exception> ThrowAsync(Task task, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Task<Exception> ThrowAsync(Task task, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return ThrowAsync(() => task, customMessage, exceptionType);
         }
@@ -39,12 +39,12 @@ namespace Shouldly
         {
             return ThrowAsync<TException>(actual, () => null);
         }
-        public static Task<TException> ThrowAsync<TException>(Func<Task> actual, string customMessage) where TException : Exception
+        public static Task<TException> ThrowAsync<TException>(Func<Task> actual, string? customMessage) where TException : Exception
         {
             return ThrowAsync<TException>(actual, () => customMessage);
         }
 
-        public static Task<TException> ThrowAsync<TException>(Func<Task> actual, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static Task<TException> ThrowAsync<TException>(Func<Task> actual, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
 #if StackTrace
             var stackTrace = new StackTrace(true);
@@ -80,7 +80,7 @@ namespace Shouldly
                                 case ShouldAssertException assert:
                                     throw assert;
                                 default:
-                                    throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), x.Result.GetType(), customMessage, stackTrace).ToString(), x.Result);                                    
+                                    throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), x.Result.GetType(), customMessage, stackTrace).ToString(), x.Result);
                             }
                         });
                 }
@@ -104,15 +104,15 @@ namespace Shouldly
 
                                 if (t.Exception.InnerException is TException expectedException)
                                     return expectedException;
-        
+
                                 return new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), t.Exception.InnerException.GetType(), customMessage).ToString());
                             }
-        
+
                             if (t.IsCanceled)
                             {
                                 return new TaskCanceledException(t);
                             }
-        
+
                             return new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), customMessage).ToString());
                         }))
                     .ContinueWith(x =>
@@ -145,11 +145,11 @@ namespace Shouldly
         {
             return ThrowAsync(actual, () => null, exceptionType);
         }
-        public static Task<Exception> ThrowAsync(Func<Task> actual, string customMessage, Type exceptionType)
+        public static Task<Exception> ThrowAsync(Func<Task> actual, string? customMessage, Type exceptionType)
         {
             return ThrowAsync(actual, () => customMessage, exceptionType);
         }
-        public static Task<Exception> ThrowAsync(Func<Task> actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Task<Exception> ThrowAsync(Func<Task> actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
 #if StackTrace
             var stackTrace = new StackTrace(true);

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
@@ -55,13 +55,11 @@ namespace Shouldly
                         {
                             if (t.IsFaulted)
                             {
-                                if (t.Exception == null)
-                                    return new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), customMessage, stackTrace).ToString());
-
-                                if (t.Exception.InnerException is TException expectedException)
+                                if (t.Exception!.InnerException is TException expectedException)
                                     return expectedException;
 
-                                return new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), t.Exception.InnerException.GetType(), customMessage, stackTrace).ToString());
+                                // If Task.IsFaulted is true, there is at least one inner exception.
+                                return new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), t.Exception.InnerException!.GetType(), customMessage, stackTrace).ToString());
                             }
 
                             if (t.IsCanceled)
@@ -99,13 +97,11 @@ namespace Shouldly
                         {
                             if (t.IsFaulted)
                             {
-                                if (t.Exception == null)
-                                    return new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), customMessage).ToString());
-
-                                if (t.Exception.InnerException is TException expectedException)
+                                if (t.Exception!.InnerException is TException expectedException)
                                     return expectedException;
 
-                                return new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), t.Exception.InnerException.GetType(), customMessage).ToString());
+                                // If Task.IsFaulted is true, there is at least one inner exception.
+                                return new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), t.Exception.InnerException!.GetType(), customMessage).ToString());
                             }
 
                             if (t.IsCanceled)

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -13,7 +13,6 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/shouldly/shouldly.git</RepositoryUrl>
-    <LangVersion>latest</LangVersion>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>

--- a/src/Shouldly/ShouldlyConfiguration.cs
+++ b/src/Shouldly/ShouldlyConfiguration.cs
@@ -33,14 +33,7 @@ namespace Shouldly
         }
 
         public static ShouldMatchConfigurationBuilder ShouldMatchApprovedDefaults { get; private set; } =
-            new ShouldMatchConfigurationBuilder(new ShouldMatchConfiguration
-            {
-                StringCompareOptions = StringCompareShould.IgnoreLineEndings,
-                TestMethodFinder = new FirstNonShouldlyMethodFinder(),
-                FileExtension = "txt",
-                FilenameGenerator = (testMethodInfo, descriminator, type, extension)
-                    => $"{testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}{descriminator}.{type}.{extension}"
-            });
+            new ShouldMatchConfigurationBuilder(new ShouldMatchConfiguration());
 #endif
 
         /// <summary>

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/DateTimeShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/DateTimeShouldBeTestExtensions.cs
@@ -10,12 +10,12 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldBe(this DateTime actual, DateTime expected, TimeSpan tolerance, string customMessage)
+        public static void ShouldBe(this DateTime actual, DateTime expected, TimeSpan tolerance, string? customMessage)
         {
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this DateTime actual, DateTime expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe(this DateTime actual, DateTime expected, TimeSpan tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -25,12 +25,12 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, string customMessage)
+        public static void ShouldBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, string? customMessage)
         {
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -40,12 +40,12 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, string customMessage)
+        public static void ShouldBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, string? customMessage)
         {
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -55,12 +55,12 @@ namespace Shouldly
             ShouldNotBe(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldNotBe(this DateTime actual, DateTime expected, TimeSpan tolerance, string customMessage)
+        public static void ShouldNotBe(this DateTime actual, DateTime expected, TimeSpan tolerance, string? customMessage)
         {
             ShouldNotBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldNotBe(this DateTime actual, DateTime expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBe(this DateTime actual, DateTime expected, TimeSpan tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => !Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -70,12 +70,12 @@ namespace Shouldly
             ShouldNotBe(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldNotBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, string customMessage)
+        public static void ShouldNotBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, string? customMessage)
         {
             ShouldNotBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldNotBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBe(this DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => !Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -85,14 +85,14 @@ namespace Shouldly
             ShouldNotBe(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldNotBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, string customMessage)
+        public static void ShouldNotBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, string? customMessage)
         {
             ShouldNotBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldNotBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBe(this TimeSpan actual, TimeSpan expected, TimeSpan tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => !Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
-        } 
+        }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 
 namespace Shouldly
@@ -10,53 +11,72 @@ namespace Shouldly
     public static partial class ShouldBeTestExtensions
     {
         [ContractAnnotation("actual:null,expected:notnull => halt;actual:notnull,expected:null => halt")]
-        public static void ShouldBe<T>(this T actual, T expected)
+        public static void ShouldBe<T>(
+            [AllowNull, NotNullIfNotNull("expected")] this T actual,
+            [AllowNull, NotNullIfNotNull("actual")] T expected)
         {
             ShouldBe(actual, expected, () => null);
         }
         [ContractAnnotation("actual:null,expected:notnull => halt;actual:notnull,expected:null => halt")]
-        public static void  ShouldBe<T>(this T actual, T expected, string customMessage)
+        public static void  ShouldBe<T>(
+            [AllowNull, NotNullIfNotNull("expected")] this T actual,
+            [AllowNull, NotNullIfNotNull("actual")] T expected
+            , string? customMessage)
         {
             ShouldBe(actual, expected, () => customMessage);
         }
         [ContractAnnotation("actual:null,expected:notnull => halt;actual:notnull,expected:null => halt")]
-        public static void ShouldBe<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe<T>(
+            [AllowNull, NotNullIfNotNull("expected")] this T actual,
+            [AllowNull, NotNullIfNotNull("actual")] T expected,
+            [InstantHandle] Func<string?>? customMessage)
         {
-            if (ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName) || typeof(T) == typeof(string))
+            if (ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName!) || typeof(T) == typeof(string))
                 actual.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<T>()), actual, expected, customMessage);
             else
                 actual.AssertAwesomely(v => Is.Equal(v, expected), actual, expected, customMessage);
         }
 
         [ContractAnnotation("actual:null,expected:null => halt")]
-        public static void ShouldNotBe<T>(this T actual, T expected)
+        public static void ShouldNotBe<T>([AllowNull] this T actual, [AllowNull] T expected)
         {
             ShouldNotBe(actual, expected, () => null);
         }
         [ContractAnnotation("actual:null,expected:null => halt")]
-        public static void ShouldNotBe<T>(this T actual, T expected, string customMessage)
+        public static void ShouldNotBe<T>([AllowNull] this T actual, [AllowNull] T expected, string? customMessage)
         {
             ShouldNotBe(actual, expected, () => customMessage);
         }
         [ContractAnnotation("actual:null,expected:null => halt")]
-        public static void ShouldNotBe<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBe<T>([AllowNull] this T actual, [AllowNull] T expected, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => !Is.Equal(v, expected), actual, expected, customMessage);
         }
 
-        public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool ignoreOrder = false)
+        public static void ShouldBe<T>(
+            [NotNullIfNotNull("expected")] this IEnumerable<T>? actual,
+            [NotNullIfNotNull("actual")] IEnumerable<T>? expected,
+            bool ignoreOrder = false)
         {
             ShouldBe(actual, expected, ignoreOrder, () => null);
         }
-        public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool ignoreOrder, string customMessage)
+        public static void ShouldBe<T>(
+            [NotNullIfNotNull("expected")] this IEnumerable<T>? actual,
+            [NotNullIfNotNull("actual")] IEnumerable<T>? expected,
+            bool ignoreOrder,
+            string? customMessage)
         {
             ShouldBe(actual, expected, ignoreOrder, () => customMessage);
         }
-        public static void ShouldBe<T>(this IEnumerable<T> actual, IEnumerable<T> expected, bool ignoreOrder, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe<T>(
+            [NotNullIfNotNull("expected")] this IEnumerable<T>? actual,
+            [NotNullIfNotNull("actual")] IEnumerable<T>? expected,
+            bool ignoreOrder,
+            [InstantHandle] Func<string?>? customMessage)
         {
-            if (!ignoreOrder && ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName))
+            if (!ignoreOrder && ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName!))
             {
-                actual.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<IEnumerable<T>>()), actual, expected, customMessage);
+                actual.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<IEnumerable<T>?>()), actual, expected, customMessage);
             }
             else
             {
@@ -75,37 +95,45 @@ namespace Shouldly
         {
             ShouldBe(actual, expected, tolerance, () => null);
         }
-        public static void ShouldBe(this IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance, string customMessage)
+        public static void ShouldBe(this IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance, string? customMessage)
         {
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
-        public static void ShouldBe(this IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe(this IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
 
-        public static void ShouldBeSameAs(this object actual, object expected)
+        public static void ShouldBeSameAs(
+            [NotNullIfNotNull("expected")] this object? actual,
+            [NotNullIfNotNull("actual")] object? expected)
         {
             ShouldBeSameAs(actual, expected, () => null);
         }
-        public static void ShouldBeSameAs(this object actual, object expected, string customMessage)
+        public static void ShouldBeSameAs(
+            [NotNullIfNotNull("expected")] this object? actual,
+            [NotNullIfNotNull("actual")] object? expected,
+            string? customMessage)
         {
             ShouldBeSameAs(actual, expected, () => customMessage);
         }
-        public static void ShouldBeSameAs(this object actual, object expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeSameAs(
+            [NotNullIfNotNull("expected")] this object? actual,
+            [NotNullIfNotNull("actual")] object? expected,
+            [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.Same(v, expected), actual, expected, customMessage);
         }
 
-        public static void ShouldNotBeSameAs(this object actual, object expected)
+        public static void ShouldNotBeSameAs(this object? actual, object? expected)
         {
             ShouldNotBeSameAs(actual, expected, () => null);
         }
-        public static void ShouldNotBeSameAs(this object actual, object expected, string customMessage)
+        public static void ShouldNotBeSameAs(this object? actual, object? expected, string? customMessage)
         {
             ShouldNotBeSameAs(actual, expected, () => customMessage);
         }
-        public static void ShouldNotBeSameAs(this object actual, object expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBeSameAs(this object? actual, object? expected, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => !Is.Same(v, expected), actual, expected, customMessage);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
@@ -32,9 +32,9 @@ namespace Shouldly
             [InstantHandle] Func<string?>? customMessage)
         {
             if (ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName!) || typeof(T) == typeof(string))
-                actual.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<T>()), actual, expected, customMessage);
+                actual!.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<T>()), actual, expected, customMessage);
             else
-                actual.AssertAwesomely(v => Is.Equal(v, expected), actual, expected, customMessage);
+                actual!.AssertAwesomely(v => Is.Equal(v, expected), actual, expected, customMessage);
         }
 
         [ContractAnnotation("actual:null,expected:null => halt")]
@@ -50,7 +50,7 @@ namespace Shouldly
         [ContractAnnotation("actual:null,expected:null => halt")]
         public static void ShouldNotBe<T>([AllowNull] this T actual, [AllowNull] T expected, [InstantHandle] Func<string?>? customMessage)
         {
-            actual.AssertAwesomely(v => !Is.Equal(v, expected), actual, expected, customMessage);
+            actual!.AssertAwesomely(v => !Is.Equal(v, expected), actual, expected, customMessage);
         }
 
         public static void ShouldBe<T>(

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/NumericShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/NumericShouldBeTestExtensions.cs
@@ -11,12 +11,12 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldBe(this float actual, float expected, double tolerance, string customMessage)
+        public static void ShouldBe(this float actual, float expected, double tolerance, string? customMessage)
         {
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this float actual, float expected, double tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe(this float actual, float expected, double tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -26,12 +26,12 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldBe(this IEnumerable<double> actual, IEnumerable<double> expected, double tolerance, string customMessage)
+        public static void ShouldBe(this IEnumerable<double> actual, IEnumerable<double> expected, double tolerance, string? customMessage)
         {
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this IEnumerable<double> actual, IEnumerable<double> expected, double tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe(this IEnumerable<double> actual, IEnumerable<double> expected, double tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -41,12 +41,12 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldBe(this IEnumerable<float> actual, IEnumerable<float> expected, double tolerance, string customMessage)
+        public static void ShouldBe(this IEnumerable<float> actual, IEnumerable<float> expected, double tolerance, string? customMessage)
         {
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this IEnumerable<float> actual, IEnumerable<float> expected, double tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe(this IEnumerable<float> actual, IEnumerable<float> expected, double tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -56,12 +56,12 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldBe(this double actual, double expected, double tolerance, string customMessage)
+        public static void ShouldBe(this double actual, double expected, double tolerance, string? customMessage)
         {
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this double actual, double expected, double tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe(this double actual, double expected, double tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         }
@@ -71,12 +71,12 @@ namespace Shouldly
             ShouldBe(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, string customMessage)
+        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, string? customMessage)
         {
             ShouldBe(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe(this decimal actual, decimal expected, decimal tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.Equal(v, expected, tolerance), actual, expected, tolerance, customMessage);
         } 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -11,24 +12,36 @@ namespace Shouldly
     [ShouldlyMethods]
     public static class ObjectGraphTestExtensions
     {
-        public static void ShouldBeEquivalentTo(this object actual, object expected)
+        public static void ShouldBeEquivalentTo(
+            [NotNullIfNotNull("expected")] this object? actual,
+            [NotNullIfNotNull("actual")] object? expected)
         {
             ShouldBeEquivalentTo(actual, expected, () => null);
         }
 
-        public static void ShouldBeEquivalentTo(this object actual, object expected, string customMessage)
+        public static void ShouldBeEquivalentTo(
+            [NotNullIfNotNull("expected")] this object? actual,
+            [NotNullIfNotNull("actual")] object? expected,
+            string? customMessage)
         {
             ShouldBeEquivalentTo(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeEquivalentTo(this object actual, object expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeEquivalentTo(
+            [NotNullIfNotNull("expected")] this object? actual,
+            [NotNullIfNotNull("actual")] object? expected,
+            [InstantHandle] Func<string?>? customMessage)
         {
-            CompareObjects(actual, expected, new List<string>(), new Dictionary<object, IList<object>>(), customMessage);
+            CompareObjects(actual, expected, new List<string>(), new Dictionary<object, IList<object?>>(), customMessage);
         }
 
-        private static void CompareObjects(object actual, object expected,
-            IList<string> path, IDictionary<object, IList<object>> previousComparisons,
-            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        private static void CompareObjects(
+            [NotNullIfNotNull("expected")] this object? actual,
+            [NotNullIfNotNull("actual")] object? expected,
+            IList<string> path,
+            IDictionary<object, IList<object?>> previousComparisons,
+            [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             if (BothValuesAreNull(actual, expected, path, customMessage, shouldlyMethod))
                 return;
@@ -49,8 +62,12 @@ namespace Shouldly
             }
         }
 
-        private static bool BothValuesAreNull(object actual, object expected, IEnumerable<string> path,
-            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        private static bool BothValuesAreNull(
+            [NotNullWhen(false)] object? actual,
+            [NotNullWhen(false)] object? expected,
+            IEnumerable<string> path,
+            [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
         {
             if (expected == null)
             {
@@ -68,7 +85,7 @@ namespace Shouldly
         }
 
         private static Type GetTypeToCompare(object actual, object expected, IList<string> path,
-            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+            [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
         {
             var expectedType = expected.GetType();
             var actualType = actual.GetType();
@@ -86,15 +103,15 @@ namespace Shouldly
         }
 
         private static void CompareValueTypes(ValueType actual, ValueType expected, IEnumerable<string> path,
-            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+            [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
         {
             if (!actual.Equals(expected))
                 ThrowException(actual, expected, path, customMessage, shouldlyMethod);
         }
 
         private static void CompareReferenceTypes(object actual, object expected, Type type,
-            IEnumerable<string> path, IDictionary<object, IList<object>> previousComparisons,
-            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+            IEnumerable<string> path, IDictionary<object, IList<object?>> previousComparisons,
+            [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
         {
             if (ReferenceEquals(actual, expected) ||
                 previousComparisons.Contains(actual, expected))
@@ -118,18 +135,18 @@ namespace Shouldly
         }
 
         private static void CompareStrings(string actual, string expected, IEnumerable<string> path,
-            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+            [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
         {
             if (!actual.Equals(expected, StringComparison.Ordinal))
                 ThrowException(actual, expected, path, customMessage, shouldlyMethod);
         }
 
         private static void CompareEnumerables(IEnumerable actual, IEnumerable expected,
-            IEnumerable<string> path, IDictionary<object, IList<object>> previousComparisons,
-            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+            IEnumerable<string> path, IDictionary<object, IList<object?>> previousComparisons,
+            [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
         {
-            var expectedList = expected.Cast<object>().ToList();
-            var actualList = actual.Cast<object>().ToList();
+            var expectedList = expected.Cast<object?>().ToList();
+            var actualList = actual.Cast<object?>().ToList();
 
             if (actualList.Count != expectedList.Count)
             {
@@ -145,8 +162,8 @@ namespace Shouldly
         }
 
         private static void CompareProperties(object actual, object expected, IEnumerable<PropertyInfo> properties,
-            IEnumerable<string> path, IDictionary<object, IList<object>> previousComparisons,
-            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+            IEnumerable<string> path, IDictionary<object, IList<object?>> previousComparisons,
+            [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
         {
             foreach (var property in properties)
             {
@@ -158,26 +175,26 @@ namespace Shouldly
             }
         }
 
-        private static void ThrowException(object actual, object expected, IEnumerable<string> path,
-            [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        private static void ThrowException(object? actual, object? expected, IEnumerable<string> path,
+            [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
         {
             throw new ShouldAssertException(
                 new ExpectedEquvalenceShouldlyMessage(expected, actual, path, customMessage, shouldlyMethod).ToString());
         }
 
-        private static bool Contains(this IDictionary<object, IList<object>> comparisons, object actual, object expected)
+        private static bool Contains(this IDictionary<object, IList<object?>> comparisons, object actual, object? expected)
         {
-            return comparisons.TryGetValue(actual, out IList<object> list)
+            return comparisons.TryGetValue(actual, out IList<object?>? list)
                    && list.Contains(expected);
         }
 
-        private static void Record(this IDictionary<object, IList<object>> comparisons, object actual,
-            object expected)
+        private static void Record(this IDictionary<object, IList<object?>> comparisons, object actual,
+            object? expected)
         {
-            if (comparisons.TryGetValue(actual, out IList<object> list))
+            if (comparisons.TryGetValue(actual, out IList<object?>? list))
                 list.Add(expected);
             else
-                comparisons.Add(actual, new List<object>(new[] { expected }));
+                comparisons.Add(actual, new List<object?>(new[] { expected }));
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringContainsTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringContainsTestExtensions.cs
@@ -21,7 +21,7 @@ namespace Shouldly
         public static void ShouldContainWithoutWhitespace(this string actual, object? expected, [InstantHandle] Func<string?>? customMessage)
         {
             var strippedActual = actual.Quotify().StripWhitespace();
-            var strippedExpected = (expected ?? "NULL").ToString().Quotify().StripWhitespace();
+            var strippedExpected = (expected?.ToString() ?? "NULL").Quotify().StripWhitespace();
 
             strippedActual.AssertAwesomely(v => v.Contains(strippedExpected), actual, expected, customMessage);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringContainsTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringContainsTestExtensions.cs
@@ -8,17 +8,17 @@ namespace Shouldly
         /// <summary>
         /// Strip out whitespace (whitespace, tabs, line-endings, etc) and compare the two strings
         /// </summary>
-        public static void ShouldContainWithoutWhitespace(this string actual, object expected)
+        public static void ShouldContainWithoutWhitespace(this string actual, object? expected)
         {
             ShouldContainWithoutWhitespace(actual, expected, () => null);
         }
 
-        public static void ShouldContainWithoutWhitespace(this string actual, object expected, string customMessage)
+        public static void ShouldContainWithoutWhitespace(this string actual, object? expected, string? customMessage)
         {
             ShouldContainWithoutWhitespace(actual, expected, () => customMessage);
         }
 
-        public static void ShouldContainWithoutWhitespace(this string actual, object expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldContainWithoutWhitespace(this string actual, object? expected, [InstantHandle] Func<string?>? customMessage)
         {
             var strippedActual = actual.Quotify().StripWhitespace();
             var strippedExpected = (expected ?? "NULL").ToString().Quotify().StripWhitespace();
@@ -36,25 +36,25 @@ namespace Shouldly
             ShouldContain(actual, expected, () => null, caseSensitivity);
         }
 
-        public static void ShouldContain(this string actual, string expected, string customMessage)
+        public static void ShouldContain(this string actual, string expected, string? customMessage)
         {
             ShouldContain(actual, expected, () => customMessage, Case.Insensitive);
         }
 
-        public static void ShouldContain(this string actual, string expected, string customMessage, Case caseSensitivity)
+        public static void ShouldContain(this string actual, string expected, string? customMessage, Case caseSensitivity)
         {
             ShouldContain(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldContain(this string actual, string expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldContain(this string actual, string expected, [InstantHandle] Func<string?>? customMessage)
         {
             ShouldContain(actual, expected, customMessage, Case.Insensitive);
         }
 
-        public static void ShouldContain(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity)
+        public static void ShouldContain(this string actual, string expected, [InstantHandle] Func<string?>? customMessage, Case caseSensitivity)
         {
             actual.AssertAwesomely(
-                v => (caseSensitivity == Case.Sensitive) ? Is.StringContainingUsingCaseSensitivity(v, expected) : Is.StringContainingIgnoreCase(v, expected), 
+                v => (caseSensitivity == Case.Sensitive) ? Is.StringContainingUsingCaseSensitivity(v, expected) : Is.StringContainingIgnoreCase(v, expected),
                 actual.Clip(100, "..."),
                 expected,
                 caseSensitivity,
@@ -71,22 +71,22 @@ namespace Shouldly
             ShouldNotContain(actual, expected, () => null, caseSensitivity);
         }
 
-        public static void ShouldNotContain(this string actual, string expected, string customMessage)
+        public static void ShouldNotContain(this string actual, string expected, string? customMessage)
         {
             ShouldNotContain(actual, expected, () => customMessage, Case.Insensitive);
         }
 
-        public static void ShouldNotContain(this string actual, string expected, string customMessage, Case caseSensitivity)
+        public static void ShouldNotContain(this string actual, string expected, string? customMessage, Case caseSensitivity)
         {
             ShouldNotContain(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldNotContain(this string actual, string expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotContain(this string actual, string expected, [InstantHandle] Func<string?>? customMessage)
         {
             ShouldNotContain(actual, expected, customMessage, Case.Insensitive);
         }
 
-        public static void ShouldNotContain(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity)
+        public static void ShouldNotContain(this string actual, string expected, [InstantHandle] Func<string?>? customMessage, Case caseSensitivity)
         {
             actual.AssertAwesomely(v =>
             {
@@ -100,12 +100,12 @@ namespace Shouldly
             ShouldMatch(actual, regexPattern, () => null);
         }
 
-        public static void ShouldMatch(this string actual, string regexPattern, string customMessage)
+        public static void ShouldMatch(this string actual, string regexPattern, string? customMessage)
         {
             ShouldMatch(actual, regexPattern, () => customMessage);
         }
 
-        public static void ShouldMatch(this string actual, string regexPattern, [InstantHandle] Func<string> customMessage)
+        public static void ShouldMatch(this string actual, string regexPattern, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.StringMatchingRegex(v, regexPattern), actual, regexPattern, customMessage);
         }
@@ -115,12 +115,12 @@ namespace Shouldly
             ShouldNotMatch(actual, regexPattern, () => null);
         }
 
-        public static void ShouldNotMatch(this string actual, string regexPattern, string customMessage)
+        public static void ShouldNotMatch(this string actual, string regexPattern, string? customMessage)
         {
             ShouldNotMatch(actual, regexPattern, () => customMessage);
         }
 
-        public static void ShouldNotMatch(this string actual, string regexPattern, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotMatch(this string actual, string regexPattern, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => !Is.StringMatchingRegex(v, regexPattern), actual, regexPattern, customMessage);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringNullOrEmptyTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringNullOrEmptyTestExtensions.cs
@@ -1,43 +1,44 @@
 ﻿using System;
 using JetBrains.Annotations;
+using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 
 namespace Shouldly
 {
     public static partial class ShouldBeStringTestExtensions
     {
         [ContractAnnotation("actual:notnull => halt")]
-        public static void ShouldBeNullOrEmpty(this string actual)
+        public static void ShouldBeNullOrEmpty(this string? actual)
         {
             ShouldBeNullOrEmpty(actual, () => null);
         }
 
         [ContractAnnotation("actual:notnull => halt")]
-        public static void ShouldBeNullOrEmpty(this string actual, string customMessage)
+        public static void ShouldBeNullOrEmpty(this string? actual, string? customMessage)
         {
             ShouldBeNullOrEmpty(actual, () => customMessage);
         }
 
         [ContractAnnotation("actual:notnull => halt")]
-        public static void ShouldBeNullOrEmpty(this string actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeNullOrEmpty(this string? actual, [InstantHandle] Func<string?>? customMessage)
         {
             if (!string.IsNullOrEmpty(actual))
                 throw new ShouldAssertException(new ActualShouldlyMessage(actual, customMessage).ToString());
         }
 
         [ContractAnnotation("actual:null => halt")]
-        public static void ShouldNotBeNullOrEmpty(this string actual)
+        public static void ShouldNotBeNullOrEmpty([NotNull] this string? actual)
         {
             ShouldNotBeNullOrEmpty(actual, () => null);
         }
 
         [ContractAnnotation("actual:null => halt")]
-        public static void ShouldNotBeNullOrEmpty(this string actual, string customMessage)
+        public static void ShouldNotBeNullOrEmpty([NotNull] this string? actual, string? customMessage)
         {
             ShouldNotBeNullOrEmpty(actual, () => customMessage);
         }
 
         [ContractAnnotation("actual:null => halt")]
-        public static void ShouldNotBeNullOrEmpty(this string actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBeNullOrEmpty([NotNull] this string? actual, [InstantHandle] Func<string?>? customMessage)
         {
             if (string.IsNullOrEmpty(actual))
                 throw new ShouldAssertException(new ActualShouldlyMessage(actual, customMessage).ToString());

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringNullOrWhitespaceTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringNullOrWhitespaceTestExtensions.cs
@@ -1,43 +1,44 @@
 ﻿using System;
 using JetBrains.Annotations;
+using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 
 namespace Shouldly
 {
     public static partial class ShouldBeStringTestExtensions
     {
         [ContractAnnotation("actual:notnull => halt")]
-        public static void ShouldBeNullOrWhiteSpace(this string actual)
+        public static void ShouldBeNullOrWhiteSpace(this string? actual)
         {
             ShouldBeNullOrWhiteSpace(actual, () => null);
         }
 
         [ContractAnnotation("actual:notnull => halt")]
-        public static void ShouldBeNullOrWhiteSpace(this string actual, string customMessage)
+        public static void ShouldBeNullOrWhiteSpace(this string? actual, string? customMessage)
         {
             ShouldBeNullOrWhiteSpace(actual, () => customMessage);
         }
 
         [ContractAnnotation("actual:notnull => halt")]
-        public static void ShouldBeNullOrWhiteSpace(this string actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeNullOrWhiteSpace(this string? actual, [InstantHandle] Func<string?>? customMessage)
         {
             if (!actual.IsNullOrWhiteSpace())
                 throw new ShouldAssertException(new ActualShouldlyMessage(actual, customMessage).ToString());
         }
 
         [ContractAnnotation("actual:null => halt")]
-        public static void ShouldNotBeNullOrWhiteSpace(this string actual)
+        public static void ShouldNotBeNullOrWhiteSpace([NotNull] this string? actual)
         {
             ShouldNotBeNullOrWhiteSpace(actual, () => null);
         }
 
         [ContractAnnotation("actual:null => halt")]
-        public static void ShouldNotBeNullOrWhiteSpace(this string actual, string customMessage)
+        public static void ShouldNotBeNullOrWhiteSpace([NotNull] this string? actual, string? customMessage)
         {
             ShouldNotBeNullOrWhiteSpace(actual, () => customMessage);
         }
 
         [ContractAnnotation("actual:null => halt")]
-        public static void ShouldNotBeNullOrWhiteSpace(this string actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBeNullOrWhiteSpace([NotNull] this string? actual, [InstantHandle] Func<string?>? customMessage)
         {
             // TODO make this an extension method (str.IsNullOrWhitespace())
             if (string.IsNullOrWhiteSpace(actual))

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringShouldBeTestExtensions.cs
@@ -1,6 +1,7 @@
 using Shouldly.Internals.AssertionFactories;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Shouldly
 {
@@ -12,8 +13,8 @@ namespace Shouldly
         /// Perform a string comparison with sensitivity options
         /// </summary>
         public static void ShouldBe(
-            this string actual,
-            string expected)
+            [NotNullIfNotNull("expected")] this string? actual,
+            [NotNullIfNotNull("actual")] string? expected)
         {
             // ReSharper disable once IntroduceOptionalParameters.Global
             ShouldBe(actual, expected, (StringCompareShould)0);
@@ -23,8 +24,8 @@ namespace Shouldly
         /// Perform a string comparison with sensitivity options
         /// </summary>
         public static void ShouldBe(
-            this string actual,
-            string expected,
+            [NotNullIfNotNull("expected")] this string? actual,
+            [NotNullIfNotNull("actual")] string? expected,
             string customMessage)
         {
             // ReSharper disable once IntroduceOptionalParameters.Global
@@ -35,9 +36,9 @@ namespace Shouldly
         /// Perform a string comparison with sensitivity options
         /// </summary>
         public static void ShouldBe(
-            this string actual,
-            string expected,
-            Func<string> customMessage)
+            [NotNullIfNotNull("expected")] this string? actual,
+            [NotNullIfNotNull("actual")] string? expected,
+            Func<string?> customMessage)
         {
             // ReSharper disable once IntroduceOptionalParameters.Global
             ShouldBe(actual, expected, customMessage, 0);
@@ -46,15 +47,15 @@ namespace Shouldly
         /// Perform a string comparison with sensitivity options
         /// </summary>
         public static void ShouldBe(
-            this string actual,
-            string expected,
+            [NotNullIfNotNull("expected")] this string? actual,
+            [NotNullIfNotNull("actual")] string? expected,
             StringCompareShould options)
         {
             ShouldBe(actual, expected, () => null, options);
         }
         public static void ShouldBe(
-            this string actual,
-            string expected,
+            [NotNullIfNotNull("expected")] this string? actual,
+            [NotNullIfNotNull("actual")] string? expected,
             string customMessage,
             StringCompareShould option)
         {
@@ -62,16 +63,16 @@ namespace Shouldly
         }
 
         public static void ShouldBe(
-            this string actual,
-            string expected,
-            Func<string> customMessage,
+            [NotNullIfNotNull("expected")] this string? actual,
+            [NotNullIfNotNull("actual")] string? expected,
+            Func<string?> customMessage,
             StringCompareShould options)
         {
             var assertion = StringShouldBeAssertionFactory.Create(expected, actual, options);
             ExecuteAssertion(assertion, customMessage);
         }
 
-        static void ExecuteAssertion(Internals.Assertions.IAssertion assertion, Func<string> customMessage)
+        static void ExecuteAssertion(Internals.Assertions.IAssertion assertion, Func<string?> customMessage)
         {
             try
             {

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringStartEndTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringStartEndTestExtensions.cs
@@ -1,88 +1,91 @@
 ﻿using System;
 using JetBrains.Annotations;
+using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 
 namespace Shouldly
 {
     public static partial class ShouldBeStringTestExtensions
     {
         /*** ShouldStartWith ***/
-        public static void ShouldStartWith(this string actual, string expected)
+        public static void ShouldStartWith([NotNull] this string? actual, string expected)
         {
             ShouldStartWith(actual, expected, () => null);
         }
 
-        public static void ShouldStartWith(this string actual, string expected, Case caseSensitivity)
+        public static void ShouldStartWith([NotNull] this string? actual, string expected, Case caseSensitivity)
         {
             ShouldStartWith(actual, expected, () => null, caseSensitivity);
         }
 
-        public static void ShouldStartWith(this string actual, string expected, string customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldStartWith([NotNull] this string? actual, string expected, string? customMessage, Case caseSensitivity = Case.Insensitive)
         {
             ShouldStartWith(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldStartWith(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldStartWith([NotNull] this string? actual, string expected, [InstantHandle] Func<string?>? customMessage, Case caseSensitivity = Case.Insensitive)
         {
             actual.AssertAwesomely(v => Is.StringStartingWithUsingCaseSensitivity(v, expected, caseSensitivity), actual, expected, customMessage);
         }
 
         /*** ShouldEndWith ***/
-        public static void ShouldEndWith(this string actual, string expected)
+        public static void ShouldEndWith([NotNull] this string? actual, string expected)
         {
             ShouldEndWith(actual, expected, () => null);
         }
 
-        public static void ShouldEndWith(this string actual, string expected, Case caseSensitivity)
+        public static void ShouldEndWith([NotNull] this string? actual, string expected, Case caseSensitivity)
         {
             ShouldEndWith(actual, expected, () => null, caseSensitivity);
         }
 
-        public static void ShouldEndWith(this string actual, string expected, string customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldEndWith([NotNull] this string? actual, string expected, string? customMessage, Case caseSensitivity = Case.Insensitive)
         {
             ShouldEndWith(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldEndWith(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldEndWith([NotNull] this string? actual, string expected, [InstantHandle] Func<string?>? customMessage, Case caseSensitivity = Case.Insensitive)
         {
             actual.AssertAwesomely(v => Is.EndsWithUsingCaseSensitivity(v, expected, caseSensitivity), actual, expected, customMessage);
         }
 
         /*** ShouldNotStartWith ***/
-        public static void ShouldNotStartWith(this string actual, string expected)
+        public static void ShouldNotStartWith(this string? actual, string expected)
         {
             ShouldNotStartWith(actual, expected, () => null);
         }
-public static void ShouldNotStartWith(this string actual, string expected, Case caseSensitivity)
+
+        public static void ShouldNotStartWith(this string? actual, string expected, Case caseSensitivity)
         {
             ShouldNotStartWith(actual, expected, () => null, caseSensitivity);
         }
 
-        public static void ShouldNotStartWith(this string actual, string expected, string customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldNotStartWith(this string? actual, string expected, string? customMessage, Case caseSensitivity = Case.Insensitive)
         {
             ShouldNotStartWith(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldNotStartWith(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldNotStartWith(this string? actual, string expected, [InstantHandle] Func<string?>? customMessage, Case caseSensitivity = Case.Insensitive)
         {
             actual.AssertAwesomely(v => !Is.StringStartingWithUsingCaseSensitivity(v, expected, caseSensitivity), actual, expected, customMessage);
         }
 
         /*** ShouldNotEndWith ***/
-        public static void ShouldNotEndWith(this string actual, string expected)
+        public static void ShouldNotEndWith(this string? actual, string expected)
         {
             ShouldNotEndWith(actual, expected, () => null);
         }
-public static void ShouldNotEndWith(this string actual, string expected, Case caseSensitivity)
+
+        public static void ShouldNotEndWith(this string? actual, string expected, Case caseSensitivity)
         {
             ShouldNotEndWith(actual, expected, () => null, caseSensitivity);
         }
 
-        public static void ShouldNotEndWith(this string actual, string expected, string customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldNotEndWith(this string? actual, string expected, string? customMessage, Case caseSensitivity = Case.Insensitive)
         {
             ShouldNotEndWith(actual, expected, () => customMessage, caseSensitivity);
         }
 
-        public static void ShouldNotEndWith(this string actual, string expected, [InstantHandle] Func<string> customMessage, Case caseSensitivity = Case.Insensitive)
+        public static void ShouldNotEndWith(this string? actual, string expected, [InstantHandle] Func<string?>? customMessage, Case caseSensitivity = Case.Insensitive)
         {
             actual.AssertAwesomely(v => !Is.EndsWithUsingCaseSensitivity(v, expected, caseSensitivity), actual, expected, customMessage);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeBooleanExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeBooleanExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 
 namespace Shouldly
@@ -8,33 +9,33 @@ namespace Shouldly
     [ShouldlyMethods]
     public static class ShouldBeBooleanExtensions
     {
-        public static void ShouldBeTrue(this bool actual)
+        public static void ShouldBeTrue([DoesNotReturnIf(false)] this bool actual)
         {
             ShouldBeTrue(actual, () => null);
         }
 
-        public static void ShouldBeTrue(this bool actual, string customMessage)
+        public static void ShouldBeTrue([DoesNotReturnIf(false)] this bool actual, string? customMessage)
         {
             ShouldBeTrue(actual, () => customMessage);
         }
 
-        public static void ShouldBeTrue(this bool actual, [InstantHandle]Func<string> customMessage)
+        public static void ShouldBeTrue([DoesNotReturnIf(false)] this bool actual, [InstantHandle] Func<string?>? customMessage)
         {
             if (!actual)
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(true, actual, customMessage).ToString());
         }
 
-        public static void ShouldBeFalse(this bool actual)
+        public static void ShouldBeFalse([DoesNotReturnIf(true)] this bool actual)
         {
             ShouldBeFalse(actual, () => null);
         }
 
-        public static void ShouldBeFalse(this bool actual, string customMessage)
+        public static void ShouldBeFalse([DoesNotReturnIf(true)] this bool actual, string? customMessage)
         {
             ShouldBeFalse(actual, () => customMessage);
         }
 
-        public static void ShouldBeFalse(this bool actual, [InstantHandle]Func<string> customMessage)
+        public static void ShouldBeFalse([DoesNotReturnIf(true)] this bool actual, [InstantHandle] Func<string?>? customMessage)
         {
             if (actual)
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(false, actual, customMessage).ToString());

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
@@ -3,71 +3,83 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using JetBrains.Annotations;
 
-namespace Shouldly 
+namespace Shouldly
 {
     [DebuggerStepThrough]
     [ShouldlyMethods]
-    public static class ShouldBeDictionaryTestExtensions 
+    public static class ShouldBeDictionaryTestExtensions
     {
         public static void ShouldContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+            where TKey : notnull
         {
             ShouldContainKey(dictionary, key, () => null);
         }
 
-        public static void ShouldContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, string customMessage)
+        public static void ShouldContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage)
+            where TKey : notnull
         {
             ShouldContainKey(dictionary, key, () => customMessage);
         }
 
-        public static void ShouldContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, [InstantHandle] Func<string> customMessage)
+        public static void ShouldContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, [InstantHandle] Func<string?>? customMessage)
+            where TKey : notnull
         {
             if (!dictionary.ContainsKey(key))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
         }
 
         public static void ShouldNotContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+            where TKey : notnull
         {
             ShouldNotContainKey(dictionary, key, () => null);
         }
 
-        public static void ShouldNotContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, string customMessage)
+        public static void ShouldNotContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage)
+            where TKey : notnull
         {
             ShouldNotContainKey(dictionary, key, () => customMessage);
         }
 
-        public static void ShouldNotContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, [InstantHandle] Func<string?>? customMessage)
+            where TKey : notnull
         {
             if (dictionary.ContainsKey(key))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
         }
 
-        public static void ShouldContainKeyAndValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val) 
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val)
+            where TKey : notnull
         {
             ShouldContainKeyAndValue(dictionary, key, val, () => null);
         }
 
-        public static void ShouldContainKeyAndValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string customMessage)
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage)
+            where TKey : notnull
         {
             ShouldContainKeyAndValue(dictionary, key, val, () => customMessage);
         }
 
-        public static void ShouldContainKeyAndValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, [InstantHandle] Func<string> customMessage)
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, [InstantHandle] Func<string?>? customMessage)
+            where TKey : notnull
         {
             if (!dictionary.ContainsKey(key) || !Equals(dictionary[key], val))
                 throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
         }
 
         public static void ShouldNotContainValueForKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val)
+            where TKey : notnull
         {
             ShouldNotContainValueForKey(dictionary, key, val, () => null);
         }
 
-        public static void ShouldNotContainValueForKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string customMessage)
+        public static void ShouldNotContainValueForKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage)
+            where TKey : notnull
         {
             ShouldNotContainValueForKey(dictionary, key, val, () => customMessage);
         }
 
-        public static void ShouldNotContainValueForKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotContainValueForKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, [InstantHandle] Func<string?>? customMessage)
+            where TKey : notnull
         {
             if (!dictionary.ContainsKey(key) || Equals(dictionary[key], val))
                 throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumExtensions.cs
@@ -10,10 +10,10 @@ namespace Shouldly.ShouldlyExtensionMethods
         public static void ShouldHaveFlag(this Enum actual, Enum expectedFlag)
             => ShouldHaveFlag(actual, expectedFlag, () => null);
 
-        public static void ShouldHaveFlag(this Enum actual, Enum expectedFlag, string customMessage)
+        public static void ShouldHaveFlag(this Enum actual, Enum expectedFlag, string? customMessage)
             => ShouldHaveFlag(actual, expectedFlag, () => customMessage);
 
-        public static void ShouldHaveFlag(this Enum actual, Enum expectedFlag, [InstantHandle] Func<string> customMessage)
+        public static void ShouldHaveFlag(this Enum actual, Enum expectedFlag, [InstantHandle] Func<string?>? customMessage)
         {
             CheckEnumHasFlagAttribute(actual);
             if (!actual.HasFlag(expectedFlag))
@@ -25,11 +25,11 @@ namespace Shouldly.ShouldlyExtensionMethods
         public static void ShouldNotHaveFlag(this Enum actual, Enum expectedFlag)
             => ShouldNotHaveFlag(actual, expectedFlag, () => null);
 
-        public static void ShouldNotHaveFlag(this Enum actual, Enum expectedFlag, string customMessage)
+        public static void ShouldNotHaveFlag(this Enum actual, Enum expectedFlag, string? customMessage)
             => ShouldNotHaveFlag(actual, expectedFlag, () => customMessage);
 
         public static void ShouldNotHaveFlag(this Enum actual, Enum expectedFlag,
-            [InstantHandle] Func<string> customMessage)
+            [InstantHandle] Func<string?>? customMessage)
         {
             CheckEnumHasFlagAttribute(actual);
             if (actual.HasFlag(expectedFlag))

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 
 namespace Shouldly
 {
@@ -16,12 +17,12 @@ namespace Shouldly
             ShouldContain(actual, expected, () => null);
         }
 
-        public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, string customMessage)
+        public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, string? customMessage)
         {
             ShouldContain(actual, expected, () => customMessage);
         }
 
-        public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldContain<T>(this IEnumerable<T> actual, T expected, [InstantHandle] Func<string?>? customMessage)
         {
             if (!actual.Contains(expected))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
@@ -32,12 +33,12 @@ namespace Shouldly
             ShouldNotContain(actual, expected, () => null);
         }
 
-        public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, string customMessage)
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, string? customMessage)
         {
             ShouldNotContain(actual, expected, () => customMessage);
         }
 
-        public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, T expected, [InstantHandle] Func<string?>? customMessage)
         {
             if (actual.Contains(expected))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
@@ -53,12 +54,12 @@ namespace Shouldly
             ShouldContain(actual, elementPredicate, expectedCount, () => null);
         }
 
-        public static void ShouldContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, int expectedCount, string customMessage)
+        public static void ShouldContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, int expectedCount, string? customMessage)
         {
             ShouldContain(actual, elementPredicate, expectedCount, () => customMessage);
         }
 
-        public static void ShouldContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, int expectedCount, Func<string> customMessage)
+        public static void ShouldContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, int expectedCount, Func<string?>? customMessage)
         {
             var condition = elementPredicate.Compile();
             var actualCount = actual.Count(condition);
@@ -68,12 +69,12 @@ namespace Shouldly
             }
         }
 
-        public static void ShouldContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, string customMessage)
+        public static void ShouldContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, string? customMessage)
         {
             ShouldContain(actual, elementPredicate, () => customMessage);
         }
 
-        public static void ShouldContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, [InstantHandle] Func<string> customMessage)
+        public static void ShouldContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, [InstantHandle] Func<string?>? customMessage)
         {
             var condition = elementPredicate.Compile();
             if (!actual.Any(condition))
@@ -85,12 +86,12 @@ namespace Shouldly
             ShouldNotContain(actual, elementPredicate, () => null);
         }
 
-        public static void ShouldNotContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, string customMessage)
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, string? customMessage)
         {
             ShouldNotContain(actual, elementPredicate, () => customMessage);
         }
 
-        public static void ShouldNotContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotContain<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, [InstantHandle] Func<string?>? customMessage)
         {
             var condition = elementPredicate.Compile();
             if (actual.Any(condition))
@@ -102,12 +103,12 @@ namespace Shouldly
             ShouldAllBe(actual, elementPredicate, () => null);
         }
 
-        public static void ShouldAllBe<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, string customMessage)
+        public static void ShouldAllBe<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, string? customMessage)
         {
             ShouldAllBe(actual, elementPredicate, () => customMessage);
         }
 
-        public static void ShouldAllBe<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, [InstantHandle] Func<string> customMessage)
+        public static void ShouldAllBe<T>(this IEnumerable<T> actual, [InstantHandle] Expression<Func<T, bool>> elementPredicate, [InstantHandle] Func<string?>? customMessage)
         {
             var condition = elementPredicate.Compile();
             var actualResults = actual.Where(part => !condition(part));
@@ -115,49 +116,49 @@ namespace Shouldly
                 throw new ShouldAssertException(new ActualFilteredWithPredicateShouldlyMessage(elementPredicate.Body, actualResults, actual, customMessage).ToString());
         }
 
-        public static void ShouldBeEmpty<T>(this IEnumerable<T> actual)
+        public static void ShouldBeEmpty<T>([NotNull] this IEnumerable<T>? actual)
         {
             ShouldBeEmpty(actual, () => null);
         }
 
-        public static void ShouldBeEmpty<T>(this IEnumerable<T> actual, string customMessage)
+        public static void ShouldBeEmpty<T>([NotNull] this IEnumerable<T>? actual, string? customMessage)
         {
             ShouldBeEmpty(actual, () => customMessage);
         }
 
-        public static void ShouldBeEmpty<T>(this IEnumerable<T> actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeEmpty<T>([NotNull] this IEnumerable<T>? actual, [InstantHandle] Func<string?>? customMessage)
         {
             if (actual == null || actual.Any())
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
         }
 
-        public static void ShouldNotBeEmpty<T>(this IEnumerable<T> actual)
+        public static void ShouldNotBeEmpty<T>([NotNull] this IEnumerable<T>? actual)
         {
             ShouldNotBeEmpty(actual, () => null);
         }
 
-        public static void ShouldNotBeEmpty<T>(this IEnumerable<T> actual, string customMessage)
+        public static void ShouldNotBeEmpty<T>([NotNull] this IEnumerable<T>? actual, string? customMessage)
         {
             ShouldNotBeEmpty(actual, () => customMessage);
         }
 
-        public static void ShouldNotBeEmpty<T>(this IEnumerable<T> actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBeEmpty<T>([NotNull] this IEnumerable<T>? actual, [InstantHandle] Func<string?>? customMessage)
         {
             if (actual == null || !actual.Any())
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
         }
 
-        public static T ShouldHaveSingleItem<T>(this IEnumerable<T> actual)
+        public static T ShouldHaveSingleItem<T>([NotNull] this IEnumerable<T>? actual)
         {
             return ShouldHaveSingleItem(actual, () => null);
         }
 
-        public static T ShouldHaveSingleItem<T>(this IEnumerable<T> actual, string customMessage)
+        public static T ShouldHaveSingleItem<T>([NotNull] this IEnumerable<T>? actual, string? customMessage)
         {
             return ShouldHaveSingleItem(actual, () => customMessage);
         }
 
-        public static T ShouldHaveSingleItem<T>(this IEnumerable<T> actual, [InstantHandle] Func<string> customMessage)
+        public static T ShouldHaveSingleItem<T>([NotNull] this IEnumerable<T>? actual, [InstantHandle] Func<string?>? customMessage)
         {
             if (actual == null || actual.Count() != 1)
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
@@ -170,12 +171,12 @@ namespace Shouldly
             ShouldContain(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldContain(this IEnumerable<float> actual, float expected, double tolerance, string customMessage)
+        public static void ShouldContain(this IEnumerable<float> actual, float expected, double tolerance, string? customMessage)
         {
             ShouldContain(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldContain(this IEnumerable<float> actual, float expected, double tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldContain(this IEnumerable<float> actual, float expected, double tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             if (!actual.Any(a => Math.Abs(expected - a) < tolerance))
                 throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance, customMessage).ToString());
@@ -186,12 +187,12 @@ namespace Shouldly
             ShouldContain(actual, expected, tolerance, () => null);
         }
 
-        public static void ShouldContain(this IEnumerable<double> actual, double expected, double tolerance, string customMessage)
+        public static void ShouldContain(this IEnumerable<double> actual, double expected, double tolerance, string? customMessage)
         {
             ShouldContain(actual, expected, tolerance, () => customMessage);
         }
 
-        public static void ShouldContain(this IEnumerable<double> actual, double expected, double tolerance, [InstantHandle] Func<string> customMessage)
+        public static void ShouldContain(this IEnumerable<double> actual, double expected, double tolerance, [InstantHandle] Func<string?>? customMessage)
         {
             if (!actual.Any(a => Math.Abs(expected - a) < tolerance))
                 throw new ShouldAssertException(new ExpectedActualToleranceShouldlyMessage(expected, actual, tolerance, customMessage).ToString());
@@ -202,12 +203,12 @@ namespace Shouldly
             ShouldBeSubsetOf(actual, expected, () => null);
         }
 
-        public static void ShouldBeSubsetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected, string customMessage)
+        public static void ShouldBeSubsetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected, string? customMessage)
         {
             ShouldBeSubsetOf(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeSubsetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeSubsetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected, [InstantHandle] Func<string?>? customMessage)
         {
             if (actual.Equals(expected))
                 return;
@@ -222,12 +223,12 @@ namespace Shouldly
             ShouldBeUnique(actual, () => null);
         }
 
-        public static void ShouldBeUnique<T>(this IEnumerable<T> actual, string customMessage)
+        public static void ShouldBeUnique<T>(this IEnumerable<T> actual, string? customMessage)
         {
             ShouldBeUnique(actual, () => customMessage);
         }
 
-        public static void ShouldBeUnique<T>(this IEnumerable<T> actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeUnique<T>(this IEnumerable<T> actual, [InstantHandle] Func<string?>? customMessage)
         {
             var duplicates = GetDuplicates(actual);
             if (duplicates.Any())
@@ -239,12 +240,12 @@ namespace Shouldly
             ShouldBe(actual, expected, caseSensitivity, () => null);
         }
 
-        public static void ShouldBe(this IEnumerable<string> actual, IEnumerable<string> expected, Case caseSensitivity, string customMessage)
+        public static void ShouldBe(this IEnumerable<string> actual, IEnumerable<string> expected, Case caseSensitivity, string? customMessage)
         {
             ShouldBe(actual, expected, caseSensitivity, () => customMessage);
         }
 
-        public static void ShouldBe(this IEnumerable<string> actual, IEnumerable<string> expected, Case caseSensitivity, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBe(this IEnumerable<string> actual, IEnumerable<string> expected, Case caseSensitivity, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomelyWithCaseSensitivity(
                 v => Is.EnumerableStringEqualWithCaseSensitivity(v, expected, caseSensitivity),
@@ -259,42 +260,42 @@ namespace Shouldly
             ShouldBeInOrder(actual, SortDirection.Ascending);
         }
 
-        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, string customMessage)
+        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, string? customMessage)
         {
             ShouldBeInOrder(actual, SortDirection.Ascending, customMessage);
         }
 
-        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, [InstantHandle] Func<string?>? customMessage)
         {
             ShouldBeInOrder(actual, SortDirection.Ascending, customMessage);
         }
 
         public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, SortDirection expectedSortDirection)
         {
-            ShouldBeInOrder(actual, expectedSortDirection, (IComparer<T>)null);
+            ShouldBeInOrder(actual, expectedSortDirection, (IComparer<T>?)null);
         }
 
-        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, SortDirection expectedSortDirection, string customMessage)
+        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, SortDirection expectedSortDirection, string? customMessage)
         {
             ShouldBeInOrder(actual, expectedSortDirection, null, customMessage);
         }
 
-        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, SortDirection expectedSortDirection, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, SortDirection expectedSortDirection, [InstantHandle] Func<string?>? customMessage)
         {
-            ShouldBeInOrder(actual, expectedSortDirection, (IComparer<T>)null, customMessage);
+            ShouldBeInOrder(actual, expectedSortDirection, (IComparer<T>?)null, customMessage);
         }
 
-        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, SortDirection expectedSortDirection, IComparer<T> customComparer)
+        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, SortDirection expectedSortDirection, IComparer<T>? customComparer)
         {
             ShouldBeInOrder(actual, expectedSortDirection, customComparer, () => null);
         }
 
-        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, SortDirection expectedSortDirection, IComparer<T> customComparer, string customMessage)
+        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, SortDirection expectedSortDirection, IComparer<T>? customComparer, string? customMessage)
         {
             ShouldBeInOrder(actual, expectedSortDirection, customComparer, () => customMessage);
         }
 
-        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, SortDirection expectedSortDirection, IComparer<T> customComparer, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeInOrder<T>(this IEnumerable<T> actual, SortDirection expectedSortDirection, IComparer<T>? customComparer, [InstantHandle] Func<string?>? customMessage)
         {
             if (customComparer == null)
                 customComparer = Comparer<T>.Default;
@@ -307,12 +308,12 @@ namespace Shouldly
             ShouldBeInOrder(actual, expectedSortDirection, (x, y) => isOutOfOrder(customComparer.Compare(x, y)), customMessage);
         }
 
-        private static List<object> GetDuplicates<T>(IEnumerable<T> items)
+        private static List<object?> GetDuplicates<T>(IEnumerable<T> items)
         {
-            var list = new List<object>();
-            var duplicates = new List<object>();
+            var list = new List<object?>();
+            var duplicates = new List<object?>();
 
-            foreach (object o1 in items)
+            foreach (object? o1 in items)
             {
                 duplicates.AddRange(list.Where(o2 => o1 != null && o1.Equals(o2)));
                 list.Add(o1);
@@ -321,9 +322,9 @@ namespace Shouldly
             return duplicates;
         }
 
-        private static void ShouldBeInOrder<T>(IEnumerable<T> actual, SortDirection expectedSortDirection, Func<T, T, bool> isOutOfOrder, Func<string> customMessage)
+        private static void ShouldBeInOrder<T>(IEnumerable<T> actual, SortDirection expectedSortDirection, Func<T, T, bool> isOutOfOrder, Func<string?>? customMessage)
         {
-            var previousItem = default(T);
+            var previousItem = default(T)!;
             var currentIndex = -1;
 
             foreach (var currentItem in actual)

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeGtLtTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeGtLtTestExtensions.cs
@@ -1,129 +1,130 @@
 ﻿using System;
 using JetBrains.Annotations;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Shouldly
 {
     public static partial class ShouldBeTestExtensions
     {
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected) where T : IComparable<T>
+        public static void ShouldBeGreaterThan<T>([AllowNull] this T actual, [AllowNull] T expected) where T : IComparable<T>?
         {
             ShouldBeGreaterThan(actual, expected, () => null);
         }
 
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected, IComparer<T> comparer)
+        public static void ShouldBeGreaterThan<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer)
         {
             ShouldBeGreaterThan(actual, expected, comparer, () => null);
         }
 
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected, IComparer<T> comparer, string customMessage)
+        public static void ShouldBeGreaterThan<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, string? customMessage)
         {
             ShouldBeGreaterThan(actual, expected, comparer, () => customMessage);
         }
 
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected, IComparer<T> comparer, Func<string> customMessage)
+        public static void ShouldBeGreaterThan<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.GreaterThan(actual, expected, comparer), actual, expected, customMessage);
         }
 
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected, string customMessage) where T : IComparable<T>
+        public static void ShouldBeGreaterThan<T>([AllowNull] this T actual, [AllowNull] T expected, string? customMessage) where T : IComparable<T>?
         {
             ShouldBeGreaterThan(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeGreaterThan<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldBeGreaterThan<T>([AllowNull] this T actual, [AllowNull] T expected, [InstantHandle] Func<string?>? customMessage) where T : IComparable<T>?
         {
             actual.AssertAwesomely(v => Is.GreaterThan(v, expected), actual, expected, customMessage);
         }
 
-        public static void ShouldBeLessThan<T>(this T actual, T expected) where T : IComparable<T>
+        public static void ShouldBeLessThan<T>([AllowNull] this T actual, [AllowNull] T expected) where T : IComparable<T>?
         {
             ShouldBeLessThan(actual, expected, () => null);
         }
 
-        public static void ShouldBeLessThan<T>(this T actual, T expected, string customMessage) where T : IComparable<T>
+        public static void ShouldBeLessThan<T>([AllowNull] this T actual, [AllowNull] T expected, string? customMessage) where T : IComparable<T>?
         {
             ShouldBeLessThan(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeLessThan<T>(this T actual, T expected, IComparer<T> comparer)
+        public static void ShouldBeLessThan<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer)
         {
             ShouldBeLessThan(actual, expected, comparer, () => null);
         }
 
-        public static void ShouldBeLessThan<T>(this T actual, T expected, IComparer<T> comparer, string customMessage)
+        public static void ShouldBeLessThan<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, string? customMessage)
         {
             ShouldBeLessThan(actual, expected, comparer, () => customMessage);
         }
 
-        public static void ShouldBeLessThan<T>(this T actual, T expected, IComparer<T> comparer, Func<string> customMessage)
+        public static void ShouldBeLessThan<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.LessThan(actual, expected, comparer), actual, expected, customMessage);
         }
 
-        public static void ShouldBeLessThan<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldBeLessThan<T>([AllowNull] this T actual, [AllowNull] T expected, [InstantHandle] Func<string?>? customMessage) where T : IComparable<T>?
         {
             actual.AssertAwesomely(v => Is.LessThan(v, expected), actual, expected, customMessage);
         }
 
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected) where T : IComparable<T>
+        public static void ShouldBeGreaterThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected) where T : IComparable<T>?
         {
             ShouldBeGreaterThanOrEqualTo(actual, expected, () => null);
         }
 
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, string customMessage) where T : IComparable<T>
+        public static void ShouldBeGreaterThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, string? customMessage) where T : IComparable<T>?
         {
             ShouldBeGreaterThanOrEqualTo(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer)
+        public static void ShouldBeGreaterThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer)
         {
             ShouldBeGreaterThanOrEqualTo(actual, expected, comparer, () => null);
         }
 
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer, string customMessage)
+        public static void ShouldBeGreaterThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, string? customMessage)
         {
             ShouldBeGreaterThanOrEqualTo(actual, expected, comparer, () => customMessage);
         }
 
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer, Func<string> customMessage)
+        public static void ShouldBeGreaterThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.GreaterThanOrEqualTo(actual, expected, comparer), actual, expected, customMessage);
         }
 
-        public static void ShouldBeGreaterThanOrEqualTo<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldBeGreaterThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, [InstantHandle] Func<string?>? customMessage) where T : IComparable<T>?
         {
             actual.AssertAwesomely(v => Is.GreaterThanOrEqualTo(v, expected), actual, expected, customMessage);
         }
 
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected) where T : IComparable<T>
+        public static void ShouldBeLessThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected) where T : IComparable<T>?
         {
             ShouldBeLessThanOrEqualTo(actual, expected, () => null);
         }
 
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, string customMessage) where T : IComparable<T>
+        public static void ShouldBeLessThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, string? customMessage) where T : IComparable<T>?
         {
             ShouldBeLessThanOrEqualTo(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer)
+        public static void ShouldBeLessThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer)
         {
             ShouldBeLessThanOrEqualTo(actual, expected, comparer, () => null);
         }
 
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer, string customMessage)
+        public static void ShouldBeLessThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, string? customMessage)
         {
             ShouldBeLessThanOrEqualTo(actual, expected, comparer, () => customMessage);
         }
 
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, IComparer<T> comparer, Func<string> customMessage)
+        public static void ShouldBeLessThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => Is.LessThanOrEqualTo(actual, expected, comparer), actual, expected, customMessage);
         }
 
-        public static void ShouldBeLessThanOrEqualTo<T>(this T actual, T expected, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldBeLessThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, [InstantHandle] Func<string?>? customMessage) where T : IComparable<T>?
         {
             actual.AssertAwesomely(v => Is.LessThanOrEqualTo(v, expected), actual, expected, customMessage);
-        } 
+        }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeGtLtTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeGtLtTestExtensions.cs
@@ -24,7 +24,7 @@ namespace Shouldly
 
         public static void ShouldBeGreaterThan<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, Func<string?>? customMessage)
         {
-            actual.AssertAwesomely(v => Is.GreaterThan(actual, expected, comparer), actual, expected, customMessage);
+            actual!.AssertAwesomely(v => Is.GreaterThan(actual, expected, comparer), actual, expected, customMessage);
         }
 
         public static void ShouldBeGreaterThan<T>([AllowNull] this T actual, [AllowNull] T expected, string? customMessage) where T : IComparable<T>?
@@ -34,7 +34,7 @@ namespace Shouldly
 
         public static void ShouldBeGreaterThan<T>([AllowNull] this T actual, [AllowNull] T expected, [InstantHandle] Func<string?>? customMessage) where T : IComparable<T>?
         {
-            actual.AssertAwesomely(v => Is.GreaterThan(v, expected), actual, expected, customMessage);
+            actual!.AssertAwesomely(v => Is.GreaterThan(v, expected), actual, expected, customMessage);
         }
 
         public static void ShouldBeLessThan<T>([AllowNull] this T actual, [AllowNull] T expected) where T : IComparable<T>?
@@ -59,12 +59,12 @@ namespace Shouldly
 
         public static void ShouldBeLessThan<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, Func<string?>? customMessage)
         {
-            actual.AssertAwesomely(v => Is.LessThan(actual, expected, comparer), actual, expected, customMessage);
+            actual!.AssertAwesomely(v => Is.LessThan(actual, expected, comparer), actual, expected, customMessage);
         }
 
         public static void ShouldBeLessThan<T>([AllowNull] this T actual, [AllowNull] T expected, [InstantHandle] Func<string?>? customMessage) where T : IComparable<T>?
         {
-            actual.AssertAwesomely(v => Is.LessThan(v, expected), actual, expected, customMessage);
+            actual!.AssertAwesomely(v => Is.LessThan(v, expected), actual, expected, customMessage);
         }
 
         public static void ShouldBeGreaterThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected) where T : IComparable<T>?
@@ -89,12 +89,12 @@ namespace Shouldly
 
         public static void ShouldBeGreaterThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, Func<string?>? customMessage)
         {
-            actual.AssertAwesomely(v => Is.GreaterThanOrEqualTo(actual, expected, comparer), actual, expected, customMessage);
+            actual!.AssertAwesomely(v => Is.GreaterThanOrEqualTo(actual, expected, comparer), actual, expected, customMessage);
         }
 
         public static void ShouldBeGreaterThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, [InstantHandle] Func<string?>? customMessage) where T : IComparable<T>?
         {
-            actual.AssertAwesomely(v => Is.GreaterThanOrEqualTo(v, expected), actual, expected, customMessage);
+            actual!.AssertAwesomely(v => Is.GreaterThanOrEqualTo(v, expected), actual, expected, customMessage);
         }
 
         public static void ShouldBeLessThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected) where T : IComparable<T>?
@@ -119,12 +119,12 @@ namespace Shouldly
 
         public static void ShouldBeLessThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, IComparer<T> comparer, Func<string?>? customMessage)
         {
-            actual.AssertAwesomely(v => Is.LessThanOrEqualTo(actual, expected, comparer), actual, expected, customMessage);
+            actual!.AssertAwesomely(v => Is.LessThanOrEqualTo(actual, expected, comparer), actual, expected, customMessage);
         }
 
         public static void ShouldBeLessThanOrEqualTo<T>([AllowNull] this T actual, [AllowNull] T expected, [InstantHandle] Func<string?>? customMessage) where T : IComparable<T>?
         {
-            actual.AssertAwesomely(v => Is.LessThanOrEqualTo(v, expected), actual, expected, customMessage);
+            actual!.AssertAwesomely(v => Is.LessThanOrEqualTo(v, expected), actual, expected, customMessage);
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeNullExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeNullExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
+using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 
 namespace Shouldly
 {
@@ -9,38 +11,38 @@ namespace Shouldly
     public static class ShouldBeNullExtensions
     {
         [ContractAnnotation("actual:notnull => halt")]
-        public static void ShouldBeNull<T>(this T actual)
+        public static void ShouldBeNull<T>([MaybeNull] this T actual)
         {
             ShouldBeNull(actual, () => null);
         }
 
         [ContractAnnotation("actual:notnull => halt")]
-        public static void ShouldBeNull<T>(this T actual, string customMessage)
+        public static void ShouldBeNull<T>([MaybeNull] this T actual, string? customMessage)
         {
             ShouldBeNull(actual, () => customMessage);
         }
 
         [ContractAnnotation("actual:notnull => halt")]
-        public static void ShouldBeNull<T>(this T actual, [InstantHandle]Func<string> customMessage)
+        public static void ShouldBeNull<T>([MaybeNull] this T actual, [InstantHandle] Func<string?>? customMessage)
         {
             if (actual != null)
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
         }
 
         [ContractAnnotation("actual:null => halt")]
-        public static void ShouldNotBeNull<T>(this T actual)
+        public static void ShouldNotBeNull<T>([NotNull] this T actual)
         {
             ShouldNotBeNull(actual, () => null);
         }
 
         [ContractAnnotation("actual:null => halt")]
-        public static void ShouldNotBeNull<T>(this T actual, string customMessage)
+        public static void ShouldNotBeNull<T>([NotNull] this T actual, string? customMessage)
         {
             ShouldNotBeNull(actual, () => customMessage);
         }
 
         [ContractAnnotation("actual:null => halt")]
-        public static void ShouldNotBeNull<T>(this T actual, [InstantHandle]Func<string> customMessage)
+        public static void ShouldNotBeNull<T>([NotNull] this T actual, [InstantHandle] Func<string?>? customMessage)
         {
             if (actual == null)
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBePositiveNegativeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBePositiveNegativeTestExtensions.cs
@@ -13,12 +13,12 @@ namespace Shouldly
             ShouldBePositive(actual, () => null);
         }
 
-        public static void ShouldBePositive(this decimal actual, string customMessage)
+        public static void ShouldBePositive(this decimal actual, string? customMessage)
         {
             ShouldBePositive(actual, () => customMessage);
         }
 
-        public static void ShouldBePositive(this decimal actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBePositive(this decimal actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(decimal);
             actual.AssertAwesomely(v => Is.GreaterThan(v, expected), actual, expected, customMessage);
@@ -29,12 +29,12 @@ namespace Shouldly
             ShouldBeNegative(actual, () => null);
         }
 
-        public static void ShouldBeNegative(this decimal actual, string customMessage)
+        public static void ShouldBeNegative(this decimal actual, string? customMessage)
         {
             ShouldBeNegative(actual, () => customMessage);
         }
 
-        public static void ShouldBeNegative(this decimal actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeNegative(this decimal actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(decimal);
             actual.AssertAwesomely(v => Is.LessThan(v, expected), actual, expected, customMessage);
@@ -48,12 +48,12 @@ namespace Shouldly
             ShouldBePositive(actual, () => null);
         }
 
-        public static void ShouldBePositive(this double actual, string customMessage)
+        public static void ShouldBePositive(this double actual, string? customMessage)
         {
             ShouldBePositive(actual, () => customMessage);
         }
 
-        public static void ShouldBePositive(this double actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBePositive(this double actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(double);
             actual.AssertAwesomely(v => Is.GreaterThan(v, expected), actual, expected, customMessage);
@@ -64,12 +64,12 @@ namespace Shouldly
             ShouldBeNegative(actual, () => null);
         }
 
-        public static void ShouldBeNegative(this double actual, string customMessage)
+        public static void ShouldBeNegative(this double actual, string? customMessage)
         {
             ShouldBeNegative(actual, () => customMessage);
         }
 
-        public static void ShouldBeNegative(this double actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeNegative(this double actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(double);
             actual.AssertAwesomely(v => Is.LessThan(v, expected), actual, expected, customMessage);
@@ -83,12 +83,12 @@ namespace Shouldly
             ShouldBePositive(actual, () => null);
         }
 
-        public static void ShouldBePositive(this float actual, string customMessage)
+        public static void ShouldBePositive(this float actual, string? customMessage)
         {
             ShouldBePositive(actual, () => customMessage);
         }
 
-        public static void ShouldBePositive(this float actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBePositive(this float actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(float);
             actual.AssertAwesomely(v => Is.GreaterThan(v, expected), actual, expected, customMessage);
@@ -99,12 +99,12 @@ namespace Shouldly
             ShouldBeNegative(actual, () => null);
         }
 
-        public static void ShouldBeNegative(this float actual, string customMessage)
+        public static void ShouldBeNegative(this float actual, string? customMessage)
         {
             ShouldBeNegative(actual, () => customMessage);
         }
 
-        public static void ShouldBeNegative(this float actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeNegative(this float actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(float);
             actual.AssertAwesomely(v => Is.LessThan(v, expected), actual, expected, customMessage);
@@ -118,12 +118,12 @@ namespace Shouldly
             ShouldBePositive(actual, () => null);
         }
 
-        public static void ShouldBePositive(this int actual, string customMessage)
+        public static void ShouldBePositive(this int actual, string? customMessage)
         {
             ShouldBePositive(actual, () => customMessage);
         }
 
-        public static void ShouldBePositive(this int actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBePositive(this int actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(int);
             actual.AssertAwesomely(v => Is.GreaterThan(v, expected), actual, expected, customMessage);
@@ -134,12 +134,12 @@ namespace Shouldly
             ShouldBeNegative(actual, () => null);
         }
 
-        public static void ShouldBeNegative(this int actual, string customMessage)
+        public static void ShouldBeNegative(this int actual, string? customMessage)
         {
             ShouldBeNegative(actual, () => customMessage);
         }
 
-        public static void ShouldBeNegative(this int actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeNegative(this int actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(int);
             actual.AssertAwesomely(v => Is.LessThan(v, expected), actual, expected, customMessage);
@@ -153,12 +153,12 @@ namespace Shouldly
             ShouldBePositive(actual, () => null);
         }
 
-        public static void ShouldBePositive(this long actual, string customMessage)
+        public static void ShouldBePositive(this long actual, string? customMessage)
         {
             ShouldBePositive(actual, () => customMessage);
         }
 
-        public static void ShouldBePositive(this long actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBePositive(this long actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(long);
             actual.AssertAwesomely(v => Is.GreaterThan(v, expected), actual, expected, customMessage);
@@ -169,12 +169,12 @@ namespace Shouldly
             ShouldBeNegative(actual, () => null);
         }
 
-        public static void ShouldBeNegative(this long actual, string customMessage)
+        public static void ShouldBeNegative(this long actual, string? customMessage)
         {
             ShouldBeNegative(actual, () => customMessage);
         }
 
-        public static void ShouldBeNegative(this long actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeNegative(this long actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(long);
             actual.AssertAwesomely(v => Is.LessThan(v, expected), actual, expected, customMessage);
@@ -188,12 +188,12 @@ namespace Shouldly
             ShouldBePositive(actual, () => null);
         }
 
-        public static void ShouldBePositive(this short actual, string customMessage)
+        public static void ShouldBePositive(this short actual, string? customMessage)
         {
             ShouldBePositive(actual, () => customMessage);
         }
 
-        public static void ShouldBePositive(this short actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBePositive(this short actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(short);
             actual.AssertAwesomely(v => Is.GreaterThan(v, expected), actual, expected, customMessage);
@@ -204,12 +204,12 @@ namespace Shouldly
             ShouldBeNegative(actual, () => null);
         }
 
-        public static void ShouldBeNegative(this short actual, string customMessage)
+        public static void ShouldBeNegative(this short actual, string? customMessage)
         {
             ShouldBeNegative(actual, () => customMessage);
         }
 
-        public static void ShouldBeNegative(this short actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeNegative(this short actual, [InstantHandle] Func<string?>? customMessage)
         {
             var expected = default(short);
             actual.AssertAwesomely(v => Is.LessThan(v, expected), actual, expected, customMessage);

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeRangeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeRangeTestExtensions.cs
@@ -17,7 +17,8 @@ namespace Shouldly
         }
         public static void ShouldBeOneOf<T>([AllowNull] this T actual, T[] expected, [InstantHandle] Func<string?>? customMessage)
         {
-            if (!expected.Contains(actual))
+            // Enumerable.Contains on an array always tolerates null.
+            if (!expected.Contains(actual!))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
         }
 
@@ -31,7 +32,8 @@ namespace Shouldly
         }
         public static void ShouldNotBeOneOf<T>([AllowNull] this T actual, T[] expected, [InstantHandle] Func<string?>? customMessage)
         {
-            if (expected.Contains(actual))
+            // Enumerable.Contains on an array always tolerates null.
+            if (expected.Contains(actual!))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
         }
 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeRangeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeRangeTestExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 
@@ -6,56 +7,56 @@ namespace Shouldly
 {
     public static partial class ShouldBeTestExtensions
     {
-        public static void ShouldBeOneOf<T>(this T actual, params T[] expected)
+        public static void ShouldBeOneOf<T>([AllowNull] this T actual, params T[] expected)
         {
             ShouldBeOneOf(actual, expected, () => null);
         }
-        public static void ShouldBeOneOf<T>(this T actual, T[] expected, string customMessage)
+        public static void ShouldBeOneOf<T>([AllowNull] this T actual, T[] expected, string? customMessage)
         {
             ShouldBeOneOf(actual, expected, () => customMessage);
         }
-        public static void ShouldBeOneOf<T>(this T actual, T[] expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeOneOf<T>([AllowNull] this T actual, T[] expected, [InstantHandle] Func<string?>? customMessage)
         {
             if (!expected.Contains(actual))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
         }
 
-        public static void ShouldNotBeOneOf<T>(this T actual, params T[] expected)
+        public static void ShouldNotBeOneOf<T>([AllowNull] this T actual, params T[] expected)
         {
             ShouldNotBeOneOf(actual, expected, () => null);
         }
-        public static void ShouldNotBeOneOf<T>(this T actual, T[] expected, string customMessage)
+        public static void ShouldNotBeOneOf<T>([AllowNull] this T actual, T[] expected, string? customMessage)
         {
             ShouldNotBeOneOf(actual, expected, () => customMessage);
         }
-        public static void ShouldNotBeOneOf<T>(this T actual, T[] expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBeOneOf<T>([AllowNull] this T actual, T[] expected, [InstantHandle] Func<string?>? customMessage)
         {
             if (expected.Contains(actual))
                 throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
         }
 
-        public static void ShouldBeInRange<T>(this T actual, T from, T to) where T : IComparable<T>
+        public static void ShouldBeInRange<T>([DisallowNull] this T actual, [AllowNull] T from, [AllowNull] T to) where T : IComparable<T>
         {
             ShouldBeInRange(actual, from, to, () => null);
         }
-        public static void ShouldBeInRange<T>(this T actual, T from, T to, string customMessage) where T : IComparable<T>
+        public static void ShouldBeInRange<T>([DisallowNull] this T actual, [AllowNull] T from, [AllowNull] T to, string? customMessage) where T : IComparable<T>
         {
             ShouldBeInRange(actual, from, to, () => customMessage);
         }
-        public static void ShouldBeInRange<T>(this T actual, T from, T to, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldBeInRange<T>([DisallowNull] this T actual, [AllowNull] T from, [AllowNull] T to, [InstantHandle] Func<string?>? customMessage) where T : IComparable<T>
         {
             actual.AssertAwesomely(v => Is.InRange<T>(v, @from, to), actual, new { @from, to }, customMessage);
         }
 
-        public static void ShouldNotBeInRange<T>(this T actual, T from, T to) where T : IComparable<T>
+        public static void ShouldNotBeInRange<T>([DisallowNull] this T actual, [AllowNull] T from, [AllowNull] T to) where T : IComparable<T>
         {
             ShouldNotBeInRange(actual, from, to, () => null);
         }
-        public static void ShouldNotBeInRange<T>(this T actual, T from, T to, string customMessage) where T : IComparable<T>
+        public static void ShouldNotBeInRange<T>([DisallowNull] this T actual, [AllowNull] T from, [AllowNull] T to, string? customMessage) where T : IComparable<T>
         {
             ShouldNotBeInRange(actual, from, to, () => customMessage);
         }
-        public static void ShouldNotBeInRange<T>(this T actual, T from, T to, [InstantHandle] Func<string> customMessage) where T : IComparable<T>
+        public static void ShouldNotBeInRange<T>([DisallowNull] this T actual, [AllowNull] T from, [AllowNull] T to, [InstantHandle] Func<string?>? customMessage) where T : IComparable<T>
         {
             actual.AssertAwesomely(v => !Is.InRange<T>(v, @from, to), actual, new { @from, to }, customMessage);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeTypeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeTypeTestExtensions.cs
@@ -1,38 +1,38 @@
 ﻿using System;
-using System.Reflection;
 using JetBrains.Annotations;
+using NotNullAttribute = System.Diagnostics.CodeAnalysis.NotNullAttribute;
 
 namespace Shouldly
 {
     public static partial class ShouldBeTestExtensions
     {
-        public static T ShouldBeAssignableTo<T>(this object actual)
+        public static T ShouldBeAssignableTo<T>(this object? actual)
         {
             return ShouldBeAssignableTo<T>(actual, () => null);
         }
 
-        public static T ShouldBeAssignableTo<T>(this object actual, string customMessage)
+        public static T ShouldBeAssignableTo<T>(this object? actual, string? customMessage)
         {
             return ShouldBeAssignableTo<T>(actual, () => customMessage);
         }
 
-        public static T ShouldBeAssignableTo<T>(this object actual, [InstantHandle] Func<string> customMessage)
+        public static T ShouldBeAssignableTo<T>(this object? actual, [InstantHandle] Func<string?>? customMessage)
         {
             ShouldBeAssignableTo(actual, typeof(T), customMessage);
-            return (T)actual;
+            return (T)actual!;
         }
 
-        public static void ShouldBeAssignableTo(this object actual, Type expected)
+        public static void ShouldBeAssignableTo(this object? actual, Type expected)
         {
             ShouldBeAssignableTo(actual, expected, () => null);
         }
 
-        public static void ShouldBeAssignableTo(this object actual, Type expected, string customMessage)
+        public static void ShouldBeAssignableTo(this object? actual, Type expected, string? customMessage)
         {
             ShouldBeAssignableTo(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeAssignableTo(this object actual, Type expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeAssignableTo(this object? actual, Type expected, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v =>
             {
@@ -43,93 +43,93 @@ namespace Shouldly
             }, actual, expected, customMessage);
         }
 
-        public static T ShouldBeOfType<T>(this object actual)
+        public static T ShouldBeOfType<T>([NotNull] this object? actual)
         {
             return ShouldBeOfType<T>(actual, () => null);
         }
 
-        public static T ShouldBeOfType<T>(this object actual, string customMessage)
+        public static T ShouldBeOfType<T>([NotNull] this object? actual, string? customMessage)
         {
             return ShouldBeOfType<T>(actual, () => customMessage);
         }
 
-        public static T ShouldBeOfType<T>(this object actual, [InstantHandle] Func<string> customMessage)
+        public static T ShouldBeOfType<T>([NotNull] this object? actual, [InstantHandle] Func<string?>? customMessage)
         {
             ShouldBeOfType(actual, typeof(T), customMessage);
             return (T)actual;
         }
 
-        public static void ShouldBeOfType(this object actual, Type expected)
+        public static void ShouldBeOfType([NotNull] this object? actual, Type expected)
         {
             ShouldBeOfType(actual, expected, () => null);
         }
 
-        public static void ShouldBeOfType(this object actual, Type expected, string customMessage)
+        public static void ShouldBeOfType([NotNull] this object? actual, Type expected, string? customMessage)
         {
             ShouldBeOfType(actual, expected, () => customMessage);
         }
 
-        public static void ShouldBeOfType(this object actual, Type expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldBeOfType([NotNull] this object? actual, Type expected, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => v != null && v.GetType() == expected, actual, expected, customMessage);
         }
 
-        public static void ShouldNotBeAssignableTo<T>(this object actual)
+        public static void ShouldNotBeAssignableTo<T>(this object? actual)
         {
             ShouldNotBeAssignableTo<T>(actual, () => null);
         }
 
-        public static void ShouldNotBeAssignableTo<T>(this object actual, string customMessage)
+        public static void ShouldNotBeAssignableTo<T>(this object? actual, string? customMessage)
         {
             ShouldNotBeAssignableTo<T>(actual, () => customMessage);
         }
 
-        public static void ShouldNotBeAssignableTo<T>(this object actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBeAssignableTo<T>(this object? actual, [InstantHandle] Func<string?>? customMessage)
         {
             ShouldNotBeAssignableTo(actual, typeof(T), customMessage);
         }
 
-        public static void ShouldNotBeAssignableTo(this object actual, Type expected)
+        public static void ShouldNotBeAssignableTo(this object? actual, Type expected)
         {
             ShouldNotBeAssignableTo(actual, expected, () => null);
         }
 
-        public static void ShouldNotBeAssignableTo(this object actual, Type expected, string customMessage)
+        public static void ShouldNotBeAssignableTo(this object? actual, Type expected, string? customMessage)
         {
             ShouldNotBeAssignableTo(actual, expected, () => customMessage);
         }
 
-        public static void ShouldNotBeAssignableTo(this object actual, Type expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBeAssignableTo(this object? actual, Type expected, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => !Is.InstanceOf(v, expected), actual, expected, customMessage);
         }
 
-        public static void ShouldNotBeOfType<T>(this object actual)
+        public static void ShouldNotBeOfType<T>(this object? actual)
         {
             ShouldNotBeOfType<T>(actual, () => null);
         }
 
-        public static void ShouldNotBeOfType<T>(this object actual, string customMessage)
+        public static void ShouldNotBeOfType<T>(this object? actual, string? customMessage)
         {
             ShouldNotBeOfType<T>(actual, () => customMessage);
         }
 
-        public static void ShouldNotBeOfType<T>(this object actual, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBeOfType<T>(this object? actual, [InstantHandle] Func<string?>? customMessage)
         {
             ShouldNotBeOfType(actual, typeof(T), customMessage);
         }
 
-        public static void ShouldNotBeOfType(this object actual, Type expected)
+        public static void ShouldNotBeOfType(this object? actual, Type expected)
         {
             ShouldNotBeOfType(actual, expected, () => null);
         }
 
-        public static void ShouldNotBeOfType(this object actual, Type expected, string customMessage)
+        public static void ShouldNotBeOfType(this object? actual, Type expected, string? customMessage)
         {
             ShouldNotBeOfType(actual, expected, () => customMessage);
         }
 
-        public static void ShouldNotBeOfType(this object actual, Type expected, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotBeOfType(this object? actual, Type expected, [InstantHandle] Func<string?>? customMessage)
         {
             actual.AssertAwesomely(v => v == null || v.GetType() != expected, actual, expected, customMessage);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldMatchApprovedTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldMatchApprovedTestExtensions.cs
@@ -45,7 +45,7 @@ namespace Shouldly
             if (config.Scrubber != null)
                 actual = config.Scrubber(actual);
 
-            var testMethodInfo = config.TestMethodFinder.GetTestMethodInfo(stackTrace, codeGetter.ShouldlyFrameIndex);
+            var testMethodInfo = config.TestMethodFinder.GetTestMethodInfo(stackTrace, codeGetter.ShouldlyFrameOffset);
             var descriminator = config.FilenameDescriminator == null ? null : "." + config.FilenameDescriminator;
             var outputFolder = testMethodInfo.SourceFileDirectory;
             if (string.IsNullOrEmpty(outputFolder))

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldMatchApprovedTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldMatchApprovedTestExtensions.cs
@@ -15,7 +15,7 @@ namespace Shouldly
         {
             actual.ShouldMatchApproved(() => null, c => { });
         }
-        public static void ShouldMatchApproved(this string actual, string customMessage)
+        public static void ShouldMatchApproved(this string actual, string? customMessage)
         {
             actual.ShouldMatchApproved(() => customMessage, c => { });
         }
@@ -25,14 +25,14 @@ namespace Shouldly
             actual.ShouldMatchApproved(() => null, configureOptions);
         }
 
-        public static void ShouldMatchApproved(this string actual, 
+        public static void ShouldMatchApproved(this string actual,
             string customMessage,
             Action<ShouldMatchConfigurationBuilder> configureOptions)
         {
             actual.ShouldMatchApproved(() => customMessage, configureOptions);
         }
 
-        public static void ShouldMatchApproved(this string actual, Func<string> customMessage, Action<ShouldMatchConfigurationBuilder> configureOptions)
+        public static void ShouldMatchApproved(this string actual, Func<string?> customMessage, Action<ShouldMatchConfigurationBuilder> configureOptions)
         {
             var codeGetter = new ActualCodeTextGetter();
             var stackTrace = new StackTrace(true);

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAllConditionsTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAllConditionsTestExtensions.cs
@@ -9,18 +9,18 @@ namespace Shouldly
     [ShouldlyMethods]
     public static class ShouldSatisfyAllConditionsTestExtensions
     {
-        public static void ShouldSatisfyAllConditions(this object actual, [InstantHandle] params Action[] conditions)
+        public static void ShouldSatisfyAllConditions(this object? actual, [InstantHandle] params Action[] conditions)
         {
             ShouldSatisfyAllConditions(actual, () => null, conditions);
         }
-        public static void ShouldSatisfyAllConditions(this object actual, string customMessage, [InstantHandle] params Action[] conditions)
+        public static void ShouldSatisfyAllConditions(this object? actual, string? customMessage, [InstantHandle] params Action[] conditions)
         {
             ShouldSatisfyAllConditions(actual, () => customMessage, conditions);
         }
-        public static void ShouldSatisfyAllConditions(this object actual, [InstantHandle] Func<string> customMessage, [InstantHandle] params Action[] conditions)
+        public static void ShouldSatisfyAllConditions(this object? actual, [InstantHandle] Func<string?>? customMessage, [InstantHandle] params Action[] conditions)
         {
             var errorMessages = new List<Exception>();
-            foreach (var action in conditions) 
+            foreach (var action in conditions)
             {
                 try
                 {

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowExtensions.cs
@@ -13,25 +13,25 @@ namespace Shouldly
         {
             return ShouldThrow<TException>(actual, () => null);
         }
-        public static TException ShouldThrow<TException>(this Action actual, string customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Action actual, string? customMessage) where TException : Exception
         {
             return ShouldThrow<TException>(actual, () => customMessage);
         }
-        public static TException ShouldThrow<TException>(this Action actual, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Action actual, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return Should.ThrowInternal<TException>(actual, customMessage);
         }
 
         /*** ShouldThrow(Func<T>) ***/
-        public static TException ShouldThrow<TException>(this Func<object> actual) where TException : Exception
+        public static TException ShouldThrow<TException>(this Func<object?> actual) where TException : Exception
         {
             return ShouldThrow<TException>(actual, () => null);
         }
-        public static TException ShouldThrow<TException>(this Func<object> actual, string customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Func<object?> actual, string? customMessage) where TException : Exception
         {
             return ShouldThrow<TException>(actual, () => customMessage);
         }
-        public static TException ShouldThrow<TException>(this Func<object> actual, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Func<object?> actual, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return Should.ThrowInternal<TException>(actual, customMessage);
         }
@@ -41,25 +41,25 @@ namespace Shouldly
         {
             return ShouldThrow(actual, () => null, exceptionType);
         }
-        public static Exception ShouldThrow(this Action actual, string customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Action actual, string? customMessage, Type exceptionType)
         {
             return ShouldThrow(actual, () => customMessage, exceptionType);
         }
-        public static Exception ShouldThrow(this Action actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Action actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return Should.ThrowInternal(actual, customMessage, exceptionType);
         }
 
         /*** ShouldThrow(Func<T>) ***/
-        public static Exception ShouldThrow(this Func<object> actual, Type exceptionType)
+        public static Exception ShouldThrow(this Func<object?> actual, Type exceptionType)
         {
             return ShouldThrow(actual, () => null, exceptionType);
         }
-        public static Exception ShouldThrow(this Func<object> actual, string customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Func<object?> actual, string? customMessage, Type exceptionType)
         {
             return ShouldThrow(actual, () => customMessage, exceptionType);
         }
-        public static Exception ShouldThrow(this Func<object> actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Func<object?> actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return Should.ThrowInternal(actual, customMessage, exceptionType);
         }
@@ -69,11 +69,11 @@ namespace Shouldly
         {
             ShouldNotThrow(action, () => null);
         }
-        public static void ShouldNotThrow(this Action action, string customMessage)
+        public static void ShouldNotThrow(this Action action, string? customMessage)
         {
             ShouldNotThrow(action, () => customMessage);
         }
-        public static void ShouldNotThrow(this Action action, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotThrow(this Action action, [InstantHandle] Func<string?>? customMessage)
         {
             Should.NotThrowInternal(action, customMessage);
         }
@@ -83,11 +83,11 @@ namespace Shouldly
         {
             return ShouldNotThrow(action, () => null);
         }
-        public static T ShouldNotThrow<T>(this Func<T> action, string customMessage)
+        public static T ShouldNotThrow<T>(this Func<T> action, string? customMessage)
         {
             return ShouldNotThrow(action, () => customMessage);
         }
-        public static T ShouldNotThrow<T>(this Func<T> action, [InstantHandle] Func<string> customMessage)
+        public static T ShouldNotThrow<T>(this Func<T> action, [InstantHandle] Func<string?>? customMessage)
         {
             return Should.NotThrowInternal(action, customMessage);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowTaskAsyncExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowTaskAsyncExtensions.cs
@@ -14,11 +14,11 @@ namespace Shouldly
         {
             return Should.ThrowAsync<TException>(task);
         }
-        public static Task<TException> ShouldThrowAsync<TException>(this Task task, string customMessage) where TException : Exception
+        public static Task<TException> ShouldThrowAsync<TException>(this Task task, string? customMessage) where TException : Exception
         {
             return Should.ThrowAsync<TException>(task, customMessage);
         }
-        public static Task<TException> ShouldThrowAsync<TException>(this Task task, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static Task<TException> ShouldThrowAsync<TException>(this Task task, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return Should.ThrowAsync<TException>(task, customMessage);
         }
@@ -28,11 +28,11 @@ namespace Shouldly
         {
             return Should.ThrowAsync(task, exceptionType);
         }
-        public static Task<Exception> ShouldThrowAsync(this Task task, string customMessage, Type exceptionType)
+        public static Task<Exception> ShouldThrowAsync(this Task task, string? customMessage, Type exceptionType)
         {
             return Should.ThrowAsync(task, customMessage, exceptionType);
         }
-        public static Task<Exception> ShouldThrowAsync(this Task task, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Task<Exception> ShouldThrowAsync(this Task task, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return Should.ThrowAsync(task, customMessage, exceptionType);
         }
@@ -42,11 +42,11 @@ namespace Shouldly
         {
             return Should.ThrowAsync<TException>(actual);
         }
-        public static Task<TException> ShouldThrowAsync<TException>(this Func<Task> actual, string customMessage) where TException : Exception
+        public static Task<TException> ShouldThrowAsync<TException>(this Func<Task> actual, string? customMessage) where TException : Exception
         {
             return Should.ThrowAsync<TException>(actual, customMessage);
         }
-        public static Task<TException> ShouldThrowAsync<TException>(this Func<Task> actual, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static Task<TException> ShouldThrowAsync<TException>(this Func<Task> actual, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return Should.ThrowAsync<TException>(actual, customMessage);
         }
@@ -56,11 +56,11 @@ namespace Shouldly
         {
             return Should.ThrowAsync(actual, exceptionType);
         }
-        public static Task<Exception> ShouldThrowAsync(this Func<Task> actual, string customMessage, Type exceptionType)
+        public static Task<Exception> ShouldThrowAsync(this Func<Task> actual, string? customMessage, Type exceptionType)
         {
             return Should.ThrowAsync(actual, customMessage, exceptionType);
         }
-        public static Task<Exception> ShouldThrowAsync(this Func<Task> actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Task<Exception> ShouldThrowAsync(this Func<Task> actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return Should.ThrowAsync(actual, customMessage, exceptionType);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowTaskExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowTaskExtensions.cs
@@ -14,11 +14,11 @@ namespace Shouldly
         {
             return ShouldThrow<TException>(() => actual);
         }
-        public static TException ShouldThrow<TException>(this Task actual, string customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Task actual, string? customMessage) where TException : Exception
         {
             return ShouldThrow<TException>(() => actual, customMessage);
         }
-        public static TException ShouldThrow<TException>(this Task actual, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Task actual, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return ShouldThrow<TException>(() => actual, customMessage);
         }
@@ -28,11 +28,11 @@ namespace Shouldly
         {
             return ShouldThrow(() => actual, exceptionType);
         }
-        public static Exception ShouldThrow(this Task actual, string customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Task actual, string? customMessage, Type exceptionType)
         {
             return ShouldThrow(() => actual, customMessage, exceptionType);
         }
-        public static Exception ShouldThrow(this Task actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Task actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return ShouldThrow(() => actual, customMessage, exceptionType);
         }
@@ -42,11 +42,11 @@ namespace Shouldly
         {
             return ShouldThrow<TException>(actual, () => null);
         }
-        public static TException ShouldThrow<TException>(this Func<Task> actual, string customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Func<Task> actual, string? customMessage) where TException : Exception
         {
             return ShouldThrow<TException>(actual, () => customMessage);
         }
-        public static TException ShouldThrow<TException>(this Func<Task> actual, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Func<Task> actual, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return ShouldThrow<TException>(actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
         }
@@ -56,11 +56,11 @@ namespace Shouldly
         {
             return ShouldThrow(actual, () => null, exceptionType);
         }
-        public static Exception ShouldThrow(this Func<Task> actual, string customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Func<Task> actual, string? customMessage, Type exceptionType)
         {
             return ShouldThrow(actual, () => customMessage, exceptionType);
         }
-        public static Exception ShouldThrow(this Func<Task> actual, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Func<Task> actual, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return ShouldThrow(actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage, exceptionType);
         }
@@ -70,11 +70,11 @@ namespace Shouldly
         {
             return ShouldThrow<TException>(() => actual, timeoutAfter);
         }
-        public static TException ShouldThrow<TException>(this Task actual, TimeSpan timeoutAfter, string customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Task actual, TimeSpan timeoutAfter, string? customMessage) where TException : Exception
         {
             return ShouldThrow<TException>(() => actual, timeoutAfter, customMessage);
         }
-        public static TException ShouldThrow<TException>(this Task actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Task actual, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return ShouldThrow<TException>(() => actual, timeoutAfter, customMessage);
         }
@@ -84,11 +84,11 @@ namespace Shouldly
         {
             return ShouldThrow(() => actual, timeoutAfter, exceptionType);
         }
-        public static Exception ShouldThrow(this Task actual, TimeSpan timeoutAfter, string customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Task actual, TimeSpan timeoutAfter, string? customMessage, Type exceptionType)
         {
             return ShouldThrow(() => actual, timeoutAfter, customMessage, exceptionType);
         }
-        public static Exception ShouldThrow(this Task actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Task actual, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return ShouldThrow(() => actual, timeoutAfter, customMessage, exceptionType);
         }
@@ -98,11 +98,11 @@ namespace Shouldly
         {
             return ShouldThrow<TException>(actual, timeoutAfter, () => null);
         }
-        public static TException ShouldThrow<TException>(this Func<Task> actual, TimeSpan timeoutAfter, string customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Func<Task> actual, TimeSpan timeoutAfter, string? customMessage) where TException : Exception
         {
             return ShouldThrow<TException>(actual, timeoutAfter, () => customMessage);
         }
-        public static TException ShouldThrow<TException>(this Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage) where TException : Exception
+        public static TException ShouldThrow<TException>(this Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage) where TException : Exception
         {
             return Should.ThrowInternal<TException>(actual, timeoutAfter, customMessage);
         }
@@ -112,11 +112,11 @@ namespace Shouldly
         {
             return ShouldThrow(actual, timeoutAfter, () => null,exceptionType);
         }
-        public static Exception ShouldThrow(this Func<Task> actual, TimeSpan timeoutAfter, string customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Func<Task> actual, TimeSpan timeoutAfter, string? customMessage, Type exceptionType)
         {
             return ShouldThrow(actual, timeoutAfter, () => customMessage,exceptionType);
         }
-        public static Exception ShouldThrow(this Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage, Type exceptionType)
+        public static Exception ShouldThrow(this Func<Task> actual, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage, Type exceptionType)
         {
             return Should.ThrowInternal(actual, timeoutAfter, customMessage,exceptionType);
         }
@@ -126,11 +126,11 @@ namespace Shouldly
         {
             ShouldNotThrow(action, () => null);
         }
-        public static void ShouldNotThrow(this Task action, string customMessage)
+        public static void ShouldNotThrow(this Task action, string? customMessage)
         {
             ShouldNotThrow(action, () => customMessage);
         }
-        public static void ShouldNotThrow(this Task action, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotThrow(this Task action, [InstantHandle] Func<string?>? customMessage)
         {
             ShouldNotThrow(() => action, customMessage);
         }
@@ -140,11 +140,11 @@ namespace Shouldly
         {
             return ShouldNotThrow(() => action);
         }
-        public static T ShouldNotThrow<T>(this Task<T> action, string customMessage)
+        public static T ShouldNotThrow<T>(this Task<T> action, string? customMessage)
         {
             return ShouldNotThrow(() => action, customMessage);
         }
-        public static T ShouldNotThrow<T>(this Task<T> action, [InstantHandle] Func<string> customMessage)
+        public static T ShouldNotThrow<T>(this Task<T> action, [InstantHandle] Func<string?>? customMessage)
         {
             return ShouldNotThrow(() => action, customMessage);
         }
@@ -154,11 +154,11 @@ namespace Shouldly
         {
             ShouldNotThrow(action, () => null);
         }
-        public static void ShouldNotThrow(this Func<Task> action, string customMessage)
+        public static void ShouldNotThrow(this Func<Task> action, string? customMessage)
         {
             ShouldNotThrow(action, () => customMessage);
         }
-        public static void ShouldNotThrow(this Func<Task> action, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotThrow(this Func<Task> action, [InstantHandle] Func<string?>? customMessage)
         {
             ShouldNotThrow(action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
         }
@@ -168,11 +168,11 @@ namespace Shouldly
         {
             ShouldNotThrow(() => action, timeoutAfter);
         }
-        public static void ShouldNotThrow(this Task action, TimeSpan timeoutAfter, string customMessage)
+        public static void ShouldNotThrow(this Task action, TimeSpan timeoutAfter, string? customMessage)
         {
             ShouldNotThrow(() => action, timeoutAfter, customMessage);
         }
-        public static void ShouldNotThrow(this Task action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotThrow(this Task action, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage)
         {
             ShouldNotThrow(() => action, timeoutAfter, customMessage);
         }
@@ -182,11 +182,11 @@ namespace Shouldly
         {
             ShouldNotThrow(action, timeoutAfter, () => null);
         }
-        public static void ShouldNotThrow(this Func<Task> action, TimeSpan timeoutAfter, string customMessage)
+        public static void ShouldNotThrow(this Func<Task> action, TimeSpan timeoutAfter, string? customMessage)
         {
             ShouldNotThrow(action, timeoutAfter, () => customMessage);
         }
-        public static void ShouldNotThrow(this Func<Task> action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
+        public static void ShouldNotThrow(this Func<Task> action, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage)
         {
             Should.NotThrowInternal(action, timeoutAfter, customMessage);
         }
@@ -196,11 +196,11 @@ namespace Shouldly
         {
             return ShouldNotThrow(action, () => null);
         }
-        public static T ShouldNotThrow<T>(this Func<Task<T>> action, string customMessage)
+        public static T ShouldNotThrow<T>(this Func<Task<T>> action, string? customMessage)
         {
             return ShouldNotThrow(action, () => customMessage);
         }
-        public static T ShouldNotThrow<T>(this Func<Task<T>> action, [InstantHandle] Func<string> customMessage)
+        public static T ShouldNotThrow<T>(this Func<Task<T>> action, [InstantHandle] Func<string?>? customMessage)
         {
             return ShouldNotThrow(action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
         }
@@ -210,11 +210,11 @@ namespace Shouldly
         {
             return ShouldNotThrow(() => action, timeoutAfter);
         }
-        public static T ShouldNotThrow<T>(this Task<T> action, TimeSpan timeoutAfter, string customMessage)
+        public static T ShouldNotThrow<T>(this Task<T> action, TimeSpan timeoutAfter, string? customMessage)
         {
             return ShouldNotThrow(() => action, timeoutAfter, customMessage);
         }
-        public static T ShouldNotThrow<T>(this Task<T> action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
+        public static T ShouldNotThrow<T>(this Task<T> action, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage)
         {
             return ShouldNotThrow(() => action, timeoutAfter, customMessage);
         }
@@ -224,11 +224,11 @@ namespace Shouldly
         {
             return ShouldNotThrow(action, timeoutAfter, () => null);
         }
-        public static T ShouldNotThrow<T>(this Func<Task<T>> action, TimeSpan timeoutAfter, string customMessage)
+        public static T ShouldNotThrow<T>(this Func<Task<T>> action, TimeSpan timeoutAfter, string? customMessage)
         {
             return ShouldNotThrow(action, timeoutAfter, () => customMessage);
         }
-        public static T ShouldNotThrow<T>(this Func<Task<T>> action, TimeSpan timeoutAfter, [InstantHandle] Func<string> customMessage)
+        public static T ShouldNotThrow<T>(this Func<Task<T>> action, TimeSpan timeoutAfter, [InstantHandle] Func<string?>? customMessage)
         {
             return Should.NotThrowInternal(action, timeoutAfter, customMessage);
         }

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -13,19 +13,19 @@ namespace Shouldly
     internal class ExpectedShouldlyMessage : ShouldlyMessage
     {
         public ExpectedShouldlyMessage(object expected, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, expected))
         {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected);
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
     internal class ActualShouldlyMessage : ShouldlyMessage
     {
         public ActualShouldlyMessage(object actual, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, actual: actual)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, actual: actual)
             {
                 HasRelevantActual = true
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -33,23 +33,23 @@ namespace Shouldly
     internal class ExpectedActualShouldlyMessage : ShouldlyMessage
     {
         public ExpectedActualShouldlyMessage(object expected, object actual, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 HasRelevantActual = true
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
     internal class ActualFilteredWithPredicateShouldlyMessage : ShouldlyMessage
     {
         public ActualFilteredWithPredicateShouldlyMessage(Expression filter, object result, object actual, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, result, actual)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, result, actual)
             {
                 HasRelevantActual = true,
                 Filter = filter
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -60,12 +60,12 @@ namespace Shouldly
             Case? caseSensitivity,
             [InstantHandle] Func<string> customMessage,
             [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 HasRelevantActual = true,
                 CaseSensitivity = caseSensitivity
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -75,12 +75,12 @@ namespace Shouldly
         public ExpectedActualToleranceShouldlyMessage(object expected, object actual, object tolerance,
             [InstantHandle] Func<string> customMessage,
             [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 Tolerance = tolerance,
                 HasRelevantActual = true
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -90,12 +90,12 @@ namespace Shouldly
         public ExpectedActualIgnoreOrderShouldlyMessage(object expected, object actual,
             [InstantHandle] Func<string> customMessage,
             [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 IgnoreOrder = true,
                 HasRelevantActual = true
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -105,13 +105,13 @@ namespace Shouldly
         public ExpectedActualKeyShouldlyMessage(object expected, object actual, object key,
             [InstantHandle] Func<string> customMessage,
             [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 Key = key,
                 HasRelevantActual = true,
                 HasRelevantKey = true
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -121,13 +121,13 @@ namespace Shouldly
         public ExpectedOrderShouldlyMessage(object actual, SortDirection expectedDirection, int outOfOrderIndex, object outOfOrderObject,
             [InstantHandle] Func<string> customMessage,
             [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, actual: actual)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, actual: actual)
             {
                 SortDirection = expectedDirection,
                 OutOfOrderIndex = outOfOrderIndex,
                 OutOfOrderObject = outOfOrderObject
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -135,11 +135,11 @@ namespace Shouldly
     internal class ExpectedEquvalenceShouldlyMessage : ShouldlyMessage
     {
         public ExpectedEquvalenceShouldlyMessage(object expected, object actual, IEnumerable<string> path, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 Path = path
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -148,25 +148,25 @@ namespace Shouldly
     {
         public ShouldlyThrowMessage(object expected, string exceptionMessage, Func<string> customMessage,
             [CallerMemberName] string shouldlyMethod = null)
+            : base(new ShouldThrowAssertionContext(expected, null, exceptionMessage, shouldlyMethod: shouldlyMethod))
         {
-            ShouldlyAssertionContext = new ShouldThrowAssertionContext(expected, null, exceptionMessage, shouldlyMethod: shouldlyMethod);
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
 
         public ShouldlyThrowMessage(object expected, object actual, [InstantHandle] Func<string> customMessage,
             [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldThrowAssertionContext(expected, actual, shouldlyMethod: shouldlyMethod)
+            : base(new ShouldThrowAssertionContext(expected, actual, shouldlyMethod: shouldlyMethod)
             {
                 HasRelevantActual = true
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
 
         public ShouldlyThrowMessage(object expected, [InstantHandle] Func<string> customMessage,
             [CallerMemberName] string shouldlyMethod = null)
+            : base(new ShouldThrowAssertionContext(expected, shouldlyMethod: shouldlyMethod))
         {
-            ShouldlyAssertionContext = new ShouldThrowAssertionContext(expected, shouldlyMethod: shouldlyMethod);
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -174,12 +174,12 @@ namespace Shouldly
     internal class ShouldContainWithCountShouldlyMessage : ShouldlyMessage
     {
         public ShouldContainWithCountShouldlyMessage(object expected, object actual, int matchCount, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 HasRelevantActual = true,
                 MatchCount = matchCount
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -187,23 +187,23 @@ namespace Shouldly
     internal class TaskShouldlyThrowMessage : ShouldlyMessage
     {
         public TaskShouldlyThrowMessage(object expected, string exceptionMessage, Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+            : base(new ShouldThrowAssertionContext(expected, null, exceptionMessage, isAsync: true, shouldlyMethod: shouldlyMethod))
         {
-            ShouldlyAssertionContext = new ShouldThrowAssertionContext(expected, null, exceptionMessage, isAsync: true, shouldlyMethod: shouldlyMethod);
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
 
         public TaskShouldlyThrowMessage(object expected, object actual, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldThrowAssertionContext(expected, actual, isAsync: true, shouldlyMethod: shouldlyMethod)
+            : base(new ShouldThrowAssertionContext(expected, actual, isAsync: true, shouldlyMethod: shouldlyMethod)
             {
                 HasRelevantActual = true
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
 
         public TaskShouldlyThrowMessage(object expected, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+            : base(new ShouldThrowAssertionContext(expected, isAsync: true, shouldlyMethod: shouldlyMethod))
         {
-            ShouldlyAssertionContext = new ShouldThrowAssertionContext(expected, isAsync: true, shouldlyMethod: shouldlyMethod);
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -213,11 +213,11 @@ namespace Shouldly
         public CompleteInShouldlyMessage(string what, TimeSpan timeout,
             [InstantHandle] Func<string> customMessage,
             [CallerMemberName] string shouldlyMethod = null)
-        {
-            ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, what)
+            : base(new ShouldlyAssertionContext(shouldlyMethod, what)
             {
                 Timeout = timeout
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -229,17 +229,17 @@ namespace Shouldly
     internal class AsyncShouldlyThrowShouldlyMessage : ShouldlyMessage
     {
         public AsyncShouldlyThrowShouldlyMessage(Type exception, [InstantHandle] Func<string> customMessage, StackTrace stackTrace)
+            : base(new ShouldThrowAssertionContext(exception, stackTrace: stackTrace, isAsync: true))
         {
-            ShouldlyAssertionContext = new ShouldThrowAssertionContext(exception, stackTrace: stackTrace, isAsync: true);
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
 
         public AsyncShouldlyThrowShouldlyMessage(Type expected, Type actual, [InstantHandle] Func<string> customMessage, StackTrace stackTrace)
-        {
-            ShouldlyAssertionContext = new ShouldThrowAssertionContext(expected, actual, stackTrace: stackTrace, isAsync: true)
+            : base(new ShouldThrowAssertionContext(expected, actual, stackTrace: stackTrace, isAsync: true)
             {
                 HasRelevantActual = true
-            };
+            })
+        {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
     }
@@ -284,7 +284,12 @@ namespace Shouldly
             new ShouldBeEquivalentToMessageGenerator()
         };
 
-        protected IShouldlyAssertionContext ShouldlyAssertionContext { get; set; }
+        public ShouldlyMessage(ShouldlyAssertionContext context)
+        {
+            ShouldlyAssertionContext = context;
+        }
+
+        protected IShouldlyAssertionContext ShouldlyAssertionContext { get; }
 
         public override string ToString()
         {

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -12,7 +12,7 @@ namespace Shouldly
 {
     internal class ExpectedShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedShouldlyMessage(object expected, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        public ExpectedShouldlyMessage(object? expected, [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, expected))
         {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
@@ -20,7 +20,7 @@ namespace Shouldly
     }
     internal class ActualShouldlyMessage : ShouldlyMessage
     {
-        public ActualShouldlyMessage(object actual, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        public ActualShouldlyMessage(object? actual, [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, actual: actual)
             {
                 HasRelevantActual = true
@@ -32,7 +32,7 @@ namespace Shouldly
 
     internal class ExpectedActualShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualShouldlyMessage(object expected, object actual, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        public ExpectedActualShouldlyMessage(object? expected, object? actual, [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 HasRelevantActual = true
@@ -43,7 +43,7 @@ namespace Shouldly
     }
     internal class ActualFilteredWithPredicateShouldlyMessage : ShouldlyMessage
     {
-        public ActualFilteredWithPredicateShouldlyMessage(Expression filter, object result, object actual, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        public ActualFilteredWithPredicateShouldlyMessage(Expression filter, object? result, object? actual, [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, result, actual)
             {
                 HasRelevantActual = true,
@@ -56,10 +56,10 @@ namespace Shouldly
 
     internal class ExpectedActualWithCaseSensitivityShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualWithCaseSensitivityShouldlyMessage(object expected, object actual,
+        public ExpectedActualWithCaseSensitivityShouldlyMessage(object? expected, object? actual,
             Case? caseSensitivity,
-            [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+            [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 HasRelevantActual = true,
@@ -72,9 +72,9 @@ namespace Shouldly
 
     internal class ExpectedActualToleranceShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualToleranceShouldlyMessage(object expected, object actual, object tolerance,
-            [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+        public ExpectedActualToleranceShouldlyMessage(object? expected, object? actual, object? tolerance,
+            [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 Tolerance = tolerance,
@@ -87,9 +87,9 @@ namespace Shouldly
 
     internal class ExpectedActualIgnoreOrderShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualIgnoreOrderShouldlyMessage(object expected, object actual,
-            [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+        public ExpectedActualIgnoreOrderShouldlyMessage(object? expected, object? actual,
+            [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 IgnoreOrder = true,
@@ -102,9 +102,9 @@ namespace Shouldly
 
     internal class ExpectedActualKeyShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedActualKeyShouldlyMessage(object expected, object actual, object key,
-            [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+        public ExpectedActualKeyShouldlyMessage(object? expected, object? actual, object key,
+            [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 Key = key,
@@ -118,9 +118,9 @@ namespace Shouldly
 
     internal class ExpectedOrderShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedOrderShouldlyMessage(object actual, SortDirection expectedDirection, int outOfOrderIndex, object outOfOrderObject,
-            [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+        public ExpectedOrderShouldlyMessage(object? actual, SortDirection expectedDirection, int outOfOrderIndex, object? outOfOrderObject,
+            [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, actual: actual)
             {
                 SortDirection = expectedDirection,
@@ -134,7 +134,7 @@ namespace Shouldly
 
     internal class ExpectedEquvalenceShouldlyMessage : ShouldlyMessage
     {
-        public ExpectedEquvalenceShouldlyMessage(object expected, object actual, IEnumerable<string> path, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        public ExpectedEquvalenceShouldlyMessage(object? expected, object? actual, IEnumerable<string> path, [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 Path = path
@@ -146,15 +146,15 @@ namespace Shouldly
 
     internal class ShouldlyThrowMessage : ShouldlyMessage
     {
-        public ShouldlyThrowMessage(object expected, string exceptionMessage, Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+        public ShouldlyThrowMessage(object? expected, string? exceptionMessage, Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldThrowAssertionContext(expected, null, exceptionMessage, shouldlyMethod: shouldlyMethod))
         {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
 
-        public ShouldlyThrowMessage(object expected, object actual, [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+        public ShouldlyThrowMessage(object? expected, object? actual, [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldThrowAssertionContext(expected, actual, shouldlyMethod: shouldlyMethod)
             {
                 HasRelevantActual = true
@@ -163,8 +163,8 @@ namespace Shouldly
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
 
-        public ShouldlyThrowMessage(object expected, [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+        public ShouldlyThrowMessage(object? expected, [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldThrowAssertionContext(expected, shouldlyMethod: shouldlyMethod))
         {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
@@ -173,7 +173,7 @@ namespace Shouldly
 
     internal class ShouldContainWithCountShouldlyMessage : ShouldlyMessage
     {
-        public ShouldContainWithCountShouldlyMessage(object expected, object actual, int matchCount, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        public ShouldContainWithCountShouldlyMessage(object? expected, object? actual, int matchCount, [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, expected, actual)
             {
                 HasRelevantActual = true,
@@ -186,13 +186,13 @@ namespace Shouldly
 
     internal class TaskShouldlyThrowMessage : ShouldlyMessage
     {
-        public TaskShouldlyThrowMessage(object expected, string exceptionMessage, Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        public TaskShouldlyThrowMessage(object? expected, string? exceptionMessage, Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldThrowAssertionContext(expected, null, exceptionMessage, isAsync: true, shouldlyMethod: shouldlyMethod))
         {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
 
-        public TaskShouldlyThrowMessage(object expected, object actual, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        public TaskShouldlyThrowMessage(object? expected, object? actual, [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldThrowAssertionContext(expected, actual, isAsync: true, shouldlyMethod: shouldlyMethod)
             {
                 HasRelevantActual = true
@@ -201,7 +201,7 @@ namespace Shouldly
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
 
-        public TaskShouldlyThrowMessage(object expected, [InstantHandle] Func<string> customMessage, [CallerMemberName] string shouldlyMethod = null)
+        public TaskShouldlyThrowMessage(object? expected, [InstantHandle] Func<string?>? customMessage, [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldThrowAssertionContext(expected, isAsync: true, shouldlyMethod: shouldlyMethod))
         {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
@@ -210,9 +210,9 @@ namespace Shouldly
 
     internal class CompleteInShouldlyMessage : ShouldlyMessage
     {
-        public CompleteInShouldlyMessage(string what, TimeSpan timeout,
-            [InstantHandle] Func<string> customMessage,
-            [CallerMemberName] string shouldlyMethod = null)
+        public CompleteInShouldlyMessage(string? what, TimeSpan timeout,
+            [InstantHandle] Func<string?>? customMessage,
+            [CallerMemberName] string shouldlyMethod = null!)
             : base(new ShouldlyAssertionContext(shouldlyMethod, what)
             {
                 Timeout = timeout
@@ -228,13 +228,13 @@ namespace Shouldly
     /// </summary>
     internal class AsyncShouldlyThrowShouldlyMessage : ShouldlyMessage
     {
-        public AsyncShouldlyThrowShouldlyMessage(Type exception, [InstantHandle] Func<string> customMessage, StackTrace stackTrace)
+        public AsyncShouldlyThrowShouldlyMessage(Type? exception, [InstantHandle] Func<string?>? customMessage, StackTrace stackTrace)
             : base(new ShouldThrowAssertionContext(exception, stackTrace: stackTrace, isAsync: true))
         {
             if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage();
         }
 
-        public AsyncShouldlyThrowShouldlyMessage(Type expected, Type actual, [InstantHandle] Func<string> customMessage, StackTrace stackTrace)
+        public AsyncShouldlyThrowShouldlyMessage(Type? expected, Type? actual, [InstantHandle] Func<string?>? customMessage, StackTrace stackTrace)
             : base(new ShouldThrowAssertionContext(expected, actual, stackTrace: stackTrace, isAsync: true)
             {
                 HasRelevantActual = true

--- a/src/Shouldly/ShouldlyTimeoutException.cs
+++ b/src/Shouldly/ShouldlyTimeoutException.cs
@@ -9,12 +9,12 @@ namespace Shouldly
         {
         }
 
-        public ShouldlyTimeoutException(string message, ShouldlyTimeoutException inner) : base(message, inner)
+        public ShouldlyTimeoutException(string? message, ShouldlyTimeoutException? inner) : base(message, inner)
         {
         }
 
 #if StackTrace
-        private string stackTrace;
+        private string? stackTrace;
 
         public override string StackTrace => StackTraceHelpers.GetStackTrace(this, ref stackTrace);
 #endif

--- a/src/Shouldly/Utils.cs
+++ b/src/Shouldly/Utils.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Threading;
+
+namespace Shouldly
+{
+    internal static class Utils
+    {
+        public static IDisposable WithSynchronizationContext(SynchronizationContext? synchronizationContext)
+        {
+            var originalSynchronizationContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(synchronizationContext);
+
+            return On.Dispose(() =>
+            {
+                if (SynchronizationContext.Current == synchronizationContext)
+                    SynchronizationContext.SetSynchronizationContext(originalSynchronizationContext);
+            });
+        }
+    }
+}

--- a/src/TestDiffTools/Program.cs
+++ b/src/TestDiffTools/Program.cs
@@ -18,7 +18,7 @@ namespace TestDiffTools
                 .GetFields()
                 .Select((f, i) => new
                 {
-                    DiffTool = (DiffTool) f.GetValue(ShouldlyConfiguration.DiffTools.KnownDiffTools),
+                    DiffTool = (DiffTool) f.GetValue(ShouldlyConfiguration.DiffTools.KnownDiffTools)!,
                     Index = i
                 }).ToList();
 
@@ -26,8 +26,8 @@ namespace TestDiffTools
             while (true)
             {
                 var diffToolsCollection = (List<DiffTool>) ShouldlyConfiguration.DiffTools.GetType()
-                    .GetField("_diffTools", BindingFlags.Instance | BindingFlags.NonPublic)
-                    .GetValue(ShouldlyConfiguration.DiffTools);
+                    .GetField("_diffTools", BindingFlags.Instance | BindingFlags.NonPublic)!
+                    .GetValue(ShouldlyConfiguration.DiffTools)!;
                 diffToolsCollection.Clear();
 
                 Console.WriteLine("Select difftool:");
@@ -63,10 +63,10 @@ namespace TestDiffTools
                 ShouldlyConfiguration.DiffTools.RegisterDiffTool(selectedDiffTool.DiffTool);
                 var stacktrace = new StackTrace(true);
 
-                var currentFrame = stacktrace.GetFrame(0);
+                var currentFrame = stacktrace.GetFrame(0)!;
                 var approved = Path.Combine(
-                    Path.GetDirectoryName(currentFrame.GetFileName()),
-                    $"{Path.GetFileNameWithoutExtension(currentFrame.GetFileName())}.{currentFrame.GetMethod().Name}.approved.txt");
+                    Path.GetDirectoryName(currentFrame.GetFileName())!,
+                    $"{Path.GetFileNameWithoutExtension(currentFrame.GetFileName())}.{currentFrame.GetMethod()!.Name}.approved.txt");
 
                 switch (selectedOption)
                 {

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.35.0" />
+	<package id="Cake" version="0.37.0" />
 </packages>


### PR DESCRIPTION
Closes #579.

I tried to keep the big initial annotation commit as straightforward as possible, saving more complex fixes for later commits. For files where the changes aren't absolutely obvious, please consider reviewing single commits at a time.

➡ Please comment if you'd like any of the types in these APIs to be annotated differently. I simply annotated them as nullable if `null` was tolerated in previous releases and left them non-nullable if `null` would have caused an exception. All nullable annotations (`?` and attributes) are a description of my understanding of the past rather than a statement from me about the future.