### PR TITLE
Make ShouldNotBeNull chainable and unwrap System.Nullable

### DIFF
--- a/documentation/documentation/equality/null.md
+++ b/documentation/documentation/equality/null.md
@@ -1,7 +1,8 @@
 # BeNull
 
-`ShouldBeNull` and `ShouldNotBeNull` allow you to check whether or not a type's reference is null.
+`ShouldBeNull` and `ShouldNotBeNull` allow you to check whether a value is null.
 
+`ShouldNotBeNull` returns the non-null value if it succeeds so that further assertions can be chained. When used with a reference type, the returned value is the same reference annotated as non-null. Equivalently, when used on a `System.Nullable<T>` expression, the returned value is the unwrapped `T` value.
 
 ## ShouldBeNull
 
@@ -24,6 +25,16 @@ myRef
 ```
 <!-- endInclude -->
 
+### ShouldBeNull (nullable value type)
+
+<!-- snippet: ShouldBeNullNotNullExamples.NullableValueShouldBeNull.codeSample.approved.cs -->
+<!-- endSnippet -->
+
+**Exception**
+
+<!-- include: ShouldBeNullNotNullExamples.NullableValueShouldBeNull.exceptionText.approved.txt -->
+<!-- endInclude -->
+
 
 ## ShouldNotBeNull
 
@@ -43,4 +54,34 @@ myRef.ShouldNotBeNull();
 myRef
     should not be null but was
 ```
+<!-- endInclude -->
+
+### ShouldNotBeNull (nullable value type)
+
+<!-- snippet: ShouldBeNullNotNullExamples.NullableValueShouldNotBeNull.codeSample.approved.cs -->
+<!-- endSnippet -->
+
+**Exception**
+
+<!-- include: ShouldBeNullNotNullExamples.NullableValueShouldNotBeNull.exceptionText.approved.txt -->
+<!-- endInclude -->
+
+## ShouldNotBeNull with chaining
+
+<!-- snippet: ShouldBeNullNotNullExamples.ShouldNotBeNullWithChaining.codeSample.approved.cs -->
+<!-- endSnippet -->
+
+**Exception**
+
+<!-- include: ShouldBeNullNotNullExamples.ShouldNotBeNullWithChaining.exceptionText.approved.txt -->
+<!-- endInclude -->
+
+### ShouldNotBeNull with chaining  (nullable value type)
+
+<!-- snippet: ShouldBeNullNotNullExamples.NullableValueShouldNotBeNullWithChaining.codeSample.approved.cs -->
+<!-- endSnippet -->
+
+**Exception**
+
+<!-- include: ShouldBeNullNotNullExamples.NullableValueShouldNotBeNullWithChaining.exceptionText.approved.txt -->
 <!-- endInclude -->

--- a/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldBeNull.codeSample.approved.cs
+++ b/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldBeNull.codeSample.approved.cs
@@ -1,0 +1,2 @@
+int? nullableValue = 42;
+nullableValue.ShouldBeNull();

--- a/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldBeNull.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldBeNull.exceptionText.approved.txt
@@ -1,0 +1,5 @@
+```
+nullableValue
+    should be null but was
+42
+```

--- a/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldNotBeNull.codeSample.approved.cs
+++ b/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldNotBeNull.codeSample.approved.cs
@@ -1,0 +1,2 @@
+int? myRef = null;
+myRef.ShouldNotBeNull();

--- a/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldNotBeNull.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldNotBeNull.exceptionText.approved.txt
@@ -1,0 +1,4 @@
+```
+myRef
+    should not be null but was
+```

--- a/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldNotBeNullWithChaining.codeSample.approved.cs
+++ b/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldNotBeNullWithChaining.codeSample.approved.cs
@@ -1,0 +1,2 @@
+SomeStruct? nullableValue = new SomeStruct { IntProperty = 41 };
+nullableValue.ShouldNotBeNull().IntProperty.ShouldBe(42);

--- a/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldNotBeNullWithChaining.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.NullableValueShouldNotBeNullWithChaining.exceptionText.approved.txt
@@ -1,0 +1,7 @@
+```
+nullableValue.ShouldNotBeNull().IntProperty
+    should be
+42
+    but was
+41
+```

--- a/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.ShouldNotBeNullWithChaining.codeSample.approved.cs
+++ b/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.ShouldNotBeNullWithChaining.codeSample.approved.cs
@@ -1,0 +1,2 @@
+var myRef = (string?)"1234";
+myRef.ShouldNotBeNull().Length.ShouldBe(5);

--- a/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.ShouldNotBeNullWithChaining.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldBeNullNotNullExamples.ShouldNotBeNullWithChaining.exceptionText.approved.txt
@@ -1,0 +1,7 @@
+```
+myRef.ShouldNotBeNull().Length
+    should be
+5
+    but was
+4
+```

--- a/src/DocumentationExamples/ShouldBeNullNotNullExamples.cs
+++ b/src/DocumentationExamples/ShouldBeNullNotNullExamples.cs
@@ -24,6 +24,16 @@ namespace DocumentationExamples
         }
 
         [Fact]
+        public void NullableValueShouldBeNull()
+        {
+            DocExampleWriter.Document(() =>
+            {
+                int? nullableValue = 42;
+                nullableValue.ShouldBeNull();
+            }, _testOutputHelper);
+        }
+
+        [Fact]
         public void ShouldNotBeNull()
         {
             DocExampleWriter.Document(() =>
@@ -31,6 +41,41 @@ namespace DocumentationExamples
                 string? myRef = null;
                 myRef.ShouldNotBeNull();
             }, _testOutputHelper);
+        }
+
+        [Fact]
+        public void ShouldNotBeNullWithChaining()
+        {
+            DocExampleWriter.Document(() =>
+            {
+                var myRef = (string?)"1234";
+                myRef.ShouldNotBeNull().Length.ShouldBe(5);
+            }, _testOutputHelper);
+        }
+
+        [Fact]
+        public void NullableValueShouldNotBeNull()
+        {
+            DocExampleWriter.Document(() =>
+            {
+                int? myRef = null;
+                myRef.ShouldNotBeNull();
+            }, _testOutputHelper);
+        }
+
+        [Fact]
+        public void NullableValueShouldNotBeNullWithChaining()
+        {
+            DocExampleWriter.Document(() =>
+            {
+                SomeStruct? nullableValue = new SomeStruct { IntProperty = 41 };
+                nullableValue.ShouldNotBeNull().IntProperty.ShouldBe(42);
+            }, _testOutputHelper);
+        }
+
+        public struct SomeStruct
+        {
+            public int IntProperty { get; set; }
         }
     }
 }

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -409,9 +409,9 @@ namespace Shouldly
         [System.Obsolete("Func based customMessage overloads have been removed. Pass in a string for the cu" +
             "stomMessage.", true)]
         public static void ShouldNotBeNull<T>(this T actual, System.Func<string?>? customMessage) { }
-        public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T? actual, string? customMessage = null)
+        public static T ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T? actual, string? customMessage = null)
             where T :  class { }
-        public static void ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T? actual, string? customMessage = null)
+        public static T ShouldNotBeNull<T>([System.Diagnostics.CodeAnalysis.NotNull] this T? actual, string? customMessage = null)
             where T :  struct { }
     }
     [Shouldly.ShouldlyMethods]

--- a/src/Shouldly.Tests/ShouldBeNull/NotNullScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeNull/NotNullScenario.cs
@@ -31,7 +31,8 @@ Additional Info:
         [Fact]
         public void ShouldPassForNonNullReference()
         {
-            "Hello World".ShouldNotBeNull();
+            string returnValue = "Hello World".ShouldNotBeNull();
+            returnValue.ShouldBe("Hello World");
         }
 
         [Fact]
@@ -60,7 +61,8 @@ Additional Info:
         [Fact]
         public void ShouldPassForSystemNullableWithValue()
         {
-            ((int?)0).ShouldNotBeNull();
+            int returnValue = ((int?)0).ShouldNotBeNull();
+            returnValue.ShouldBe(0);
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeNullExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeNullExtensions.cs
@@ -26,19 +26,17 @@ namespace Shouldly
         }
 
         [ContractAnnotation("actual:null => halt")]
-        public static void ShouldNotBeNull<T>([NotNull] this T? actual, string? customMessage = null)
+        public static T ShouldNotBeNull<T>([NotNull] this T? actual, string? customMessage = null)
             where T : class
         {
-            if (actual == null)
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
+            return actual ?? throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
         }
 
         [ContractAnnotation("actual:null => halt")]
-        public static void ShouldNotBeNull<T>([NotNull] this T? actual, string? customMessage = null)
+        public static T ShouldNotBeNull<T>([NotNull] this T? actual, string? customMessage = null)
             where T : struct
         {
-            if (actual == null)
-                throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
+            return actual ?? throw new ShouldAssertException(new ExpectedShouldlyMessage(actual, customMessage).ToString());
         }
     }
 }


### PR DESCRIPTION
Closes #559 (supersedes the design)

I noticed that the new ShouldHaveValue() method would be completely identical to the struct variant of ShouldNotBeNull that we already ended up with. Instead of adding a new method, I augmented the existing ones. Making ShouldNotBeNull chainable for reference types was already on my wish list.

```cs
int unwrapped = ((int?)42).ShouldNotBeNull();
string worksWithNRTsToo = ((string?)"42").ShouldNotBeNull();
```