### PR TITLE
Bump timeout to make Windows CI happier.

### DIFF
--- a/src/Shouldly.Tests/ShouldThrow/FuncOfTaskWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests/ShouldThrow/FuncOfTaskWithTimeoutScenario.cs
@@ -45,7 +45,7 @@ namespace Shouldly.Tests.ShouldThrow
                 CancellationToken.None, TaskCreationOptions.None,
                 TaskScheduler.Default);
 
-            var ex = task.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(2));
+            var ex = task.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(10));
 
             ex.ShouldNotBe(null);
             ex.ShouldBeOfType<InvalidOperationException>();
@@ -58,7 +58,7 @@ namespace Shouldly.Tests.ShouldThrow
                 CancellationToken.None, TaskCreationOptions.None,
                 TaskScheduler.Default);
 
-            var ex = task.ShouldThrow(TimeSpan.FromSeconds(2), typeof(InvalidOperationException));
+            var ex = task.ShouldThrow(TimeSpan.FromSeconds(10), typeof(InvalidOperationException));
 
             ex.ShouldNotBe(null);
             ex.ShouldBeOfType<InvalidOperationException>();


### PR DESCRIPTION
Windows CI seems to be crazy slow and hits this 2 second timeout - let's just bump it to 10 seconds.

Build https://ci.appveyor.com/project/shouldly/shouldly/builds/38274996 for https://github.com/shouldly/shouldly/pull/778 shows this should be the remaining barrier to getting the build green.