### PR TITLE
Better error when comparing indexers

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Shouldly.Tests.ShouldBeEquivalentTo
 {
@@ -10,5 +11,20 @@ namespace Shouldly.Tests.ShouldBeEquivalentTo
         public FakeObject? Child { get; set; }
         public ICollection<string>? Colors { get; set; }
         public IEnumerable? Adjectives { get; set; }
+    }
+
+    public class IndexableObject
+    {
+        private Dictionary<int, string> _indexedStrings;
+        public IndexableObject(IEnumerable<string> strings)
+        {
+            _indexedStrings =
+                strings
+                    .Select((item, index) => new KeyValuePair<int, string>(index, item))
+                    .ToDictionary(x => x.Key, x => x.Value);
+        }
+
+        // Indexing is different to standard properties, in that indexing is a property that takes an argument.
+        public string this[int index] => _indexedStrings[index];
     }
 }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -1,4 +1,6 @@
-﻿using Shouldly.Tests.Strings;
+﻿using System;
+using System.Collections.Generic;
+using Shouldly.Tests.Strings;
 using Xunit;
 
 namespace Shouldly.Tests.ShouldBeEquivalentTo
@@ -284,6 +286,19 @@ Additional Info:
             expected.Child = expected;
 
             subject.ShouldBeEquivalentTo(expected);
+        }
+
+        [Fact]
+        public void ShouldThrowSensibleErrorWhenIndexersUsed()
+        {
+            var subject = new IndexableObject(new List<string>{"foo", "bar"});
+            var expected = new IndexableObject(new List<string>{"a", "b"});
+            Action indexableObjectComparison = () => subject.ShouldBeEquivalentTo(expected);
+
+            indexableObjectComparison
+                .ShouldThrow<NotSupportedException>()
+                .Message
+                .ShouldBe("Comparing types that have indexers is not supported.");
         }
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -147,10 +147,17 @@ namespace Shouldly
         {
             foreach (var property in properties)
             {
+                if (property.GetIndexParameters().Length != 0)
+                {
+                    // There's no sensible way to compare indexers, as there does not exist a way to obtain a collection
+                    // of all values in a way that's common to all indexer implementations.
+                    throw new NotSupportedException("Comparing types that have indexers is not supported.");
+                }
+
                 var actualValue = property.GetValue(actual, Array.Empty<object>());
                 var expectedValue = property.GetValue(expected, Array.Empty<object>());
 
-                var newPath = path.Concat(new[] { property.Name });
+                var newPath = path.Concat(new[] {property.Name});
                 CompareObjects(actualValue, expectedValue, newPath.ToList(), previousComparisons, customMessage, shouldlyMethod);
             }
         }


### PR DESCRIPTION
Previously you'd get a `TargetParameterCountException` when encountering an indexer, as indexers are properties with parameters, and the existing code assumed that no properties took parameters.

Ultimately there's no good way to compare indexers, as you can't obtain the full collection to compare, so this PR results in a better error in those cases.