### PR TITLE
Fields now supported by `ShouldBeEquivalentTo`

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
@@ -7,6 +7,7 @@ namespace Shouldly.Tests.ShouldBeEquivalentTo
     public class FakeObject
     {
         public int Id { get; set; }
+        public string? Title;
         public string? Name { get; set; }
         public FakeObject? Child { get; set; }
         public ICollection<string>? Colors { get; set; }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
@@ -7,7 +7,7 @@ namespace Shouldly.Tests.ShouldBeEquivalentTo
     public class FakeObject
     {
         public int Id { get; set; }
-        public string? Title;
+        public string? TitleField;
         public string? Name { get; set; }
         public FakeObject? Child { get; set; }
         public ICollection<string>? Colors { get; set; }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -86,18 +86,18 @@ Additional Info:
         }
 
         [Fact]
-        public void ShouldFailWhenTitleDoesNotMatch()
+        public void ShouldFailWhenFieldDoesNotMatch()
         {
             var subject = new FakeObject
             {
                 Id = 5,
-                Title = "Mr",
+                TitleField = "Mr",
                 Name = "Bob",
             };
             var expected = new FakeObject
             {
                 Id = 5,
-                Title = "Sir",
+                TitleField = "Sir",
                 Name = "Bob",
             };
             Verify.ShouldFail(() =>
@@ -282,7 +282,7 @@ Additional Info:
                 Name = "Bob",
                 Adjectives = new[] { "funny", "wise" },
                 Colors = new[] { "red", "blue" },
-                Title = "Mr",
+                TitleField = "Mr",
                 Child = new FakeObject
                 {
                     Id = 6,
@@ -295,7 +295,7 @@ Additional Info:
             var expected = new FakeObject
             {
                 Id = 5,
-                Title = "Mr",
+                TitleField = "Mr",
                 Name = "Bob",
                 Adjectives = new[] { "funny", "wise" },
                 Colors = new[] { "red", "blue" },

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -297,5 +297,20 @@ Additional Info:
 
             indexableObjectComparison.ShouldThrow<NotSupportedException>();
         }
+
+        private class MyObject
+        {
+            public string? Field;
+            public string? Property { get; set; }
+        }
+
+        // TODO MC: Finish implementing tests for this.
+        // https://github.com/shouldly/shouldly/issues/755
+        [Fact]
+        public void CompareObjects()
+        {
+            //new MyObject {Property = "actual"}.ShouldBeEquivalentTo(new MyObject {Property = "expected"}); // Shouldly fails - good
+            new MyObject {Field = "actual"}.ShouldBeEquivalentTo(new MyObject {Field = "expected"}); // Shouldly - passes!
+        }
     }
 }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -106,7 +106,7 @@ Additional Info:
                 errorWithSource:
                 @"Comparing object equivalence, at path:
 subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
-    Title [System.String]
+    TitleField [System.String]
 
     Expected value to be
 ""Sir""
@@ -119,7 +119,7 @@ Additional Info:
                 errorWithoutSource:
                 @"Comparing object equivalence, at path:
 <root> [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
-    Title [System.String]
+    TitleField [System.String]
 
     Expected value to be
 ""Sir""

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -86,6 +86,51 @@ Additional Info:
         }
 
         [Fact]
+        public void ShouldFailWhenTitleDoesNotMatch()
+        {
+            var subject = new FakeObject
+            {
+                Id = 5,
+                Title = "Mr",
+                Name = "Bob",
+            };
+            var expected = new FakeObject
+            {
+                Id = 5,
+                Title = "Sir",
+                Name = "Bob",
+            };
+            Verify.ShouldFail(() =>
+                    subject.ShouldBeEquivalentTo(expected, "Some additional context"),
+
+                errorWithSource:
+                @"Comparing object equivalence, at path:
+subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Title [System.String]
+
+    Expected value to be
+""Sir""
+    but was
+""Mr""
+
+Additional Info:
+    Some additional context",
+
+                errorWithoutSource:
+                @"Comparing object equivalence, at path:
+<root> [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Title [System.String]
+
+    Expected value to be
+""Sir""
+    but was
+""Mr""
+
+Additional Info:
+    Some additional context");
+        }
+
+        [Fact]
         public void ShouldFailWhenObjectIsComplex()
         {
             var subject = new FakeObject
@@ -237,6 +282,7 @@ Additional Info:
                 Name = "Bob",
                 Adjectives = new[] { "funny", "wise" },
                 Colors = new[] { "red", "blue" },
+                Title = "Mr",
                 Child = new FakeObject
                 {
                     Id = 6,
@@ -249,6 +295,7 @@ Additional Info:
             var expected = new FakeObject
             {
                 Id = 5,
+                Title = "Mr",
                 Name = "Bob",
                 Adjectives = new[] { "funny", "wise" },
                 Colors = new[] { "red", "blue" },
@@ -296,21 +343,6 @@ Additional Info:
             Action indexableObjectComparison = () => subject.ShouldBeEquivalentTo(expected);
 
             indexableObjectComparison.ShouldThrow<NotSupportedException>();
-        }
-
-        private class MyObject
-        {
-            public string? Field;
-            public string? Property { get; set; }
-        }
-
-        // TODO MC: Finish implementing tests for this.
-        // https://github.com/shouldly/shouldly/issues/755
-        [Fact]
-        public void CompareObjects()
-        {
-            //new MyObject {Property = "actual"}.ShouldBeEquivalentTo(new MyObject {Property = "expected"}); // Shouldly fails - good
-            new MyObject {Field = "actual"}.ShouldBeEquivalentTo(new MyObject {Field = "expected"}); // Shouldly - passes!
         }
     }
 }


### PR DESCRIPTION
As raised in https://github.com/shouldly/shouldly/issues/755 this PR adds support for comparison of fields by `ShouldBeEquivalentTo`.

I've run the modified tests with and without the production code change, and verified `ShouldFailWhenTitleDoesNotMatch` erroneously does not fail in that case.