### PR TITLE
Remove redundant dependency to System.Dynamic.Runtime.

### DIFF
--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -31,7 +31,6 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" Condition="$(Configuration) == 'Release'" />
     <PackageReference Include="MinVer" Version="2.3.1" PrivateAssets="all" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <None Include="..\..\assets\logo_128x128.png" Pack="true" PackagePath="assets" />


### PR DESCRIPTION
It is not needed for .NET Standard 2.0.

I would especially appreciate if this PR was marked with a `hacktoberfest-accepted` label.