### PR TITLE
Improved deterministic build support

### DIFF
--- a/src/DeterministicTests/DeterministicTests.csproj
+++ b/src/DeterministicTests/DeterministicTests.csproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\Shouldly\buildTransitive\Shouldly.targets" />
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>

--- a/src/DeterministicTests/Directory.Build.props
+++ b/src/DeterministicTests/Directory.Build.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <NoWarn>CS1591;CS0649</NoWarn>
     <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   <ItemGroup>
     <SourceRoot Include = " $(MSBuildThisFileDirectory)/ " />

--- a/src/Shouldly/Configuration/TestMethodInfo.cs
+++ b/src/Shouldly/Configuration/TestMethodInfo.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
+using Shouldly.Internals;
 
 namespace Shouldly.Configuration;
 
@@ -7,7 +8,9 @@ public class TestMethodInfo
 {
     public TestMethodInfo(StackFrame callingFrame)
     {
-        SourceFileDirectory = Path.GetDirectoryName(callingFrame.GetFileName());
+        var fileName = callingFrame.GetFileName();
+        fileName = DeterministicBuildHelpers.ResolveDeterministicPaths(fileName);
+        SourceFileDirectory = Path.GetDirectoryName(fileName);
 
         var method = callingFrame.GetMethod();
         var originalMethodInfo = GetOriginalMethodInfoForStateMachineMethod(method);

--- a/src/Shouldly/Internals/DeterministicBuildHelpers.cs
+++ b/src/Shouldly/Internals/DeterministicBuildHelpers.cs
@@ -1,0 +1,41 @@
+using System.Text.RegularExpressions;
+
+namespace Shouldly.Internals;
+
+internal static class DeterministicBuildHelpers
+{
+    private static readonly Regex DeterministicPathRegex = new(@"^/_\d*/");
+    
+    private static readonly Lazy<IEnumerable<(string, string)>> LazySourcePathMap
+        = new(() =>
+        {
+            var shouldlySourcePathMap = Environment.GetEnvironmentVariable("SHOULDLY_SOURCE_PATH_MAP") ?? "";
+            var pathMapPairs = shouldlySourcePathMap
+                .Split(',')
+                .Select(x => x.Split('='))
+                .Where(x => x.Length == 2)
+                .Select(x => (x[0], x[1]));
+            
+            return pathMapPairs;
+        });
+
+    private static IEnumerable<(string, string)> SourcePathMap => LazySourcePathMap.Value;
+    
+    internal static string? ResolveDeterministicPaths(string? fileName)
+    {
+        foreach (var (path, placeholder) in SourcePathMap)
+        {
+            if (fileName?.StartsWith(placeholder, StringComparison.Ordinal) == true)
+            {
+                return fileName.Replace(placeholder, path);
+            }
+        }
+
+        return fileName;
+    }
+    
+    internal static bool PathAppearsToBeDeterministic(string fileName)
+    {
+        return DeterministicPathRegex.IsMatch(fileName);
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldMatchApprovedTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldMatchApprovedTestExtensions.cs
@@ -27,6 +27,9 @@ public static partial class ShouldMatchApprovedTestExtensions
         var outputFolder = testMethodInfo.SourceFileDirectory;
         if (string.IsNullOrEmpty(outputFolder))
             throw new($"Source information not available, make sure you are compiling with full debug information. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
+        if (DeterministicBuildHelpers.PathAppearsToBeDeterministic(outputFolder))
+            throw new($"Unable to resolve source file from determinist build source path. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
+        
         if (!string.IsNullOrEmpty(config.ApprovalFileSubFolder))
         {
             outputFolder = Path.Combine(outputFolder, config.ApprovalFileSubFolder);

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldMatchApprovedTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldMatchApprovedTestExtensions.cs
@@ -28,7 +28,7 @@ public static partial class ShouldMatchApprovedTestExtensions
         if (string.IsNullOrEmpty(outputFolder))
             throw new($"Source information not available, make sure you are compiling with full debug information. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
         if (DeterministicBuildHelpers.PathAppearsToBeDeterministic(outputFolder))
-            throw new($"Unable to resolve source file from determinist build source path. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
+            throw new($"Unable to resolve source file from deterministic build source path. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
         
         if (!string.IsNullOrEmpty(config.ApprovalFileSubFolder))
         {

--- a/src/Shouldly/buildTransitive/Shouldly.targets
+++ b/src/Shouldly/buildTransitive/Shouldly.targets
@@ -12,7 +12,13 @@
         </Task>
     </UsingTask>
     
-    <Target Name="CapturePathMapsForShouldly" BeforeTargets="CoreCompile" DependsOnTargets="_SetPathMapFromSourceRoots" Condition=" '$(DeterministicSourcePaths)' == 'true' " >
+    <!--
+        This target is used to capture the PathMap value when building the project. The PathMap is used by Shouldly to map paths
+        in stack traces to the source files. The PathMap is written to a file and read by the SetShouldlyPathMaps target.
+        When VSTestNoBuild is not true, then VSTest has inititiated the build so the SetShouldlyPathMaps target has already ran,
+        so we need to set the SHOULDLY_SOURCE_PATH_MAP environment variable here.
+    -->
+    <Target Name="CapturePathMapsForShouldly" BeforeTargets="CoreCompile" DependsOnTargets="_SetPathMapFromSourceRoots" Condition=" '$(DisableShouldlyPathMaps)' != 'true' AND '$(DeterministicSourcePaths)' == 'true' " >
         <PropertyGroup>
             <_ShouldlyPathMapsFilePath>$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))ShouldlyPathMaps_$(AssemblyName)</_ShouldlyPathMapsFilePath>
         </PropertyGroup>
@@ -23,7 +29,11 @@
         <SetEnvVar EnvName="SHOULDLY_SOURCE_PATH_MAP" EnvValue="$(PathMap)" Condition=" '$(VSTestNoBuild)' != 'true' " />
     </Target>
     
-    <Target Name="SetShouldlyPathMaps" BeforeTargets="VSTest" Condition=" '$(VSTestNoBuild)' == 'true' ">
+    <!--
+        This target is used to set the SHOULDLY_SOURCE_PATH_MAP environment variable when running tests with VSTestNoBuild=true.
+        This is necessary because the VSTest task does not run the CoreCompile target, so the PathMap is not set.    
+    -->
+    <Target Name="SetShouldlyPathMaps" BeforeTargets="VSTest" Condition=" '$(DisableShouldlyPathMaps)' != 'true' AND '$(VSTestNoBuild)' == 'true' ">
         <PropertyGroup>
             <_ShouldlyPathMapsFilePath>$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))ShouldlyPathMaps_$(AssemblyName)</_ShouldlyPathMapsFilePath>
         </PropertyGroup>

--- a/src/Shouldly/buildTransitive/Shouldly.targets
+++ b/src/Shouldly/buildTransitive/Shouldly.targets
@@ -12,7 +12,27 @@
         </Task>
     </UsingTask>
     
-    <Target Name="SetPathMapsForShouldly" BeforeTargets="CoreCompile" DependsOnTargets="_SetPathMapFromSourceRoots" Condition=" '$(PathMap)' != '' AND '$(SHOULDLY_SOURCE_PATH_MAP)' == '' " >
-        <SetEnvVar EnvName="SHOULDLY_SOURCE_PATH_MAP" EnvValue="$(PathMap)" />
+    <Target Name="CapturePathMapsForShouldly" BeforeTargets="CoreCompile" DependsOnTargets="_SetPathMapFromSourceRoots" Condition=" '$(DeterministicSourcePaths)' == 'true' " >
+        <PropertyGroup>
+            <_ShouldlyPathMapsFilePath>$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))ShouldlyPathMaps_$(AssemblyName)</_ShouldlyPathMapsFilePath>
+        </PropertyGroup>
+        <WriteLinesToFile File="$(_ShouldlyPathMapsFilePath)" Lines="$(PathMap)" Overwrite="true" Encoding="Unicode" Condition=" '$(PathMap)' != '' " WriteOnlyWhenDifferent="true" />
+        <ItemGroup>
+            <FileWrites Include="$(_ShouldlyPathMapsFilePath)" Condition=" '$(PathMap)' != '' " />
+        </ItemGroup>
+        <SetEnvVar EnvName="SHOULDLY_SOURCE_PATH_MAP" EnvValue="$(PathMap)" Condition=" '$(VSTestNoBuild)' != 'true' " />
+    </Target>
+    
+    <Target Name="SetShouldlyPathMaps" BeforeTargets="VSTest" Condition=" '$(VSTestNoBuild)' == 'true' ">
+        <PropertyGroup>
+            <_ShouldlyPathMapsFilePath>$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))ShouldlyPathMaps_$(AssemblyName)</_ShouldlyPathMapsFilePath>
+        </PropertyGroup>
+        <ReadLinesFromFile File="$(_ShouldlyPathMapsFilePath)">
+            <Output TaskParameter="Lines" ItemName="_ShouldlyPathMaps" />
+        </ReadLinesFromFile>
+        <PropertyGroup>
+            <ShouldlyPathMaps>%(_ShouldlyPathMaps.Identity)</ShouldlyPathMaps>
+        </PropertyGroup>
+        <SetEnvVar EnvName="SHOULDLY_SOURCE_PATH_MAP" EnvValue="$(ShouldlyPathMaps)" Condition=" '$(ShouldlyPathMaps)' != '' " />
     </Target>
 </Project>

--- a/src/Shouldly/buildTransitive/Shouldly.targets
+++ b/src/Shouldly/buildTransitive/Shouldly.targets
@@ -15,7 +15,7 @@
     <!--
         This target is used to capture the PathMap value when building the project. The PathMap is used by Shouldly to map paths
         in stack traces to the source files. The PathMap is written to a file and read by the SetShouldlyPathMaps target.
-        When VSTestNoBuild is not true, then VSTest has inititiated the build so the SetShouldlyPathMaps target has already ran,
+        When VSTestNoBuild is not true, then VSTest has inititiated the build so the SetShouldlyPathMaps target has already started,
         so we need to set the SHOULDLY_SOURCE_PATH_MAP environment variable here.
     -->
     <Target Name="CapturePathMapsForShouldly" BeforeTargets="CoreCompile" DependsOnTargets="_SetPathMapFromSourceRoots" Condition=" '$(DisableShouldlyPathMaps)' != 'true' AND '$(DeterministicSourcePaths)' == 'true' " >


### PR DESCRIPTION
Following on from #883, it turns out that as suspected there is a need to support building and running tests in separate steps while also using deterministic builds.

This PR adds:
* Refactoring deterministic build code to `DeterministicBuildHelpers`
* A method to check for paths which "look deterministic" if the build tooling fails for some reason. These paths are prefixed with `/_/`, `/_1/` etc.. This is used in the `ShouldMatchApproved` method, where an accurate resolved location is essential.
* New MSBuild targets which produce a file during build capturing the path maps and copying this to the output folder, then reading this value during VSTest and setting it as an environment variable.
* In the case where `dotnet test` is ran on it's own, a build will be performed but it will be "within" the VSTest target, so wont run before it. In this case we set the environment variable directly, as we know the tests will run later and in the same process tree.
* A `DisableShouldlyPathMaps` build property users can set to `true` to completely disable this behaviour, just in case.