### PR TITLE
Modify FindAsyncMethodUsingAttribute to discover async test methods.

### DIFF
--- a/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.CanFindTestAttributeInAsync.approved.txt
+++ b/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.CanFindTestAttributeInAsync.approved.txt
@@ -1,0 +1,1 @@
+testAttributes

--- a/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
+++ b/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
@@ -168,6 +168,14 @@ In the meantime use 'ShouldlyConfiguration.DiffTools.RegisterDiffTool()' to add 
         }
 
         [Fact]
+        public async Task CanFindTestAttributeInAsync()
+        {
+            await Task.Delay(200);
+
+            "testAttributes".ShouldMatchApproved(b => b.LocateTestMethodUsingAttribute<FactAttribute>());
+        }
+
+        [Fact]
         public async Task HandlesAsync()
         {
             await Task.Delay(200);

--- a/src/Shouldly/Configuration/FindMethodUsingAttribute.cs
+++ b/src/Shouldly/Configuration/FindMethodUsingAttribute.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
 
 namespace Shouldly.Configuration
 {
@@ -9,13 +11,59 @@ namespace Shouldly.Configuration
         {
             for (var i = startAt; stackTrace.GetFrame(i) is { } frame; i++)
             {
-                if (frame.GetMethod() is { } method && method.IsDefined(typeof(T), inherit: true))
+                var method = frame.GetMethod();
+                var originalMethod = GetOriginalMethodInfoForStateMachineMethod(method);
+                method = originalMethod != null ? originalMethod.Value.DeclaringType.GetMethod(originalMethod.Value.MethodName) : method;
+
+                if ((method?.IsDefined(typeof(T), inherit: true)).GetValueOrDefault())
                 {
                     return new TestMethodInfo(frame);
                 }
             }
 
             throw new InvalidOperationException($"Cannot find a method in the stack trace with attribute {typeof(T).FullName}.");
+        }
+
+        private static OriginalMethodInfo? GetOriginalMethodInfoForStateMachineMethod(MethodBase? method)
+        {
+            if (method?.DeclaringType is { IsByRef: false } declaringType
+                && declaringType.DeclaringType is { } originalMethodDeclaringType
+                && ContainsAttribute(declaringType, "System.Runtime.CompilerServices.CompilerGeneratedAttribute")
+                && declaringType.GetInterface("System.Runtime.CompilerServices.IAsyncStateMachine") is object)
+            {
+                var stateMachineTypeName = declaringType.Name;
+                var openingAngleBracket = stateMachineTypeName.IndexOf('<');
+                if (openingAngleBracket != -1)
+                {
+                    var closingAngleBracket = stateMachineTypeName.IndexOf('>', openingAngleBracket + 1);
+                    if (closingAngleBracket != -1)
+                    {
+                        var originalMethodName = stateMachineTypeName.Substring(openingAngleBracket + 1, closingAngleBracket - (openingAngleBracket + 1));
+
+                        return new OriginalMethodInfo(originalMethodName, originalMethodDeclaringType);
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private static bool ContainsAttribute(MemberInfo member, string attributeName)
+        {
+            return member.CustomAttributes.Any(a =>
+                a.AttributeType.FullName?.StartsWith(attributeName, StringComparison.Ordinal) ?? false);
+        }
+
+        private readonly struct OriginalMethodInfo
+        {
+            public OriginalMethodInfo(string methodName, Type declaringType)
+            {
+                MethodName = methodName;
+                DeclaringType = declaringType;
+            }
+
+            public string MethodName { get; }
+            public Type DeclaringType { get; }
         }
     }
 }


### PR DESCRIPTION
This PR fixes `FindMethodUsingAttribute` so that it will correctly find the test method when the test method is async.

If you use `ShouldMatchApproved` in an async test method, after an await, the continuation that is created causes the stack trace to loose information about the original calling method.

e.g. This will fail with "Cannot find method in call stack with attribute NUnit.Framework.TestAttribute"
```
        [Test]
        public async Task ShouldMatchSnapshot_AsyncTestWithTestAttribute_ShouldMatchStringValueSnapshot()
        {
            await Task.Delay(1);

            const string stringValue = "String Value";
            stringValue.ShouldMatchApproved(c => c.LocateTestMethodUsingAttribute<TestAttribute>());
        }
```

While investigating this problem I realized that the `TestMethodInfo` class already appears to be aware of this issue and includes code to resolve the async methods, however this has not been implemented in `FindMethodUsingAttribute`.

To fix this, I've copied a number of classes/methods from `TestMethodInfo` and applied them in `FindMethodUsingAttribute`.  Note that I've copied `OriginalMethodInfo`, `GetOriginalMethodInfoForStateMachineMethod` and `ContainsAttribute`, and these are all unchanged, so it may be worth refactoring them to a shared location later.

If anyone wishes to make use of this before the PR is merged, you can simply define a new `FindMethodUsingAttribute` with a defferent name (e.g. `FindAsyncMethodUsingAttribute`, and then configure `ShouldMatchApproved` to use it like so...
`stringValue.ShouldMatchApproved(c => c.Configure(smc => smc.TestMethodFinder = new FindAsyncMethodUsingAttribute<TestAttribute>()));`