### PR TITLE
Fix version conflicts caused by PR#820

### DIFF
--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -21,8 +21,8 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DiffEngine" Version="6.6.0" />
-    <PackageReference Include="EmptyFiles" Version="2.6.0" PrivateAssets="None" />
+    <PackageReference Include="DiffEngine" Version="6.9.2" />
+    <PackageReference Include="EmptyFiles" Version="2.7.0" PrivateAssets="None" />
     <Content Include="build.props" PackagePath="build\Shouldly.props" />
     <Content Include="buildMultiTargeting.props" PackagePath="buildMultiTargeting\Shouldly.props" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" Condition="$(Configuration) == 'Release'" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump DiffEngine from 6.6.0 to 6.9.2. [(PR#820)](https://github.com/shouldly/shouldly/pull/820).
Hope this fix can help you.

Best regards,
sucrose
