### PR TITLE
Enumerate Once Preserving Current Fail Message

### DIFF
--- a/src/Shouldly/Internals/EnumerableExtensions.cs
+++ b/src/Shouldly/Internals/EnumerableExtensions.cs
@@ -14,10 +14,5 @@ namespace Shouldly.Internals
                 index++;
             }
         }
-
-        public static IEnumerable<T>? Wrap<T>(this IEnumerable<T>? source)
-        {
-            return EnumerableProxy<T>.Wrap(source);
-        }
     }
 }

--- a/src/Shouldly/Internals/EnumerableExtensions.cs
+++ b/src/Shouldly/Internals/EnumerableExtensions.cs
@@ -14,5 +14,10 @@ namespace Shouldly.Internals
                 index++;
             }
         }
+
+        public static IEnumerable<T>? Wrap<T>(this IEnumerable<T>? source)
+        {
+            return EnumerableProxy<T>.Wrap(source);
+        }
     }
 }

--- a/src/Shouldly/Internals/EnumerableProxy.cs
+++ b/src/Shouldly/Internals/EnumerableProxy.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Shouldly.Internals
+{
+    interface IProxy
+    {
+        object ProxiedValue {  get; }
+    }
+
+    sealed class EnumerableProxy<T> : IEnumerable<T>, IProxy
+    {
+        public static IEnumerable<T>? Wrap(IEnumerable<T>? baseEnum)
+        {
+            if(baseEnum is (null or EnumerableProxy<T>))
+            {
+                return baseEnum;
+            }
+
+            IEnumerable<T> baseCollection;
+            if (baseEnum is (IReadOnlyCollection<T> or ICollection<T> or ICollection))
+            {
+                baseCollection = baseEnum;
+            }
+            else
+            {
+                baseCollection = baseEnum.ToList();
+            }
+
+            return new EnumerableProxy<T>(baseEnum, baseCollection);
+
+        }
+
+        public IEnumerable<T> ProxiedValue { get; }
+        object IProxy.ProxiedValue => ProxiedValue;
+
+        private readonly IEnumerable<T> _baseReentrable;
+
+
+        private EnumerableProxy(IEnumerable<T> baseEnum, IEnumerable<T> baseReentrable)
+        {
+            ProxiedValue = baseEnum;
+            _baseReentrable = baseReentrable;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return _baseReentrable.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Shouldly/Internals/EnumerableProxy.cs
+++ b/src/Shouldly/Internals/EnumerableProxy.cs
@@ -5,12 +5,12 @@ using System.Linq;
 
 namespace Shouldly.Internals
 {
-    interface IProxy
+    interface IEnumerableProxy
     {
         object ProxiedValue {  get; }
     }
 
-    sealed class EnumerableProxy<T> : IEnumerable<T>, IProxy
+    sealed class EnumerableProxy<T> : IEnumerable<T>, IEnumerableProxy
     {
         public static IEnumerable<T>? WrapNonCollection(IEnumerable<T>? baseEnum)
         {
@@ -27,7 +27,7 @@ namespace Shouldly.Internals
         }
 
         public IEnumerable<T> ProxiedValue { get; }
-        object IProxy.ProxiedValue => ProxiedValue;
+        object IEnumerableProxy.ProxiedValue => ProxiedValue;
 
         private readonly IEnumerable<T> _baseReentrable;
 

--- a/src/Shouldly/Internals/EnumerableProxy.cs
+++ b/src/Shouldly/Internals/EnumerableProxy.cs
@@ -12,25 +12,18 @@ namespace Shouldly.Internals
 
     sealed class EnumerableProxy<T> : IEnumerable<T>, IProxy
     {
-        public static IEnumerable<T>? Wrap(IEnumerable<T>? baseEnum)
+        public static IEnumerable<T>? WrapNonCollection(IEnumerable<T>? baseEnum)
         {
-            if(baseEnum is (null or EnumerableProxy<T>))
+            if(baseEnum is (null or IReadOnlyCollection<T> or ICollection<T> or ICollection))
             {
                 return baseEnum;
             }
-
-            IEnumerable<T> baseCollection;
-            if (baseEnum is (IReadOnlyCollection<T> or ICollection<T> or ICollection))
+            if (baseEnum is EnumerableProxy<T>)
             {
-                baseCollection = baseEnum;
-            }
-            else
-            {
-                baseCollection = baseEnum.ToList();
+                throw new ArgumentException("Value already wrapped.", nameof(baseEnum));
             }
 
-            return new EnumerableProxy<T>(baseEnum, baseCollection);
-
+            return new EnumerableProxy<T>(baseEnum, baseEnum.ToList());
         }
 
         public IEnumerable<T> ProxiedValue { get; }

--- a/src/Shouldly/Internals/StringHelpers.cs
+++ b/src/Shouldly/Internals/StringHelpers.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Shouldly.Internals;
 
 namespace Shouldly
 {
@@ -41,9 +42,17 @@ namespace Shouldly
             {
                 var objects = enumerable.Cast<object>();
                 var inspect = "[" + objects.Select(o => o.ToStringAwesomely()).CommaDelimited() + "]";
-                if (inspect == "[]" && value.ToString() != objectType.FullName)
+                if (inspect == "[]")
                 {
-                    inspect += " (" + value + ")";
+                    if (value is IProxy proxy)
+                    {
+                        objectType = proxy.ProxiedValue.GetType();
+                        value = proxy.ProxiedValue;
+                    }
+                    if(value.ToString() != objectType.FullName)
+                    {
+                        inspect += " (" + value + ")";
+                    }
                 }
 
                 return inspect;

--- a/src/Shouldly/Internals/StringHelpers.cs
+++ b/src/Shouldly/Internals/StringHelpers.cs
@@ -44,7 +44,7 @@ namespace Shouldly
                 var inspect = "[" + objects.Select(o => o.ToStringAwesomely()).CommaDelimited() + "]";
                 if (inspect == "[]")
                 {
-                    if (value is IProxy proxy)
+                    if (value is IEnumerableProxy proxy)
                     {
                         objectType = proxy.ProxiedValue.GetType();
                         value = proxy.ProxiedValue;

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
+using Shouldly.Internals;
 
 namespace Shouldly
 {
@@ -57,11 +58,8 @@ namespace Shouldly
             bool ignoreOrder,
             string? customMessage)
         {
-            if (actual is not (null or IReadOnlyCollection<T> or ICollection<T> or ICollection))
-                actual = actual.ToList();
-
-            if (expected is not (null or IReadOnlyCollection<T> or ICollection<T> or ICollection))
-                expected = expected.ToList();
+            actual = actual.Wrap();
+            expected = expected.Wrap();
 
             if (!ignoreOrder && ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName!))
             {

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
@@ -58,8 +58,8 @@ namespace Shouldly
             bool ignoreOrder,
             string? customMessage)
         {
-            actual = actual.Wrap();
-            expected = expected.Wrap();
+            actual = EnumerableProxy<T>.Wrap(actual);
+            expected = EnumerableProxy<T>.Wrap(expected);
 
             if (!ignoreOrder && ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName!))
             {

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
@@ -58,8 +58,8 @@ namespace Shouldly
             bool ignoreOrder,
             string? customMessage)
         {
-            actual = EnumerableProxy<T>.Wrap(actual);
-            expected = EnumerableProxy<T>.Wrap(expected);
+            actual = EnumerableProxy<T>.WrapNonCollection(actual);
+            expected = EnumerableProxy<T>.WrapNonCollection(expected);
 
             if (!ignoreOrder && ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName!))
             {


### PR DESCRIPTION
This is to illustrate one strategy to preserve current failed messages while only enumerating an enumerable once. (see PR #759, issue #735)

If this seems to be a viable solution, then tests should probably be added to flush out possible corner cases.

CC @jnm2 @SimonCropp 