### PR TITLE
Adds DynamicShould.Throw method to cover corner case

### DIFF
--- a/src/Shouldly.Tests/DynamicShould/ThrowFromObjectMethodScenario.cs
+++ b/src/Shouldly.Tests/DynamicShould/ThrowFromObjectMethodScenario.cs
@@ -1,0 +1,80 @@
+using System;
+using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.DynamicShould
+{
+    public class ThrowFromObjectMethodScenario
+    {
+        class Foo
+        {
+            public object NoExceptionMethod()
+            {
+                return this;
+            }
+
+            public object ExceptionMethod()
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        [Fact]
+        public void NotThrowFromDynamicMethodScenarioShouldFail()
+        {
+            Verify.ShouldFail(() =>
+                    Shouldly.DynamicShould
+                        .Throw<InvalidOperationException>(() => ((dynamic)new Foo()).NoExceptionMethod(), "Some additional context"),
+
+errorWithSource:
+@"`(dynamic)new Foo()).NoExceptionMethod(`
+    should throw
+System.InvalidOperationException
+    but did not
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"delegate
+    should throw
+System.InvalidOperationException
+    but did not
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ThrowOtherExceptionFromDynamicMethodScenarioShouldFail()
+        {
+            Verify.ShouldFail(() =>
+                    Shouldly.DynamicShould
+                        .Throw<ArgumentException>(() => ((dynamic)new Foo()).NoExceptionMethod(), "Some additional context"),
+
+errorWithSource:
+@"`(dynamic)new Foo()).NoExceptionMethod(`
+    should throw
+System.ArgumentException
+    but did not
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"delegate
+    should throw
+System.ArgumentException
+    but did not
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            Shouldly.DynamicShould.Throw<InvalidOperationException>(() => ((dynamic)new Foo()).ExceptionMethod(), "Some additional context");
+        }
+    }
+}

--- a/src/Shouldly.Tests/DynamicShould/ThrowFromVoidMethodScenario.cs
+++ b/src/Shouldly.Tests/DynamicShould/ThrowFromVoidMethodScenario.cs
@@ -1,0 +1,79 @@
+using System;
+using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.DynamicShould
+{
+    public class ThrowFromVoidMethodScenario
+    {
+        class Foo
+        {
+            public void NoExceptionMethod()
+            {
+            }
+
+            public void ExceptionMethod()
+            {
+                throw new InvalidOperationException();
+            }
+        }
+
+        [Fact]
+        public void NotThrowFromDynamicMethodScenarioShouldFail()
+        {
+            Verify.ShouldFail(() =>
+                    Shouldly.DynamicShould
+                        .Throw<InvalidOperationException>(() => ((dynamic)new Foo()).NoExceptionMethod(), "Some additional context"),
+
+errorWithSource:
+@"`(dynamic)new Foo()).NoExceptionMethod(`
+    should throw
+System.InvalidOperationException
+    but did not
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"delegate
+    should throw
+System.InvalidOperationException
+    but did not
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ThrowOtherExceptionFromDynamicMethodScenarioShouldFail()
+        {
+            Verify.ShouldFail(() =>
+                    Shouldly.DynamicShould
+                        .Throw<ArgumentException>(() => ((dynamic)new Foo()).NoExceptionMethod(), "Some additional context"),
+
+errorWithSource:
+@"`(dynamic)new Foo()).NoExceptionMethod(`
+    should throw
+System.ArgumentException
+    but did not
+
+Additional Info:
+    Some additional context",
+
+errorWithoutSource:
+@"delegate
+    should throw
+System.ArgumentException
+    but did not
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void ShouldPass()
+        {
+            Shouldly.DynamicShould.Throw<InvalidOperationException>(() => ((dynamic)new Foo()).ExceptionMethod(), "Some additional context");
+        }
+    }
+}

--- a/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
+++ b/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
@@ -1,4 +1,5 @@
 using System.Dynamic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Shouldly

--- a/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
+++ b/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
@@ -1,6 +1,5 @@
 using System.Dynamic;
 using System.Linq;
-using JetBrains.Annotations;
 
 namespace Shouldly
 {

--- a/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
+++ b/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -27,6 +29,11 @@ namespace Shouldly
                     throw new ShouldAssertException(new ExpectedShouldlyMessage(propertyName, customMessage).ToString());
                 }
             }
+        }
+
+        public static TException Throw<TException>([InstantHandle] Action actual, string? customMessage = null) where TException : Exception
+        {
+            return Should.Throw<TException>(actual, customMessage);
         }
     }
 }

--- a/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
+++ b/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
@@ -1,5 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using JetBrains.Annotations;
@@ -29,11 +27,6 @@ namespace Shouldly
                     throw new ShouldAssertException(new ExpectedShouldlyMessage(propertyName, customMessage).ToString());
                 }
             }
-        }
-
-        public static TException Throw<TException>([InstantHandle] Action actual, string? customMessage = null) where TException : Exception
-        {
-            return Should.Throw<TException>(actual, customMessage);
         }
     }
 }


### PR DESCRIPTION
This pull request resolved #133 issue using an additional method, available for dynamic context.
It is not general-purpose, because of it's easy to forget about such cases, but it's better to have it instead of making custom workaround.

The issue happens in such cases:
```
void ShouldPass()
{
    Should.Throw<NotImplementedException>(() => ((dynamic)this).Thrower());
}

public void Thrower()
{
    throw new NotImplementedException();
}
```

In case of using standard Should.Throw method with dynamic void method compiler is choosing to call not compatible overload and it produces RuntimeBinderException.

Now you can re-write it to get expected behavior:
```
void ShouldPass()
{
    Shouldly.DynamicShould<NotImplementedException>(() => ((dynamic)this).Thrower());
}

public void Thrower()
{
    throw new NotImplementedException();
}
```
