### PR TITLE
Fix Should.ThrowAsync<Exception> does not fail for a succeeding task

### DIFF
--- a/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
+++ b/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Shouldly.Tests.ShouldThrowAsync
 {
@@ -156,6 +157,28 @@ namespace Shouldly.Tests.ShouldThrowAsync
                     but threw
                     System.DivideByZeroException");
             }
+        }
+
+        [Fact] // Issue 818
+        public async Task ShouldThrowAssertException_ExceptionTypeIsException()
+        {
+            try
+            {
+                Func<Task> doSomething = () => Task.CompletedTask;
+                await Should.ThrowAsync<Exception>(async () => await doSomething());
+            }
+            catch (Exception e)
+            {
+                var ex = e.ShouldBeOfType<ShouldAssertException>();
+                ex.Message.ShouldContainWithoutWhitespace(@"
+                    Task `async () => await doSomething()`
+                    should throw 
+                    System.Exception
+                    but did not");
+                return;
+            }
+
+            throw new XunitException("ShouldThrowAsync did not throw");
         }
     }
 }

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
@@ -52,10 +52,10 @@ namespace Shouldly
                     {
                         switch (x.Result)
                         {
-                            case TException expectedException:
-                                return expectedException;
                             case ShouldAssertException assert:
                                 throw assert;
+                            case TException expectedException:
+                                return expectedException;
                             default:
                                 throw new ShouldAssertException(new AsyncShouldlyThrowShouldlyMessage(typeof(TException), x.Result.GetType(), customMessage, stackTrace).ToString(), x.Result);
                         }


### PR DESCRIPTION
Fixes https://github.com/shouldly/shouldly/issues/818.

Although it's not best practice for applications to throw generic Exception's, nothing stops this and we can support it here with no pain by reordering our switch to go from specific downward

The test could be written a couple ways, but the key for it to be red before the change is the final `throw new XunitException("ShouldThrowAsync did not throw");`, which i understand is Xunit's equivalent of `Assert.Fail(message)`.