### PR TITLE
Restore the ability to use Should(Not)BeNull on System.Nullable<T> values

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -402,16 +402,14 @@ namespace Shouldly
     {
         [System.Obsolete("Func based customMessage overloads have been removed. Pass in a string for the cu" +
             "somMessage.", true)]
-        public static void ShouldBeNull<T>(this T? actual, System.Func<string?>? customMessage)
-            where T :  class { }
+        public static void ShouldBeNull<T>(this T actual, System.Func<string?>? customMessage) { }
         public static void ShouldBeNull<T>([System.Diagnostics.CodeAnalysis.MaybeNull] this T? actual, string? customMessage = null)
             where T :  class { }
         public static void ShouldBeNull<T>([System.Diagnostics.CodeAnalysis.MaybeNull] this T? actual, string? customMessage = null)
             where T :  struct { }
         [System.Obsolete("Func based customMessage overloads have been removed. Pass in a string for the cu" +
             "somMessage.", true)]
-        public static void ShouldNotBeNull<T>(this T? actual, System.Func<string?>? customMessage)
-            where T :  class { }
+        public static void ShouldNotBeNull<T>(this T actual, System.Func<string?>? customMessage) { }
         public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T? actual, string? customMessage = null)
             where T :  class { }
         public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T? actual, string? customMessage = null)

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -406,12 +406,16 @@ namespace Shouldly
             where T :  class { }
         public static void ShouldBeNull<T>([System.Diagnostics.CodeAnalysis.MaybeNull] this T? actual, string? customMessage = null)
             where T :  class { }
+        public static void ShouldBeNull<T>([System.Diagnostics.CodeAnalysis.MaybeNull] this T? actual, string? customMessage = null)
+            where T :  struct { }
         [System.Obsolete("Func based customMessage overloads have been removed. Pass in a string for the cu" +
             "somMessage.", true)]
         public static void ShouldNotBeNull<T>(this T? actual, System.Func<string?>? customMessage)
             where T :  class { }
         public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T? actual, string? customMessage = null)
             where T :  class { }
+        public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T? actual, string? customMessage = null)
+            where T :  struct { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeStringTestExtensions

--- a/src/Shouldly.Tests/ShouldBeNull/NotNullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeNull/NotNullScenario.cs
@@ -6,7 +6,7 @@ namespace Shouldly.Tests.ShouldBeNull
     public class NotNullScenario
     {
         [Fact]
-        public void NotNullScenarioShouldFail()
+        public void ShouldFailForNullReference()
         {
             string? myNullRef = null;
             // ReSharper disable once ExpressionIsAlwaysNull
@@ -29,9 +29,38 @@ Additional Info:
         }
 
         [Fact]
-        public void ShouldPass()
+        public void ShouldPassForNonNullReference()
         {
             "Hello World".ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void ShouldFailForSystemNullableWithoutValue()
+        {
+            int? myNullRef = null;
+            // ReSharper disable once ExpressionIsAlwaysNull
+            Verify.ShouldFail(() =>
+                    myNullRef.ShouldNotBeNull("Some additional context"),
+
+                errorWithSource:
+                @"myNullRef
+    should not be null but was
+
+Additional Info:
+    Some additional context",
+
+                errorWithoutSource:
+                @"null
+    should not be null but was
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPassForSystemNullableWithValue()
+        {
+            ((int?)0).ShouldNotBeNull();
         }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeNull/NullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeNull/NullScenario.cs
@@ -6,7 +6,7 @@ namespace Shouldly.Tests.ShouldBeNull
     public class NullScenario
     {
         [Fact]
-        public void NullScenarioShouldFail()
+        public void ShouldFailForNonNullReference()
         {
             var myNullRef = "Hello World";
             Verify.ShouldFail(() =>
@@ -29,9 +29,39 @@ Additional Info:
         }
 
         [Fact]
-        public void ShouldPass()
+        public void ShouldPassForNullReference()
         {
             ((string?)null).ShouldBeNull();
+        }
+
+
+        [Fact]
+        public void ShouldFailForSystemNullableWithValue()
+        {
+            var myNullRef = (int?)0;
+            Verify.ShouldFail(() =>
+myNullRef.ShouldBeNull("Some additional context"),
+
+errorWithSource:
+@"myNullRef
+    should be null but was
+0
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"0
+    should be null but was
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPassForSystemNullableWithoutValue()
+        {
+            ((int?)null).ShouldBeNull();
         }
     }
 }

--- a/src/Shouldly/Obsoletes.cs
+++ b/src/Shouldly/Obsoletes.cs
@@ -421,15 +421,13 @@ Diff launching can be controlled at the test level using `ShouldMatchConfigurati
     public static partial class ShouldBeNullExtensions
     {
         [Obsolete(ObsoleteMessages.FuncCustomMessage, true)]
-        public static void ShouldBeNull<T>(this T? actual, Func<string?>? customMessage)
-            where T : class
+        public static void ShouldBeNull<T>(this T actual, Func<string?>? customMessage)
         {
             throw new NotImplementedException();
         }
 
         [Obsolete(ObsoleteMessages.FuncCustomMessage, true)]
-        public static void ShouldNotBeNull<T>(this T? actual, Func<string?>? customMessage)
-            where T : class
+        public static void ShouldNotBeNull<T>(this T actual, Func<string?>? customMessage)
         {
             throw new NotImplementedException();
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeNullExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeNullExtensions.cs
@@ -17,9 +17,25 @@ namespace Shouldly
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
         }
 
+        [ContractAnnotation("actual:notnull => halt")]
+        public static void ShouldBeNull<T>([MaybeNull] this T? actual, string? customMessage = null)
+            where T : struct
+        {
+            if (actual != null)
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
+        }
+
         [ContractAnnotation("actual:null => halt")]
         public static void ShouldNotBeNull<T>([NotNull] this T? actual, string? customMessage = null)
             where T : class
+        {
+            if (actual == null)
+                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
+        }
+
+        [ContractAnnotation("actual:null => halt")]
+        public static void ShouldNotBeNull<T>([NotNull] this T? actual, string? customMessage = null)
+            where T : struct
         {
             if (actual == null)
                 throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());


### PR DESCRIPTION
Fixes #674. Adds tests that would have brought this to our attention in #626.

I think it was a recent backported compiler change that allows this kind of overload resolution, though maybe this has been around longer than I'm thinking too:

```cs
public static void ShouldBeNull<T>(this T? x) where T : class { }
public static void ShouldBeNull<T>(this T? x) where T : struct { }
```

```cs
((string?)null).ShouldBeNull(); // No error!
((int?)null).ShouldBeNull(); // No error!
4.ShouldBeNull(); // Error!
```