### PR TITLE
Introducing tests for Image-specific message generation.

### DIFF
--- a/src/Shouldly.Tests/ShouldBe/ByteScenarios.cs
+++ b/src/Shouldly.Tests/ShouldBe/ByteScenarios.cs
@@ -1,0 +1,73 @@
+﻿
+using System.Drawing;
+using System.Drawing.Imaging;
+
+namespace Shouldly.Tests.ShouldBe;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA1416:...", Justification = "Explanation for suppression.")]
+public class ByteScenarios
+{
+   [Fact]
+    public void ImageBytesShouldBeEqual()
+    {
+        byte[] expectedImage = Generate2x2Image(Color.Red, Color.Green, Color.Blue, Color.Blue, ImageFormat.Jpeg);
+        byte[] actualImage = (byte[])expectedImage.Clone();
+        expectedImage.ShouldBe(actualImage);
+    }
+
+    [Fact]
+    public void ImageBytesShouldNotBeEqual()
+    {
+        byte[] expectedImage = Generate2x2Image(Color.Red, Color.Green, Color.Blue, Color.Blue, ImageFormat.Png);
+        byte[] actualImage = Generate2x2Image(Color.White, Color.White, Color.White, Color.White, ImageFormat.Png);
+        Should.Throw<ShouldAssertException>(
+            () =>expectedImage.ShouldBe(actualImage),
+            customMessage:
+             """
+Shouldly.ShouldAssertException : expectedImage
+    should be
+[[255, 255, 255, 255], [255, 255, 255, 255], [255, 255, 255, 255], [255, 255, 255, 255]]
+    but was
+[[255, 255, 0, 0], [255, 0, 0, 255], [255, 0, 128, 0], [255, 0, 0, 255]]
+    difference
+[*[255, 255, 0, 0] *, *[255, 0, 0, 255] *, *[255, 0, 128, 0] *, *[255, 0, 0, 255] *]
+"""
+);
+    }
+
+[Fact]
+    public void RegularBytesThrowMessageTest()
+    {
+        byte[] expected = { 1, 1, 0, 1, 0, 0, 0, 0 };
+        byte[] actual = { 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+        Should.Throw<ShouldAssertException>(()=>expected.ShouldBe(actual),
+            customMessage:
+            """
+Shouldly.ShouldAssertException : expected
+    should be
+[0, 0, 0, 0, 0, 0, 0, 0, 0]
+    but was
+[1, 1, 0, 1, 0, 0, 0, 0]
+    difference
+[*1*, *1*, 0, *1*, 0, 0, 0, 0, *]
+"""
+);
+    }
+
+
+
+
+    private static byte[] Generate2x2Image(Color pixel1, Color pixel2, Color pixel3, Color pixel4, ImageFormat format)
+    {
+        using Bitmap bitmap = new Bitmap(2, 2);
+        bitmap.SetPixel(0, 0, pixel1);
+        bitmap.SetPixel(1, 0, pixel2);
+        bitmap.SetPixel(0, 1, pixel3);
+        bitmap.SetPixel(1, 1, pixel4);
+        using MemoryStream stream = new MemoryStream();
+        bitmap.Save(stream, format);
+        byte[] byteArray = stream.ToArray();
+        return byteArray;
+    }
+    
+}

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\Shouldly\Shouldly.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="MarkdownSnippets.MsBuild" Version="24.5.1" PrivateAssets="all" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
     <PackageReference Include="TestStack.ConventionTests" Version="4.0.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/src/Shouldly/MessageGenerators/ImageShouldBeEqualGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ImageShouldBeEqualGenerator.cs
@@ -1,0 +1,59 @@
+﻿using System.Drawing;
+
+namespace Shouldly.MessageGenerators;
+
+class ImageShouldBeEqualGenerator : ShouldlyMessageGenerator
+{
+    public override bool CanProcess(IShouldlyAssertionContext context) =>
+        context is
+        {
+            ShouldMethod: "ShouldBe" or "ShouldNotBe",
+            Expected: byte[],
+            Actual: byte[],
+        };
+
+    public override string GenerateErrorMessage(IShouldlyAssertionContext context)
+    {
+        Debug.Assert(context.Expected is byte[]);
+        Debug.Assert(context.Actual is byte[]);
+        try
+        {
+            var codePart = context.CodePart;
+            byte[] expectedBytes = (byte[])context.Expected;
+            byte[] actualBytes = (byte[])context.Actual;
+            context.Expected = ExtractPixels(expectedBytes);
+            context.Actual = ExtractPixels(actualBytes);
+            return new ShouldBeMessageGenerator().GenerateErrorMessage(context);
+        }
+        catch (Exception)
+        {
+            return new ShouldBeMessageGenerator().GenerateErrorMessage(context);
+        }
+    }
+
+    private static byte[][] ExtractPixels(byte[] imageBytes)
+    {
+        using MemoryStream stream = new MemoryStream(imageBytes);
+        using Bitmap bitmap = new Bitmap(stream);
+        int width = bitmap.Width;
+        int height = bitmap.Height;
+
+        byte[][] pixelData = new byte[height*width][];
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                Color pixel = bitmap.GetPixel(x, y);
+                int argbValue = pixel.ToArgb();
+                byte[] convertedPixel = BitConverter.GetBytes(argbValue);
+                if (BitConverter.IsLittleEndian)
+                {
+                    Array.Reverse(convertedPixel);
+                }
+                pixelData[x*width+y] = convertedPixel;
+            }
+        }
+        return pixelData;
+    }
+}
+

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="DiffEngine" Version="11.3.0" />
     <PackageReference Include="EmptyFiles" Version="4.4.0" PrivateAssets="None" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" Condition="$(Configuration) == 'Release'" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
     <None Include="..\..\assets\logo_128x128.png" Pack="true" PackagePath="assets" />
     <None Include="buildTransitive\Shouldly.targets" Pack="true" PackagePath="buildTransitive\Shouldly.targets" />
   </ItemGroup>

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -258,6 +258,7 @@ public abstract class ShouldlyMessage
     {
         new ShouldHaveFlagMessageGenerator(),
         new ShouldNotHaveFlagMessageGenerator(),
+        new ImageShouldBeEqualGenerator(),
         new ShouldBeNullOrEmptyMessageGenerator(),
         new ShouldBeEmptyMessageGenerator(),
         new ShouldAllBeMessageGenerator(),


### PR DESCRIPTION
This pull request addresses issue #909 .
Introducing additional functionality for ShouldBe and ShouldNotBe test fail message generation with parsing byte[] elements representing images into byte[][], where inner array represents pixel values in ARGB color format.