### PR TITLE
Add RegexPattern attributes to regex parameters

### DIFF
--- a/src/Shouldly/Internals/Is.cs
+++ b/src/Shouldly/Internals/Is.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
+using JetBrains.Annotations;
 
 namespace Shouldly
 {
@@ -189,7 +190,7 @@ namespace Shouldly
             return (actual - expected).Duration() < tolerance;
         }
 
-        public static bool StringMatchingRegex(string actual, string regexPattern)
+        public static bool StringMatchingRegex(string actual, [RegexPattern] string regexPattern)
         {
             return Regex.IsMatch(actual, regexPattern);
         }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringContainsTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringContainsTestExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Shouldly
+﻿using JetBrains.Annotations;
+
+namespace Shouldly
 {
     public static partial class ShouldBeStringTestExtensions
     {
@@ -32,12 +34,12 @@
             }, actual.Clip(100, "..."), expected, caseSensitivity, customMessage);
         }
 
-        public static void ShouldMatch(this string actual, string regexPattern, string? customMessage = null)
+        public static void ShouldMatch(this string actual, [RegexPattern] string regexPattern, string? customMessage = null)
         {
             actual.AssertAwesomely(v => Is.StringMatchingRegex(v, regexPattern), actual, regexPattern, customMessage);
         }
 
-        public static void ShouldNotMatch(this string actual, string regexPattern, string? customMessage = null)
+        public static void ShouldNotMatch(this string actual, [RegexPattern] string regexPattern, string? customMessage = null)
         {
             actual.AssertAwesomely(v => !Is.StringMatchingRegex(v, regexPattern), actual, regexPattern, customMessage);
         }


### PR DESCRIPTION
Addresses https://github.com/shouldly/shouldly/issues/766: Shouldly already has the `Jetbrains.Annotations` attribute source as internal attributes - no further types are being exposed, and there's no need to depend on `Jetbrains.Annotations` through nuget.

I'm able to see that usages in `Shouldly.Test` are appropriately highlighted once the attribute is added.