### PR TITLE
Improve user quality of life when debugging assertions in VS by not embedding the PDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ output
 test-results
 *.gem
 *crunch*.xml
-*.nupkg
+*.*nupkg
 *DotSettings*
 *DS_Store
 *ncrunch*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ build_script:
 
 test: off
 artifacts:
-- path: nugets\*.nupkg
+- path: nugets\*.*nupkg
 
 on_failure:
   - ps: Get-ChildItem *.received.* -recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Optimize>false</Optimize>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AssemblyOriginatorKeyFile>sn.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -19,6 +17,8 @@
     <GeneratePackageOnBuild Condition="$(Configuration) == 'Release'">true</GeneratePackageOnBuild>
     <PackageOutputPath>..\..\nugets</PackageOutputPath>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <PackageSymbolFormat>snupkg</PackageSymbolFormat>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DiffEngine" Version="6.5.5" />


### PR DESCRIPTION
Fixes #769

@JosephWoodward When publishing the .nupkg to a feed, just make sure that the .snupkg is in the same directory as the .nupkg file and the right thing will happen by default.

https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg
https://devblogs.microsoft.com/nuget/improved-package-debugging-experience-with-the-nuget-org-symbol-server/