### PR TITLE
Only mention each duplicate once

### DIFF
--- a/src/Shouldly.Tests/ShouldBeUnique/RepeatedDuplicateScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeUnique/RepeatedDuplicateScenario.cs
@@ -1,0 +1,59 @@
+﻿using Shouldly.Tests.Strings;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeUnique
+{
+    public class RepeatedDuplicateScenario
+    {
+        [Fact]
+        public void EachDuplicateShouldBeReportedOnce()
+        {
+            Verify.ShouldFail(() =>
+new[] { 1, 1, 2, 2, 2, 1 }.ShouldBeUnique("Some additional context"),
+
+errorWithSource:
+@"new[] { 1, 1, 2, 2, 2, 1 }
+    should be unique but
+[1, 2]
+    was duplicated
+
+Additional Info:
+    Some additional context",
+
+    errorWithoutSource:
+@"[1, 1, 2, 2, 2, 1]
+    should be unique but
+[1, 2]
+    was duplicated
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
+        public void EachDuplicateShouldBeReportedOnceWhenUsingComparer()
+        {
+            Verify.ShouldFail(() =>
+new[] { 1, 1, 2, 2, 2, 1 }.ShouldBeUnique(EqualityComparer<int>.Default, "Some additional context"),
+
+errorWithSource:
+@"new[] { 1, 1, 2, 2, 2, 1 }
+    should be unique but
+[1, 2]
+    was duplicated
+
+Additional Info:
+    Some additional context",
+
+    errorWithoutSource:
+@"[1, 1, 2, 2, 2, 1]
+    should be unique but
+[1, 2]
+    was duplicated
+
+Additional Info:
+    Some additional context");
+        }
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -171,10 +171,10 @@ namespace Shouldly
             ShouldBeInOrder(actual, expectedSortDirection, (x, y) => isOutOfOrder(customComparer.Compare(x, y)), customMessage);
         }
 
-        private static List<T> GetDuplicates<T>(IEnumerable<T> items, IEqualityComparer<T>? comparer = null)
+        private static HashSet<T> GetDuplicates<T>(IEnumerable<T> items, IEqualityComparer<T>? comparer = null)
         {
             var uniqueItems = new HashSet<T>(comparer);
-            var duplicates = new List<T>();
+            var duplicates = new HashSet<T>(comparer);
 
             foreach (var item in items)
             {


### PR DESCRIPTION
It sounded off to me to say "1, 1" was duplicated; the thing that was duplicated was what the duplicates all have in common. In this case "1"-ness.

@SimonCropp @JosephWoodward @slang25 This is more of a design change. Does anyone have a concern about it?