### PR TITLE
Optimized `.ShouldBeUnique()` for large datasets

### DIFF
--- a/src/Shouldly.Tests/ShouldBeUnique/LargeDatasetScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeUnique/LargeDatasetScenario.cs
@@ -1,0 +1,18 @@
+﻿using System.Linq;
+
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeUnique
+{
+    public class LargeDatasetScenario
+    {
+        [Fact]
+        public void ShouldPass()
+        {
+            Enumerable.Range(1, 500000)
+                .ToArray()
+                .ShouldBeUnique();
+        }
+    }
+}
+

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -307,16 +307,14 @@ namespace Shouldly
             ShouldBeInOrder(actual, expectedSortDirection, (x, y) => isOutOfOrder(customComparer.Compare(x, y)), customMessage);
         }
 
-        private static List<object> GetDuplicates<T>(IEnumerable<T> items)
+        private static List<T> GetDuplicates<T>(IEnumerable<T> items)
         {
-            var list = new List<object>();
-            var duplicates = new List<object>();
+            var uniqueItems = new HashSet<T>();
+            var duplicates = new List<T>();
 
-            foreach (object o1 in items)
-            {
-                duplicates.AddRange(list.Where(o2 => o1 != null && o1.Equals(o2)));
-                list.Add(o1);
-            }
+            foreach (var item in items)
+                if (!uniqueItems.Add(item))
+                    duplicates.Add(item);
 
             return duplicates;
         }


### PR DESCRIPTION
With corresponding test.

Resolves #602.