### PR TITLE
Update nugets

### DIFF
--- a/src/DeterministicTests/DeterministicTests.csproj
+++ b/src/DeterministicTests/DeterministicTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <ProjectReference Include="..\Shouldly\Shouldly.csproj" />

--- a/src/DocumentationExamples/DocumentationExamples.csproj
+++ b/src/DocumentationExamples/DocumentationExamples.csproj
@@ -9,11 +9,11 @@
     <Compile Remove="**\*.approved.cs;**\*.received.cs" />
     <Compile Include="..\Shouldly.Tests\ConventionTests\IgnoreOnAppVeyorLinuxFact.cs" Link="IgnoreOnAppVeyorLinuxFact.cs" />
     <ProjectReference Include="..\Shouldly\Shouldly.csproj" />
-    <PackageReference Include="MarkdownSnippets.MsBuild" Version="23.1.1">
+    <PackageReference Include="MarkdownSnippets.MsBuild" Version="23.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -8,11 +8,11 @@
   <ItemGroup>
     <Compile Remove="**\*.approved.cs;**\*.received.cs" />
     <ProjectReference Include="..\Shouldly\Shouldly.csproj" />
-    <PackageReference Include="MarkdownSnippets.MsBuild" Version="23.1.1">
+    <PackageReference Include="MarkdownSnippets.MsBuild" Version="23.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="TestStack.ConventionTests" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -21,8 +21,8 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DiffEngine" Version="6.6.0" />
-    <PackageReference Include="EmptyFiles" Version="2.6.0" PrivateAssets="None" />
+    <PackageReference Include="DiffEngine" Version="6.8.0" />
+    <PackageReference Include="EmptyFiles" Version="2.7.0" PrivateAssets="None" />
     <Content Include="build.props" PackagePath="build\Shouldly.props" />
     <Content Include="buildMultiTargeting.props" PackagePath="buildMultiTargeting\Shouldly.props" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" Condition="$(Configuration) == 'Release'" />


### PR DESCRIPTION
 * Microsoft.NET.Test.Sdk 16.9.4
 * MarkdownSnippets.MsBuild 23.1.2
 * DiffEngine 6.8.0
 * EmptyFiles 2.7.0
 
The main reason for this is relevant fixes in DiffEngine (https://github.com/VerifyTests/DiffEngine/issues/196, https://github.com/VerifyTests/DiffEngine/pull/219, https://github.com/VerifyTests/DiffEngine/pull/218), but i figured i would update the other pending nugets in one PR.

