### PR TITLE
Added ignore to ordering of enumerable in ShouldBeEquivalentTo

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/EnumerableScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/EnumerableScenario.cs
@@ -77,18 +77,19 @@ Additional Info:
         public void ShouldFailWhenListsDoNotMatch()
         {
             var subject = new[] { 1, 2, 6, 4, 5 };
+
             Verify.ShouldFail(() =>
 subject.ShouldBeEquivalentTo(new[] { 1, 2, 3, 4, 5 }, "Some additional context"),
 
 errorWithSource:
 @"Comparing object equivalence, at path:
 subject [System.Int32[]]
-    Element [2] [System.Int32]
+    Element 3 not found
 
     Expected value to be
-3
+[1, 2, 3, 4, 5]
     but was
-6
+[1, 2, 6, 4, 5]
 
 Additional Info:
     Some additional context",
@@ -96,12 +97,12 @@ Additional Info:
 errorWithoutSource:
 @"Comparing object equivalence, at path:
 <root> [System.Int32[]]
-    Element [2] [System.Int32]
+    Element 3 not found
 
     Expected value to be
-3
+[1, 2, 3, 4, 5]
     but was
-6
+[1, 2, 6, 4, 5]
 
 Additional Info:
     Some additional context");
@@ -111,6 +112,14 @@ Additional Info:
         public void ShouldPass()
         {
             var subject = new[] { 1, 2, 6, 4, 5 };
+            subject.ShouldBeEquivalentTo(new[] { 1, 2, 6, 4, 5 });
+        }
+
+
+        [Fact]
+        public void ShouldPassIfOutOfOrder()
+        {
+            var subject = new[] { 1, 2, 4, 5, 6 };
             subject.ShouldBeEquivalentTo(new[] { 1, 2, 6, 4, 5 });
         }
     }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -117,19 +117,19 @@ Additional Info:
             };
 
             Verify.ShouldFail(() =>
-subject.ShouldBeEquivalentTo(expected, "Some additional context"),
+                    subject.ShouldBeEquivalentTo(expected, "Some additional context"),
 
-errorWithSource:
+                errorWithSource:
 @"Comparing object equivalence, at path:
 subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
     Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
         Adjectives [System.String[]]
-            Element [0] [System.String]
+            Element beautiful not found
 
     Expected value to be
-""beautiful""
+[""beautiful"", ""intelligent""]
     but was
-""ugly""
+[""ugly"", ""intelligent""]
 
 Additional Info:
     Some additional context",
@@ -139,12 +139,12 @@ errorWithoutSource:
 <root> [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
     Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
         Adjectives [System.String[]]
-            Element [0] [System.String]
+            Element beautiful not found
 
     Expected value to be
-""beautiful""
+[""beautiful"", ""intelligent""]
     but was
-""ugly""
+[""ugly"", ""intelligent""]
 
 Additional Info:
     Some additional context");
@@ -193,12 +193,12 @@ errorWithSource:
 subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
     Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
         Adjectives [System.String[]]
-            Element [1] [System.String]
+            Element dumb not found
 
     Expected value to be
-""dumb""
+[""beautiful"", ""dumb""]
     but was
-""intelligent""
+[""beautiful"", ""intelligent""]
 
 Additional Info:
     Some additional context",
@@ -208,12 +208,12 @@ errorWithoutSource:
 <root> [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
     Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
         Adjectives [System.String[]]
-            Element [1] [System.String]
+            Element dumb not found
 
     Expected value to be
-""dumb""
+[""beautiful"", ""dumb""]
     but was
-""intelligent""
+[""beautiful"", ""intelligent""]
 
 Additional Info:
     Some additional context");


### PR DESCRIPTION
## Fixes #679

A change has been made to the check of enumerable objects in the `ShouldBeEquivalentTo` method to ensure that the order is not taken into account as this is covered by the `ShouldBe` method also. 

This allows for a check on two collections that have the same items but in differing orders. Tests have been added for the scenario of the same but in a different order. Tests have also been updated for the changed error messaging and existing tests have been re-run to ensure they are still working as intended. 