### PR TITLE
Add support for ImmutableArray for ShouldBeEquivalentTo

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ImmutableArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ImmutableArrayScenario.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Immutable;
+
+namespace Shouldly.Tests.ShouldBeEquivalentTo;
+
+public class ImmutableArrayScenario
+{
+    [Fact]
+    public void ShouldPass()
+    {
+        var subject = ImmutableArray.Create(1, 2, 6, 4, 5);
+        subject.ShouldBeEquivalentTo(ImmutableArray.Create(1, 2, 6, 4, 5));
+    }
+}

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
     <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <Reference Include="System.Runtime" />

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -31,7 +31,15 @@ public static partial class ObjectGraphTestExtensions
 
         var type = GetTypeToCompare(actual, expected, path, customMessage, shouldlyMethod);
 
-        if (type.GetTypeInfo().IsValueType)
+        if (type == typeof(string))
+        {
+            CompareStrings((string)actual, (string)expected, path, customMessage, shouldlyMethod);
+        }
+        else if (typeof(IEnumerable).IsAssignableFrom(type))
+        {
+            CompareEnumerables((IEnumerable)actual, (IEnumerable)expected, path, previousComparisons, customMessage, shouldlyMethod);
+        }
+        else if (type.GetTypeInfo().IsValueType)
         {
             CompareValueTypes((ValueType)actual, (ValueType)expected, path, customMessage, shouldlyMethod);
         }


### PR DESCRIPTION
ShouldBeEquivalentTo now succeeds when comparing instances of `ImmutableArray<T>` with equivalent elements. The wrong assumption was that if a type is a value type, then it cannot also be of type IEnumerable, but that is actually the case for `ImmutableArray<T>`