### PR TITLE
Add support for comparing dictionaries

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.cs
@@ -13,7 +13,7 @@ namespace Shouldly.Tests.ShouldBeEquivalentTo
         }
 
         [Fact]
-        public void ShouldFailWhenComparingNonIdenticalNestedDictionaries()
+        public void ShouldFailWhenComparingNonIdenticalNestedDictionariesWithSameKey()
         {
             var expected = CreateNestedDict();
             expected["outer"]["inner"] = "otherValue";
@@ -72,6 +72,31 @@ Verify.ShouldFail(actual [System.Collections.Generic.Dictionary`2[[System.String
         public void ShouldPassWhenComparingIdenticalNonNestedDictionaries()
         {
             CreateNonNestedDict().ShouldBeEquivalentTo(CreateNonNestedDict());
+        }
+
+        [Fact]
+        public void ShouldFailWhenComparingNonNestedDictionariesWithDisjointKeys()
+        {
+            var expected = new Dictionary<string, string> {{"key", "value"}};
+            var actual = new Dictionary<string, string> {{"otherKey", "value"}};
+
+            Verify.ShouldFail(() => actual.ShouldBeEquivalentTo(expected),
+                errorWithSource: @"Comparing object equivalence, at path:
+Verify.ShouldFail(actual [System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]]
+    Key [key]
+
+    Expected value to be
+""value""
+    but was
+null",
+                errorWithoutSource: @"Comparing object equivalence, at path:
+<root> [System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]]
+    Key [key]
+
+    Expected value to be
+""value""
+    but was
+null");
         }
 
         private static Dictionary<string, Dictionary<string, string>> CreateNestedDict() =>

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using Shouldly.Tests.Strings;
+using Xunit;
+
+namespace Shouldly.Tests.ShouldBeEquivalentTo
+{
+    public class DictionaryScenario
+    {
+        [Fact]
+        public void ShouldPassWhenComparingIdenticalNestedDictionaries()
+        {
+            CreateNestedDict().ShouldBeEquivalentTo(CreateNestedDict());
+        }
+
+        [Fact]
+        public void ShouldFailWhenComparingNonIdenticalNestedDictionaries()
+        {
+            var expected = CreateNestedDict();
+            expected["outer"]["inner"] = "otherValue";
+            var actual = CreateNestedDict();
+            Verify.ShouldFail(() => actual.ShouldBeEquivalentTo(expected),
+                errorWithSource: @"Comparing object equivalence, at path:
+Verify.ShouldFail(actual [System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]]
+    Key [outer] [System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]]
+        Key [inner] [System.String]
+
+    Expected value to be
+""otherValue""
+    but was
+""value""",
+                errorWithoutSource: @"Comparing object equivalence, at path:
+<root> [System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]]
+    Key [outer] [System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]]
+        Key [inner] [System.String]
+
+    Expected value to be
+""otherValue""
+    but was
+""value""");
+        }
+
+        [Fact]
+        public void ShouldFailWhenComparingNestedDictionariesOfDifferentSizes()
+        {
+            var expected = CreateNestedDict();
+            expected["outer"]["anotherInner"] = "value";
+            var actual = CreateNestedDict();
+            Verify.ShouldFail(() => actual.ShouldBeEquivalentTo(expected),
+                errorWithSource:
+                @"Comparing object equivalence, at path:
+Verify.ShouldFail(actual [System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]]
+    Key [outer] [System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]]
+        Count
+
+    Expected value to be
+2
+    but was
+1",
+                errorWithoutSource: @"Comparing object equivalence, at path:
+<root> [System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]]
+    Key [outer] [System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]]
+        Count
+
+    Expected value to be
+2
+    but was
+1");
+
+        }
+
+        [Fact]
+        public void ShouldPassWhenComparingIdenticalNonNestedDictionaries()
+        {
+            CreateNonNestedDict().ShouldBeEquivalentTo(CreateNonNestedDict());
+        }
+
+        private static Dictionary<string, Dictionary<string, string>> CreateNestedDict() =>
+            new() {{"outer", CreateNonNestedDict()}};
+
+        private static Dictionary<string, string> CreateNonNestedDict() =>
+            new() {{"inner", "value"}};
+    }
+}


### PR DESCRIPTION
This should cover the primary issue highlighted as part of https://github.com/shouldly/shouldly/issues/767 - the failure output is a little verbose: could we consider eliding some of the type qualifications when the output relating to type specification reaches a certain size?

Maybe should also think about the error message when an expected key is missing, just saying the key was "null" at the moment isn't ideal.