### PR TITLE
Deterministic build

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -72,6 +72,17 @@ Shouldly uses the source code to make its error messages better. Hence, on the b
 
 What is meant by "full" is that when you set up your "release" configuration in Visual Studio and you go to Project Properties &gt; Build &gt; Advanced &gt; Debug, you should set it to "full" rather than "pdb-only".
 
+## Prerequisites for using Shouldly in a non-test project
+
+The Shouldly NuGet package contains a file `Shouldly.props` which modifies the build of your test project to work properly with Shouldly out of the box. But sometimes it might be necessary to add Shouldly as a dependency in a non-test project. Maybe if you want to centralize your test setup in a NuGet. In such a scenario Shouldly might break your build. In such a case you can deactivate the modification by adding `<UseShouldlyInNonTestProject>true</UseShouldlyInNonTestProject>` to your project file. Then you can set the needed properties as you need. Those are the by Shouldly set build properties:
+
+```xml
+<DebugSymbols>true</DebugSymbols>
+<Optimize>false</Optimize>
+<DebugType>embedded</DebugType>
+<Deterministic>false</Deterministic>
+<DeterministicSourcePaths>false</DeterministicSourcePaths>
+```
 
 ## Currently maintained by
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -74,7 +74,13 @@ What is meant by "full" is that when you set up your "release" configuration in 
 
 ## Prerequisites for using Shouldly in a non-test project
 
-The Shouldly NuGet package contains a file `Shouldly.props` which modifies the build of your test project to work properly with Shouldly out of the box. But sometimes it might be necessary to add Shouldly as a dependency in a non-test project. Maybe if you want to centralize your test setup in a NuGet. In such a scenario Shouldly might break your build. In such a case you can deactivate the modification by adding `<UseShouldlyInNonTestProject>true</UseShouldlyInNonTestProject>` to your project file. Then you can set the needed properties as you need. Those are the by Shouldly set build properties:
+The Shouldly NuGet package contains a file `Shouldly.props` which modifies the build of your test project to work properly with Shouldly out of the box. But sometimes it might be necessary to add Shouldly as a dependency in a non-test project. Maybe if you want to centralize your test setup in a NuGet. In such a scenario Shouldly might break your build. In such a case you can deactivate the modification.
+
+```shell
+dotnet build project.csproj -p:UseShouldlyInNonTestProject=true
+```
+
+Alternatively you can add `<UseShouldlyInNonTestProject>true</UseShouldlyInNonTestProject>` to your `Directory.Build.props`. Then you can set the properties as you need. Those are the build properties set by Shouldly:
 
 ```xml
 <DebugSymbols>true</DebugSymbols>
@@ -83,6 +89,18 @@ The Shouldly NuGet package contains a file `Shouldly.props` which modifies the b
 <Deterministic>false</Deterministic>
 <DeterministicSourcePaths>false</DeterministicSourcePaths>
 ```
+
+The way MSBuild evaluates the build properties prevents setting `<UseShouldlyInNonTestProject>` directly in a `*.csproj`. If you want to ignore the modifications in `*.csproj` you can exclude the build assets by adding Shouldly like this:
+
+```xml
+<PackageReference Include="Shouldly" Version="4.1.0">
+    <ExcludeAssets>build</ExcludeAssets>
+</PackageReference>
+```
+
+`<ExcludeAssets>build</ExcludeAssets>` will also prevent Shouldly to create better messages with links to failing tests. Consider to add conditions for your build configurations.
+
+Which solution works best for you depends on the context in which you use Shouldly. 
 
 ## Currently maintained by
 

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Had to remove the .net5.0 target. https://github.com/shouldly/shouldly/pull/870 -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <Optimize>false</Optimize>
     <DebugSymbols>true</DebugSymbols>
@@ -14,7 +15,7 @@
     <PackageProjectUrl>https://shouldly.org</PackageProjectUrl>
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/shouldly/shouldly.git</RepositoryUrl>
+    <RepositoryUrl></RepositoryUrl> <!-- Is set by Microsoft.SourceLink.GitHub -->
     <PackageReleaseNotes>https://github.com/shouldly/releases/tag/$(Version)</PackageReleaseNotes>
     <GeneratePackageOnBuild Condition="$(Configuration) == 'Release'">true</GeneratePackageOnBuild>
     <PackageOutputPath>..\..\nugets</PackageOutputPath>

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -19,6 +19,7 @@
     <GeneratePackageOnBuild Condition="$(Configuration) == 'Release'">true</GeneratePackageOnBuild>
     <PackageOutputPath>..\..\nugets</PackageOutputPath>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <WarningsNotAsErrors>NU1505</WarningsNotAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EmptyFiles" Version="4.1.0" PrivateAssets="None" />

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Had to remove the .net5.0 target. https://github.com/shouldly/shouldly/pull/870 -->
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net5</TargetFrameworks>
     <Optimize>false</Optimize>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Optimize>false</Optimize>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>

--- a/src/Shouldly/build.props
+++ b/src/Shouldly/build.props
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <!-- If <UseShouldlyInNonTestProject>false</UseShouldlyInNonTestProject> is set in csproj or not set at all. -->
-  <PropertyGroup Condition="'$(UseShouldlyInNonTestProject)' != 'true'">
-    <DebugSymbols>true</DebugSymbols>
-    <Optimize>false</Optimize>
-    <DebugType>embedded</DebugType>
-    <Deterministic>false</Deterministic>
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-  </PropertyGroup>
+	<!-- If <UseShouldlyInNonTestProject>false</UseShouldlyInNonTestProject> is set in Directory.Build.props, passed in via argument to dotnet build or not set at all. -->
+	<PropertyGroup Condition="'$(UseShouldlyInNonTestProject)' != 'true'">
+		<DebugSymbols>true</DebugSymbols>
+		<Optimize>false</Optimize>
+		<DebugType>embedded</DebugType>
+		<Deterministic>false</Deterministic>
+		<DeterministicSourcePaths>false</DeterministicSourcePaths>
+	</PropertyGroup>
 </Project>

--- a/src/Shouldly/build.props
+++ b/src/Shouldly/build.props
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
-  <PropertyGroup>
+  <!-- If <UseShouldlyInNonTestProject>false</UseShouldlyInNonTestProject> is set in csproj or not set at all. -->
+  <PropertyGroup Condition="'$(UseShouldlyInNonTestProject)' != 'true'">
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
     <DebugType>embedded</DebugType>


### PR DESCRIPTION
The build action was broken by https://github.com/shouldly/shouldly/pull/870. I had to remove the net5.0 target framework to make it work. It is already out of support so it should be removed anyway.

This pull request targets #795.

The idea is to make the configuration in `build.props` conditional. The standard way to use Shouldly is by referencing it in a test project. It should be no big deal to alter the build configuration of those. But if Shouldly is used in a non-test project those settings can break their builds. By setting a property `<UseShouldlyInNonTestProject>true</UseShouldlyInNonTestProject>` in the CSPROJ the settings in `build.props` should be ignored.

This would address https://github.com/shouldly/shouldly/issues/795#issuecomment-809150457 without the need for multiple nugets.

It's an alternative to https://github.com/shouldly/shouldly/issues/795#issuecomment-879084212. Maybe more descriptive.