### PR TITLE
Add upgrade doc example of how `ShouldNotBeNull` change could cause compile errors 

### DIFF
--- a/documentation/documentation/upgrade/3to4.md
+++ b/documentation/documentation/upgrade/3to4.md
@@ -6,7 +6,7 @@ Also see the [4.0 milestone](https://github.com/shouldly/shouldly/milestone/2?cl
 
 ## Class constraint added to `ShouldNotBeNull`
 
-In previous versions it was possible to assert that a non-nullable type `ShouldNotBeNull`, even though this logically makes no sense. For exmaple, the following would happlly compile, but of course could never cause a test failure:
+In previous versions it was possible to assert that a non-nullable type `ShouldNotBeNull`, even though this logically makes no sense. For exmaple, the following would happily compile, but of course could never cause a test failure:
 
 ```charp
 const long value = 1;
@@ -24,7 +24,7 @@ All overloads that accepted a `Func<string> customMessage` have been changed to 
 
 Diff tool functionality is now provided by [DiffEngine](https://github.com/VerifyTests/DiffEngine).
 
-The following APIs have been removed:
+As such, the following APIs have been removed:
 
  * `Shouldly.Configuration.DiffTool`
  * `ShouldlyConfiguration.DiffTools`

--- a/documentation/documentation/upgrade/3to4.md
+++ b/documentation/documentation/upgrade/3to4.md
@@ -2,13 +2,23 @@
 
 This is a work in progress. Please send a PR with any amendments.
 
-Also see the [4.0 milestone](https://github.com/shouldly/shouldly/milestone/2?closed=1)
+Also see the [4.0 milestone](https://github.com/shouldly/shouldly/milestone/2?closed=1).
 
+## Class constraint added to `ShouldNotBeNull`
+
+In previous versions it was possible to assert that a non-nullable type `ShouldNotBeNull`, even though this logically makes no sense. For exmaple, the following would happlly compile, but of course could never cause a test failure:
+
+```charp
+const long value = 1;
+
+value.ShouldNotBeNull();
+```
+
+The `class` constraint was added to `ShouldNotBeNull` in v4, which means the above code will no longer compile. This is a good thing because it allows you to find and fix nonsensical tests in your codebase!
 
 ## `Func<string> customMessage` removed
 
 All overloads that accepted a `Func<string> customMessage` have been changed to `string customMessage`.
-
 
 ## Diff tool functionality moved to DiffEngine
 


### PR DESCRIPTION
Sadly this actually happened in a codebase I maintain, and was very confusing for a while!