### PR TITLE
Add documentation for Enumerable ShouldHaveSingleItem

### DIFF
--- a/documentation/documentation/enumerable/shouldHaveSingleItem.md
+++ b/documentation/documentation/enumerable/shouldHaveSingleItem.md
@@ -1,0 +1,26 @@
+# ShouldHaveSingleItem
+
+<!-- snippet: EnumerableShouldHaveSingleItemExamples.ShouldHaveSingleItem.codeSample.approved.cs -->
+<a id='b42566a8'></a>
+
+```cs
+var maggie = new Person { Name = "Maggie" };
+var homer = new Person { Name = "Homer" };
+var simpsonsBabies = new List<Person> { homer, maggie };
+simpsonsBabies.ShouldHaveSingleItem();
+```
+
+<sup><a href='/src/DocumentationExamples/CodeExamples/EnumerableShouldHaveSingleItemExamples.ShouldHaveSingleItem.codeSample.approved.cs#L1-L4' title='Snippet source file'>snippet source</a> | <a href='#b42566a8' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+**Exception**
+
+<!-- include: EnumerableShouldHaveSingleItemExamples.ShouldHaveSingleItem.exceptionText.approved.txt -->
+```
+simpsonsBabies
+    should have single item but had
+2
+    items and was
+[Homer, Maggie]
+```
+<!-- endInclude -->


### PR DESCRIPTION
Added the documentation for the ShouldHaveSingleItem using the already published examples.

Extends #365.