### PR TITLE
Improve some of the flaky tests

### DIFF
--- a/src/Shouldly.Tests/ShouldBe/ShouldBeScenarios.cs
+++ b/src/Shouldly.Tests/ShouldBe/ShouldBeScenarios.cs
@@ -230,7 +230,7 @@ public class ShouldBeScenarios
             """
             new BaseClass()
                 should be
-            Shouldly.Tests.ShouldBe.ShouldBeScenarios+SubclassWithStubbedEquals (0)
+            Shouldly.Tests.ShouldBe.ShouldBeScenarios+SubclassWithStubbedEquals (000000)
                 but was
             Shouldly.Tests.ShouldBe.ShouldBeScenarios+BaseClass (000000)
 
@@ -242,7 +242,7 @@ public class ShouldBeScenarios
             """
             Shouldly.Tests.ShouldBe.ShouldBeScenarios+BaseClass (000000)
                 should be
-            Shouldly.Tests.ShouldBe.ShouldBeScenarios+SubclassWithStubbedEquals (0)
+            Shouldly.Tests.ShouldBe.ShouldBeScenarios+SubclassWithStubbedEquals (000000)
                 but was not
 
             Additional Info:

--- a/src/Shouldly.Tests/ShouldCompleteInTests.cs
+++ b/src/Shouldly.Tests/ShouldCompleteInTests.cs
@@ -4,7 +4,7 @@ public class ShouldCompleteInTests
 {
     private static readonly TimeSpan ShortWait = TimeSpan.FromSeconds(0.5);
     private static readonly TimeSpan LongWait = TimeSpan.FromSeconds(15);
-    private static readonly TimeSpan ImmediateTaskTimeout = TimeSpan.FromMilliseconds(2);
+    private static readonly TimeSpan ImmediateTaskTimeout = TimeSpan.FromSeconds(2);
     
     [Fact]
     public void ShouldCompleteIn_WhenFinishBeforeTimeout()

--- a/src/Shouldly.Tests/ShouldCompleteInTests.cs
+++ b/src/Shouldly.Tests/ShouldCompleteInTests.cs
@@ -4,6 +4,7 @@ public class ShouldCompleteInTests
 {
     private static readonly TimeSpan ShortWait = TimeSpan.FromSeconds(0.5);
     private static readonly TimeSpan LongWait = TimeSpan.FromSeconds(15);
+    private static readonly TimeSpan ImmediateTaskTimeout = TimeSpan.FromMilliseconds(2);
     
     [Fact]
     public void ShouldCompleteIn_WhenFinishBeforeTimeout()
@@ -48,7 +49,7 @@ public class ShouldCompleteInTests
     [Fact]
     public void ShouldCompleteIn_WhenThrowsNonTimeoutException()
     {
-        Should.Throw<NotImplementedException>(() => Should.CompleteIn(() => throw new NotImplementedException(), ShortWait));
+        Should.Throw<NotImplementedException>(() => Should.CompleteIn(() => throw new NotImplementedException(), ImmediateTaskTimeout));
     }
 
     [Fact]
@@ -107,6 +108,6 @@ public class ShouldCompleteInTests
     [Fact]
     public void ShouldCompleteInT_WhenThrowsNonTimeoutException()
     {
-        Should.Throw<NotImplementedException>(() => Should.CompleteIn(new Func<string>(() => throw new NotImplementedException()), ShortWait));
+        Should.Throw<NotImplementedException>(() => Should.CompleteIn(new Func<string>(() => throw new NotImplementedException()), ImmediateTaskTimeout));
     }
 }

--- a/src/Shouldly.Tests/ShouldCompleteInTests.cs
+++ b/src/Shouldly.Tests/ShouldCompleteInTests.cs
@@ -2,22 +2,25 @@
 
 public class ShouldCompleteInTests
 {
+    private static readonly TimeSpan ShortWait = TimeSpan.FromSeconds(0.5);
+    private static readonly TimeSpan LongWait = TimeSpan.FromSeconds(15);
+    
     [Fact]
     public void ShouldCompleteIn_WhenFinishBeforeTimeout()
     {
-        Should.NotThrow(() => Should.CompleteIn(() => Task.Delay(TimeSpan.FromSeconds(0.5)).Wait(), TimeSpan.FromSeconds(5)));
+        Should.NotThrow(() => Should.CompleteIn(() => Task.Delay(ShortWait).Wait(), LongWait));
     }
 
     [Fact]
     public void ShouldCompleteIn_WhenFinishAfterTimeout()
     {
         var ex = Should.Throw<ShouldlyTimeoutException>(() =>
-            Should.CompleteIn(() => Task.Delay(TimeSpan.FromSeconds(5)).Wait(), TimeSpan.FromSeconds(1), "Some additional context"));
+            Should.CompleteIn(() => Task.Delay(LongWait).Wait(), ShortWait, "Some additional context"));
         ex.Message.ShouldContainWithoutWhitespace(
             """
             Delegate
                 should complete in
-            00:00:01
+            00:00:00.5000000
                 but did not
             Additional Info:
             Some additional context
@@ -29,13 +32,13 @@ public class ShouldCompleteInTests
     {
         var ex = Should.Throw<ShouldlyTimeoutException>(() =>
             Should.CompleteIn(
-                () => Task.Factory.StartNew(() => Task.Delay(TimeSpan.FromSeconds(5)).Wait()),
-                TimeSpan.FromMilliseconds(10), "Some additional context"));
+                () => Task.Factory.StartNew(() => Task.Delay(LongWait).Wait()),
+                ShortWait, "Some additional context"));
         ex.Message.ShouldContainWithoutWhitespace(
             """
             Task
                 should complete in
-            00:00:00.0100000
+            00:00:00.5000000
                 but did not
             Additional Info:
             Some additional context
@@ -45,7 +48,7 @@ public class ShouldCompleteInTests
     [Fact]
     public void ShouldCompleteIn_WhenThrowsNonTimeoutException()
     {
-        Should.Throw<NotImplementedException>(() => Should.CompleteIn(() => throw new NotImplementedException(), TimeSpan.FromSeconds(1)));
+        Should.Throw<NotImplementedException>(() => Should.CompleteIn(() => throw new NotImplementedException(), ShortWait));
     }
 
     [Fact]
@@ -53,9 +56,9 @@ public class ShouldCompleteInTests
     {
         Should.NotThrow(() => Should.CompleteIn(() =>
         {
-            Task.Delay(TimeSpan.FromSeconds(1)).Wait();
+            Task.Delay(ShortWait).Wait();
             return "";
-        }, TimeSpan.FromSeconds(5)));
+        }, LongWait));
     }
 
     [Fact]
@@ -63,15 +66,15 @@ public class ShouldCompleteInTests
     {
         var ex = Should.Throw<ShouldlyTimeoutException>(() => Should.CompleteIn(() =>
         {
-            Task.Delay(TimeSpan.FromSeconds(5)).Wait();
+            Task.Delay(LongWait).Wait();
             return "";
-        }, TimeSpan.FromSeconds(1), "Some additional context"));
+        }, ShortWait, "Some additional context"));
 
         ex.Message.ShouldContainWithoutWhitespace(
             """
             Delegate
                 should complete in
-            00:00:01
+            00:00:00.5000000
                 but did not
             Additional Info:
             Some additional context
@@ -85,16 +88,16 @@ public class ShouldCompleteInTests
         {
             return Task.Factory.StartNew(() =>
             {
-                Task.Delay(TimeSpan.FromSeconds(5)).Wait();
+                Task.Delay(LongWait).Wait();
                 return "";
             });
-        }, TimeSpan.FromSeconds(1), "Some additional context"));
+        }, ShortWait, "Some additional context"));
 
         ex.Message.ShouldContainWithoutWhitespace(
             """
             Task
                 should complete in
-            00:00:01
+            00:00:00.5000000
                 but did not
             Additional Info:
             Some additional context
@@ -104,6 +107,6 @@ public class ShouldCompleteInTests
     [Fact]
     public void ShouldCompleteInT_WhenThrowsNonTimeoutException()
     {
-        Should.Throw<NotImplementedException>(() => Should.CompleteIn(new Func<string>(() => throw new NotImplementedException()), TimeSpan.FromSeconds(2)));
+        Should.Throw<NotImplementedException>(() => Should.CompleteIn(new Func<string>(() => throw new NotImplementedException()), ShortWait));
     }
 }

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskWithTimeoutScenario.cs
@@ -5,12 +5,11 @@ public class FuncOfTaskWithTimeoutScenario
     [Fact]
     public void ShouldThrowAWobbly()
     {
-        var task = Task.Factory.StartNew(() => { Task.Delay(5000).Wait(); },
-            CancellationToken.None, TaskCreationOptions.None,
-            TaskScheduler.Default);
-
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var perpetualTask = tcs.Task;
+        
         var ex = Should.Throw<ShouldCompleteInException>(() =>
-            task.ShouldNotThrow(TimeSpan.FromSeconds(0.5), "Some additional context"));
+            perpetualTask.ShouldNotThrow(TimeSpan.FromSeconds(0.5), "Some additional context"));
 
         ex.Message.ShouldContainWithoutWhitespace(ChuckedAWobblyErrorMessage);
     }
@@ -29,10 +28,10 @@ public class FuncOfTaskWithTimeoutScenario
     [Fact]
     public void ShouldPass()
     {
-        var task = Task.Factory.StartNew(() => { },
-            CancellationToken.None, TaskCreationOptions.None,
-            TaskScheduler.Default);
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        tcs.SetResult(null);
+        var completedTask = tcs.Task;
 
-        task.ShouldNotThrow(TimeSpan.FromSeconds(2));
+        completedTask.ShouldNotThrow(TimeSpan.FromSeconds(2));
     }
 }

--- a/src/Shouldly.Tests/ShouldNotThrow/TaskWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/TaskWithTimeoutScenario.cs
@@ -5,11 +5,10 @@ public class TaskWithTimeoutScenario
     [Fact]
     public void ShouldThrowAWobbly()
     {
-        var task = Task.Factory.StartNew(() => { Task.Delay(5000).Wait(); },
-            CancellationToken.None, TaskCreationOptions.None,
-            TaskScheduler.Default);
-
-        var ex = Should.Throw<ShouldCompleteInException>(() => task.ShouldNotThrow(TimeSpan.FromSeconds(0.5), "Some additional context"));
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var perpetualTask = tcs.Task;
+        
+        var ex = Should.Throw<ShouldCompleteInException>(() => perpetualTask.ShouldNotThrow(TimeSpan.FromSeconds(0.5), "Some additional context"));
         ex.Message.ShouldContainWithoutWhitespace(ChuckedAWobblyErrorMessage);
     }
 
@@ -26,10 +25,10 @@ public class TaskWithTimeoutScenario
     [Fact]
     public void ShouldPass()
     {
-        var task = Task.Factory.StartNew(() => { },
-            CancellationToken.None, TaskCreationOptions.None,
-            TaskScheduler.Default);
-
-        task.ShouldNotThrow(TimeSpan.FromSeconds(2));
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        tcs.SetResult(null);
+        var completedTask = tcs.Task;
+        
+        completedTask.ShouldNotThrow(TimeSpan.FromSeconds(2));
     }
 }

--- a/src/Shouldly.Tests/ShouldThrow/FuncOfTaskWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests/ShouldThrow/FuncOfTaskWithTimeoutScenario.cs
@@ -5,14 +5,11 @@ public class FuncOfTaskWithTimeoutScenario
     [Fact]
     public void ShouldThrowAWobbly()
     {
-        var task = Task.Factory.StartNew(
-            () => { Task.Delay(5000).Wait(); },
-            CancellationToken.None,
-            TaskCreationOptions.None,
-            TaskScheduler.Default);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var perpetualTask = tcs.Task;
 
         var ex = Should.Throw<ShouldCompleteInException>(
-            () => task.ShouldThrow<ShouldCompleteInException>(TimeSpan.FromSeconds(0.1), "Some additional context"));
+            () => perpetualTask.ShouldThrow<ShouldCompleteInException>(TimeSpan.FromSeconds(0.1), "Some additional context"));
 
         ex.Message.ShouldContainWithoutWhitespace(ChuckedAWobblyErrorMessage);
     }
@@ -20,14 +17,11 @@ public class FuncOfTaskWithTimeoutScenario
     [Fact]
     public void ShouldThrowAWobbly_ExceptionTypePassedIn()
     {
-        var task = Task.Factory.StartNew(
-            () => { Task.Delay(5000).Wait(); },
-            CancellationToken.None,
-            TaskCreationOptions.None,
-            TaskScheduler.Default);
-
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var perpetualTask = tcs.Task;
+        
         var ex = Should.Throw(
-            () => task.ShouldThrow(
+            () => perpetualTask.ShouldThrow(
                 TimeSpan.FromSeconds(0.1),
                 "Some additional context",
                 typeof(ShouldCompleteInException)),
@@ -49,11 +43,11 @@ public class FuncOfTaskWithTimeoutScenario
     [Fact]
     public void ShouldPass()
     {
-        var task = Task.Factory.StartNew(() => throw new InvalidOperationException(),
-            CancellationToken.None, TaskCreationOptions.None,
-            TaskScheduler.Default);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        tcs.SetException(new InvalidOperationException());
+        var faultedTask = tcs.Task;
 
-        var ex = task.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(10));
+        var ex = faultedTask.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(10));
 
         ex.ShouldNotBe(null);
         ex.ShouldBeOfType<InvalidOperationException>();
@@ -62,11 +56,11 @@ public class FuncOfTaskWithTimeoutScenario
     [Fact]
     public void ShouldPass_ExceptionTypePassedIn()
     {
-        var task = Task.Factory.StartNew(() => throw new InvalidOperationException(),
-            CancellationToken.None, TaskCreationOptions.None,
-            TaskScheduler.Default);
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        tcs.SetException(new InvalidOperationException());
+        var faultedTask = tcs.Task;
 
-        var ex = task.ShouldThrow(TimeSpan.FromSeconds(10), typeof(InvalidOperationException));
+        var ex = faultedTask.ShouldThrow(TimeSpan.FromSeconds(10), typeof(InvalidOperationException));
 
         ex.ShouldNotBe(null);
         ex.ShouldBeOfType<InvalidOperationException>();

--- a/src/Shouldly.Tests/ShouldThrow/FuncOfTaskWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests/ShouldThrow/FuncOfTaskWithTimeoutScenario.cs
@@ -5,7 +5,7 @@ public class FuncOfTaskWithTimeoutScenario
     [Fact]
     public void ShouldThrowAWobbly()
     {
-        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         var perpetualTask = tcs.Task;
 
         var ex = Should.Throw<ShouldCompleteInException>(
@@ -17,7 +17,7 @@ public class FuncOfTaskWithTimeoutScenario
     [Fact]
     public void ShouldThrowAWobbly_ExceptionTypePassedIn()
     {
-        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         var perpetualTask = tcs.Task;
         
         var ex = Should.Throw(
@@ -43,7 +43,7 @@ public class FuncOfTaskWithTimeoutScenario
     [Fact]
     public void ShouldPass()
     {
-        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         tcs.SetException(new InvalidOperationException());
         var faultedTask = tcs.Task;
 
@@ -56,7 +56,7 @@ public class FuncOfTaskWithTimeoutScenario
     [Fact]
     public void ShouldPass_ExceptionTypePassedIn()
     {
-        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
         tcs.SetException(new InvalidOperationException());
         var faultedTask = tcs.Task;
 

--- a/src/Shouldly.Tests/ShouldThrow/TaskWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests/ShouldThrow/TaskWithTimeoutScenario.cs
@@ -5,22 +5,20 @@ public class TaskWithTimeoutScenario
     [Fact]
     public void ShouldThrowAWobbly()
     {
-        var task = Task.Factory.StartNew(() => { Task.Delay(5000).Wait(); },
-            CancellationToken.None, TaskCreationOptions.None,
-            TaskScheduler.Default);
-
-        var ex = Should.Throw<ShouldCompleteInException>(() => task.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(0.5), "Some additional context"));
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var perpetualTask = tcs.Task;
+        
+        var ex = Should.Throw<ShouldCompleteInException>(() => perpetualTask.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(0.5), "Some additional context"));
         ex.Message.ShouldContainWithoutWhitespace(ChuckedAWobblyErrorMessage);
     }
 
-    [Fact(Skip = "flaky")]
+    [Fact]
     public void ShouldThrowAWobbly_ExceptionTypePassedIn()
     {
-        var task = Task.Factory.StartNew(() => { Task.Delay(5000).Wait(); },
-            CancellationToken.None, TaskCreationOptions.None,
-            TaskScheduler.Default);
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var perpetualTask = tcs.Task;
 
-        var ex = Should.Throw(() => task.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(0.5), "Some additional context"), typeof(ShouldCompleteInException));
+        var ex = Should.Throw(() => perpetualTask.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(0.5), "Some additional context"), typeof(ShouldCompleteInException));
         ex.Message.ShouldContainWithoutWhitespace(ChuckedAWobblyErrorMessage);
     }
 
@@ -35,11 +33,11 @@ public class TaskWithTimeoutScenario
     [Fact]
     public void ShouldPass()
     {
-        var task = Task.Factory.StartNew(() => throw new InvalidOperationException(),
-            CancellationToken.None, TaskCreationOptions.None,
-            TaskScheduler.Default);
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        tcs.SetException(new InvalidOperationException());
+        var faultedTask = tcs.Task;
 
-        var ex = task.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(2));
+        var ex = faultedTask.ShouldThrow<InvalidOperationException>(TimeSpan.FromSeconds(2));
         ex.ShouldNotBe(null);
         ex.ShouldBeOfType<InvalidOperationException>();
     }
@@ -47,11 +45,11 @@ public class TaskWithTimeoutScenario
     [Fact]
     public void ShouldPass_ExceptionTypePassedIn()
     {
-        var task = Task.Factory.StartNew(() => throw new InvalidOperationException(),
-            CancellationToken.None, TaskCreationOptions.None,
-            TaskScheduler.Default);
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        tcs.SetException(new InvalidOperationException());
+        var faultedTask = tcs.Task;
 
-        var ex = task.ShouldThrow(TimeSpan.FromSeconds(2), typeof(InvalidOperationException));
+        var ex = faultedTask.ShouldThrow(TimeSpan.FromSeconds(2), typeof(InvalidOperationException));
         ex.ShouldNotBe(null);
         ex.ShouldBeOfType<InvalidOperationException>();
     }

--- a/src/Shouldly.Tests/Strings/Verify.cs
+++ b/src/Shouldly.Tests/Strings/Verify.cs
@@ -5,7 +5,7 @@ namespace Shouldly.Tests.Strings;
 [ShouldlyMethods]
 public static class Verify
 {
-    private static readonly Regex MatchGetHashCode = new("\\(\\d{5,8}\\)");
+    private static readonly Regex MatchGetHashCode = new(@"\(-?\d{6,10}\)");
 
     public static void ShouldFail(Action action, string errorWithSource, string errorWithoutSource, Func<string, string>? messageScrubber = null)
     {

--- a/src/Shouldly/Internals/StringHelpers.cs
+++ b/src/Shouldly/Internals/StringHelpers.cs
@@ -80,7 +80,7 @@ static class StringHelpers
 
         var toString = value.ToString();
         if (toString == objectType.FullName)
-            return $"{value} ({value.GetHashCode()})";
+            return $"{value} ({value.GetHashCode():D6})";
 
         return toString; // ToString() may return null.
     }


### PR DESCRIPTION
* Use `TaskCompletionSource` to avoid task scheduler and waits where appropriate, these are unreliable on slow hardware (AppVeyor).
* Standardise some of the wait durations, and have them be more lenient. The eventual solution to this would be `TimeProvider`, but that's a more substantial change.
* Format HashCodes printing to a minimum of 6 digits (we'd occasionally get 4 digit hashcodes which was breaking the tests)
* Improve HashCode scrubbing to handle all scenarios

I've tried to be careful about not changing the tests to act on delegates that are intended to not immediately complete, I think I've got the balance right here.