### PR TITLE
Include Enumerable Have documentation in summary

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -39,6 +39,7 @@
   * [Contain](documentation/enumerable/contain.md)
   * [Unique](documentation/enumerable/unique.md)
   * [SubsetOf](documentation/enumerable/subsetOf.md)
+  * [Have](documentation/enumerable/have.md)
 * [Dictionary](documentation/dictionary/README.md)
   * [ContainKey](documentation/dictionary/containKey.md)
   * [ContainKeyAndValue](documentation/dictionary/containKeyAndValue.md)

--- a/documentation/documentation/enumerable/have.md
+++ b/documentation/documentation/enumerable/have.md
@@ -1,4 +1,6 @@
-# ShouldHaveSingleItem
+# Have
+
+## ShouldHaveSingleItem
 
 <!-- snippet: EnumerableShouldHaveSingleItemExamples.ShouldHaveSingleItem.codeSample.approved.cs -->
 <a id='aa895b2d'></a>


### PR DESCRIPTION
Included the **Enumerable > Have** documentation in the documentation summary.

This completes PR #824 which added the documentation but did not include it in the summary; which resulted in the documentation not being available on the <https://docs.shouldly.org> site.

Extends the original issue #365.