### PR TITLE
Bring back obsolete overload that was deleted

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -478,6 +478,9 @@ namespace Shouldly
         public static void ShouldNotMatch(this string actual, string regexPattern, System.Func<string?>? customMessage) { }
         public static void ShouldNotMatch(this string actual, string regexPattern, string? customMessage = null) { }
         public static void ShouldNotStartWith(this string? actual, string expected, Shouldly.Case caseSensitivity = 1, string? customMessage = null) { }
+        [System.Obsolete("Func based customMessage overloads have been removed. Pass in a string for the cu" +
+            "stomMessage.", true)]
+        public static void ShouldNotStartWith(this string? actual, string expected, System.Func<string?>? customMessage, Shouldly.Case caseSensitivity = 1) { }
         public static void ShouldStartWith([System.Diagnostics.CodeAnalysis.NotNull] this string? actual, string expected, Shouldly.Case caseSensitivity = 1, string? customMessage = null) { }
         [System.Obsolete("Func based customMessage overloads have been removed. Pass in a string for the cu" +
             "stomMessage.", true)]

--- a/src/Shouldly/Obsoletes.cs
+++ b/src/Shouldly/Obsoletes.cs
@@ -526,6 +526,12 @@ Diff launching can be controlled at the test level using `ShouldMatchConfigurati
         }
 
         [Obsolete(ObsoleteMessages.FuncCustomMessage, true)]
+        public static void ShouldNotStartWith(this string? actual, string expected, Func<string?>? customMessage, Case caseSensitivity = Case.Insensitive)
+        {
+            throw new NotImplementedException();
+        }
+
+        [Obsolete(ObsoleteMessages.FuncCustomMessage, true)]
         public static void ShouldStartWith(this string? actual, string expected, Func<string?>? customMessage, Case caseSensitivity = Case.Insensitive)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
The reason that the obsoleted overload existed prior to #689 was so that code that already called that overload would have a nicer error message than the C# compiler saying you used the wrong parameter types after you upgrade. That reason applies just as much after #689 as it did before it.