### PR TITLE
Assortment of Minor Improvements

### DIFF
--- a/documentation/documentation/completeIn.md
+++ b/documentation/documentation/completeIn.md
@@ -4,8 +4,8 @@
 <a id='snippet-ShouldCompleteInExamples.ShouldCompleteIn.codeSample.approved.cs'></a>
 ```cs
 Should.CompleteIn(
-                    action: () => { Thread.Sleep(TimeSpan.FromSeconds(2)); },
-                    timeout: TimeSpan.FromSeconds(1),
+                    action: () => { Thread.Sleep(TimeSpan.FromSeconds(15)); },
+                    timeout: TimeSpan.FromSeconds(0.5),
                     customMessage: "Some additional context");
 ```
 <sup><a href='/src/DocumentationExamples/CodeExamples/ShouldCompleteInExamples.ShouldCompleteIn.codeSample.approved.cs#L1-L4' title='Snippet source file'>snippet source</a> | <a href='#snippet-ShouldCompleteInExamples.ShouldCompleteIn.codeSample.approved.cs' title='Start of snippet'>anchor</a></sup>
@@ -19,7 +19,7 @@ Should.CompleteIn(
 
 Delegate
     should complete in
-00:00:01
+00:00:00.5000000
     but did not
 
 Additional Info:

--- a/documentation/documentation/equality/shouldBe.md
+++ b/documentation/documentation/equality/shouldBe.md
@@ -6,12 +6,12 @@
 `ShouldBeExamples` works on all types and compares using `.Equals`.
 
 <!-- snippet: ShouldBeObjects -->
-<a id='snippet-shouldbeobjects'></a>
+<a id='snippet-ShouldBeObjects'></a>
 ```cs
 var theSimpsonsCat = new Cat { Name = "Santas little helper" };
 theSimpsonsCat.Name.ShouldBe("Snowball 2");
 ```
-<sup><a href='/src/DocumentationExamples/ShouldBeExamples.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-shouldbeobjects' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/DocumentationExamples/ShouldBeExamples.cs#L14-L19' title='Snippet source file'>snippet source</a> | <a href='#snippet-ShouldBeObjects' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 **Exception**

--- a/documentation/documentation/exceptions/throw.md
+++ b/documentation/documentation/exceptions/throw.md
@@ -31,23 +31,20 @@ System.DivideByZeroException
 ## ShouldThrowAsync
 
 <!-- snippet: ShouldThrowAsync -->
-<a id='snippet-shouldthrowasync'></a>
+<a id='snippet-ShouldThrowAsync'></a>
 ```cs
-Func<Task> doSomething = async () =>
-{
-    await Task.Delay(1);
-};
+Task doSomething() => Task.CompletedTask;
 var exception = await Should.ThrowAsync<DivideByZeroException>(() => doSomething());
 ```
-<sup><a href='/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs#L103-L109' title='Snippet source file'>snippet source</a> | <a href='#snippet-shouldthrowasync' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs#L91-L95' title='Snippet source file'>snippet source</a> | <a href='#snippet-ShouldThrowAsync' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 **Exception**
 
-Task `doSomething()` <!-- include: FuncOfTaskScenarioAsync.ShouldThrowAsync.approved.txt -->
+Task `doSomething()`<!-- include: FuncOfTaskScenarioAsync.ShouldThrowAsync.approved.txt -->
     should throw
 System.DivideByZeroException
-    but did not <!-- endInclude -->
+    but did not<!-- endInclude -->
 
 
 ## ShouldThrow Action Extension

--- a/src/DocumentationExamples/CodeExamples/ShouldCompleteInExamples.ShouldCompleteIn.codeSample.approved.cs
+++ b/src/DocumentationExamples/CodeExamples/ShouldCompleteInExamples.ShouldCompleteIn.codeSample.approved.cs
@@ -1,4 +1,4 @@
 Should.CompleteIn(
-                    action: () => { Thread.Sleep(TimeSpan.FromSeconds(2)); },
-                    timeout: TimeSpan.FromSeconds(1),
+                    action: () => { Thread.Sleep(TimeSpan.FromSeconds(15)); },
+                    timeout: TimeSpan.FromSeconds(0.5),
                     customMessage: "Some additional context");

--- a/src/DocumentationExamples/CodeExamples/ShouldCompleteInExamples.ShouldCompleteIn.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldCompleteInExamples.ShouldCompleteIn.exceptionText.approved.txt
@@ -2,7 +2,7 @@
 
 Delegate
     should complete in
-00:00:01
+00:00:00.5000000
     but did not
 
 Additional Info:

--- a/src/DocumentationExamples/ShouldCompleteInExamples.cs
+++ b/src/DocumentationExamples/ShouldCompleteInExamples.cs
@@ -5,15 +5,15 @@
     public ShouldCompleteInExamples(ITestOutputHelper testOutputHelper) =>
         _testOutputHelper = testOutputHelper;
 
-    [Fact(Skip = "Flaky test")]
+    [Fact]
     public void ShouldCompleteIn()
     {
         DocExampleWriter.Document(
             () =>
             {
                 Should.CompleteIn(
-                    action: () => { Thread.Sleep(TimeSpan.FromSeconds(2)); },
-                    timeout: TimeSpan.FromSeconds(1),
+                    action: () => { Thread.Sleep(TimeSpan.FromSeconds(15)); },
+                    timeout: TimeSpan.FromSeconds(0.5),
                     customMessage: "Some additional context");
             },
             _testOutputHelper);

--- a/src/Shouldly.Tests/CommonWaitDurations.cs
+++ b/src/Shouldly.Tests/CommonWaitDurations.cs
@@ -2,39 +2,17 @@ namespace Shouldly.Tests;
 
 internal static class CommonWaitDurations
 {
-    public static TimeSpan ShortWait
-    {
-        get
-        {
-            if (Environment.GetEnvironmentVariable("CI") == "true")
-            {
-                return TimeSpan.FromSeconds(0.5);
-            }
-            return TimeSpan.FromSeconds(0.2);
-        }
-    }
+    private static readonly bool IsRunningOnContinuousIntegration =
+        Environment.GetEnvironmentVariable("CI")
+            ?.Equals("true", StringComparison.OrdinalIgnoreCase)
+        ?? false;
 
-    public static TimeSpan LongWait
-    {
-        get
-        {
-            if (Environment.GetEnvironmentVariable("CI") == "true")
-            {
-                return TimeSpan.FromSeconds(15);
-            }
-            return TimeSpan.FromSeconds(5);
-        }
-    }
+    public static TimeSpan ShortWait => 
+        TimeSpan.FromSeconds(IsRunningOnContinuousIntegration ? 0.5 : 0.2);
 
-    public static TimeSpan ImmediateTaskTimeout
-    {
-        get
-        {
-            if (Environment.GetEnvironmentVariable("CI") == "true")
-            {
-                return TimeSpan.FromSeconds(2);    
-            }
-            return TimeSpan.FromSeconds(0.1);
-        }
-    }
+    public static TimeSpan LongWait =>
+        TimeSpan.FromSeconds(IsRunningOnContinuousIntegration ? 15 : 5);
+
+    public static TimeSpan ImmediateTaskTimeout =>
+        TimeSpan.FromSeconds(IsRunningOnContinuousIntegration ? 2 : 0.1);
 }

--- a/src/Shouldly.Tests/CommonWaitDurations.cs
+++ b/src/Shouldly.Tests/CommonWaitDurations.cs
@@ -14,5 +14,5 @@ internal static class CommonWaitDurations
         TimeSpan.FromSeconds(IsRunningOnContinuousIntegration ? 15 : 5);
 
     public static TimeSpan ImmediateTaskTimeout =>
-        TimeSpan.FromSeconds(IsRunningOnContinuousIntegration ? 2 : 0.1);
+        TimeSpan.FromSeconds(IsRunningOnContinuousIntegration ? 2 : 0.5);
 }

--- a/src/Shouldly.Tests/CommonWaitDurations.cs
+++ b/src/Shouldly.Tests/CommonWaitDurations.cs
@@ -1,0 +1,40 @@
+namespace Shouldly.Tests;
+
+internal static class CommonWaitDurations
+{
+    public static TimeSpan ShortWait
+    {
+        get
+        {
+            if (Environment.GetEnvironmentVariable("CI") == "true")
+            {
+                return TimeSpan.FromSeconds(0.5);
+            }
+            return TimeSpan.FromSeconds(0.2);
+        }
+    }
+
+    public static TimeSpan LongWait
+    {
+        get
+        {
+            if (Environment.GetEnvironmentVariable("CI") == "true")
+            {
+                return TimeSpan.FromSeconds(15);
+            }
+            return TimeSpan.FromSeconds(5);
+        }
+    }
+
+    public static TimeSpan ImmediateTaskTimeout
+    {
+        get
+        {
+            if (Environment.GetEnvironmentVariable("CI") == "true")
+            {
+                return TimeSpan.FromSeconds(2);    
+            }
+            return TimeSpan.FromSeconds(0.1);
+        }
+    }
+}

--- a/src/Shouldly.Tests/ConventionTests/ShouldlyConventions.cs
+++ b/src/Shouldly.Tests/ConventionTests/ShouldlyConventions.cs
@@ -30,7 +30,7 @@ public class ShouldlyConventions
         var ex = Should.Throw<ConventionFailedException>(() =>
         {
             var convention = new ShouldlyMethodsShouldHaveCustomMessageOverload();
-            var types = Types.InCollection(new[] { typeof(TestWithMissingOverloads) }, "Sample");
+            var types = Types.InCollection([typeof(TestWithMissingOverloads)], "Sample");
             Convention.Is(convention, types);
         });
 

--- a/src/Shouldly.Tests/InternalTests/DifferenceHighlighterHelpersTests.cs
+++ b/src/Shouldly.Tests/InternalTests/DifferenceHighlighterHelpersTests.cs
@@ -7,7 +7,7 @@ public class DifferenceHighlighterHelpersTests
     [Fact]
     public void HighlightDifferencesBetween_IntegerListsSameExceptOne_HighlightsDifference()
     {
-        Should.Throw<ShouldAssertException>(() => new[] { 2, 2, 3 }.ShouldBe(new[] { 1, 2, 3 }))
+        Should.Throw<ShouldAssertException>(() => new[] { 2, 2, 3 }.ShouldBe([1, 2, 3]))
             .Message.ShouldContain("[*2*, 2, 3]");
     }
 
@@ -21,14 +21,14 @@ public class DifferenceHighlighterHelpersTests
     [Fact]
     public void HighlightDifferencesBetween_ListsActualHasMoreElements_HighlightsMissingElements()
     {
-        Should.Throw<ShouldAssertException>(() => new[] { 1, 2, 3 }.ShouldBe(new[] { 1 }))
+        Should.Throw<ShouldAssertException>(() => new[] { 1, 2, 3 }.ShouldBe([1]))
             .Message.ShouldContain("[1, *2*, *3*]");
     }
 
     [Fact]
     public void HighlightDifferencesBetween_ListsActualHasLessElements_HighlightsMissingElements()
     {
-        Should.Throw<ShouldAssertException>(() => new[] { 1 }.ShouldBe(new[] { 1, 2, 3 }))
+        Should.Throw<ShouldAssertException>(() => new[] { 1 }.ShouldBe([1, 2, 3]))
             .Message.ShouldContain("[1, *, *]");
     }
 
@@ -49,49 +49,52 @@ public class DifferenceHighlighterHelpersTests
     [Fact]
     public void HighlightDifferencesBetween_ListsSameElementsInDifferentOrder_HighlightAllAsDifferent()
     {
-        Should.Throw<ShouldAssertException>(() => new[] { 2, 3, 1 }.ShouldBe(new[] { 1, 2, 3 }))
+        Should.Throw<ShouldAssertException>(() => new[] { 2, 3, 1 }.ShouldBe([1, 2, 3]))
             .Message.ShouldContain("[*2*, *3*, *1*]");
     }
 
     [Fact]
     public void HighlightDifferencesBetween_StringLists_HighlightsDifference()
     {
-        Should.Throw<ShouldAssertException>(() => new[] { "rita", "sue", "betty" }.ShouldBe(new[] { "rita", "sue", "bob" }))
+        Should.Throw<ShouldAssertException>(() => new[] { "rita", "sue", "betty" }.ShouldBe(["rita", "sue", "bob"]))
             .Message.ShouldContain("[\"rita\", \"sue\", *\"betty\"*]");
     }
 
     [Fact]
     public void HighlightDifferencesBetween_EnumLists_HighlightsDifference()
     {
-        Should.Throw<ShouldAssertException>(() => new[] { Weapons.Screwdriver, Weapons.Axe }.ShouldBe(new[] { Weapons.Chainsaw, Weapons.Axe }))
+        Should.Throw<ShouldAssertException>(() => new[] { Weapons.Screwdriver, Weapons.Axe }.ShouldBe([Weapons.Chainsaw, Weapons.Axe
+            ]))
             .Message.ShouldContain("[*Weapons.Screwdriver*, Weapons.Axe]");
     }
 
     [Fact]
     public void HighlightDifferencesBetween_BoolLists_HighlightsDifference()
     {
-        Should.Throw<ShouldAssertException>(() => new[] { true, true, false }.ShouldBe(new[] { true, false, true }))
+        Should.Throw<ShouldAssertException>(() => new[] { true, true, false }.ShouldBe([true, false, true]))
             .Message.ShouldContain("[True, *True*, *False*]");
     }
 
     [Fact]
     public void HighlightDifferencesBetween_ListOfObjectWithEqualsDefined_HighlightsDifference()
     {
-        Should.Throw<ShouldAssertException>(() => new[] { new EqualType("t1"), new EqualType("t3") }.ShouldBe(new[] { new EqualType("t1"), new EqualType("t2") }))
+        Should.Throw<ShouldAssertException>(() => new[] { new EqualType("t1"), new EqualType("t3") }.ShouldBe([new EqualType("t1"), new EqualType("t2")
+            ]))
             .Message.ShouldContain("[t1, *t3*]");
     }
 
     [Fact]
     public void HighlightDifferencesBetween_ListOfObjectWithoutEqualsDefined_HighlightsEverythingAsDifference()
     {
-        Should.Throw<ShouldAssertException>(() => new[] { new NonEqualType("t1"), new NonEqualType("t2") }.ShouldBe(new[] { new NonEqualType("t1"), new NonEqualType("t2") }))
+        Should.Throw<ShouldAssertException>(() => new[] { new NonEqualType("t1"), new NonEqualType("t2") }.ShouldBe([new NonEqualType("t1"), new NonEqualType("t2")
+            ]))
             .Message.ShouldContain("[*t1*, *t2*]");
     }
 
     [Fact]
     public void HighlightDifferencesBetween_GenericList_HighlightsDifference()
     {
-        Should.Throw<ShouldAssertException>(() => new List<int> { 1, 4, 3 }.ShouldBe(new() { 1, 2, 3 }))
+        Should.Throw<ShouldAssertException>(() => new List<int> { 1, 4, 3 }.ShouldBe([1, 2, 3]))
             .Message.ShouldContain("[1, *4*, 3]");
     }
 
@@ -163,7 +166,7 @@ public class DifferenceHighlighterHelpersTests
 
     private class PureEnumerable : IEnumerable
     {
-        private readonly List<int> _numbers = new();
+        private readonly List<int> _numbers = [];
 
         public void Add(int number) => _numbers.Add(number);
 

--- a/src/Shouldly.Tests/ModuleInitializer.cs
+++ b/src/Shouldly.Tests/ModuleInitializer.cs
@@ -1,0 +1,13 @@
+using System.Runtime.CompilerServices;
+using static Shouldly.Tests.CommonWaitDurations;
+
+namespace Shouldly.Tests;
+
+internal static class ModuleInitializer
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        ShouldlyConfiguration.DefaultTaskTimeout = LongWait;
+    }
+}

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/EnumerableOfComplexTypeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/EnumerableOfComplexTypeScenario.cs
@@ -3,7 +3,7 @@
 public class EnumerableOfComplexTypeScenario
 {
     private readonly IEnumerable<Widget> _aEnumerable = new Widget { Name = "Joe", Enabled = true }.ToEnumerable();
-    private readonly Widget[] _bArray = { new() { Name = "Joeyjojoshabadoo Jr", Enabled = true } };
+    private readonly Widget[] _bArray = [new() { Name = "Joeyjojoshabadoo Jr", Enabled = true }];
 
     [Fact]
     public void EnumerableOfComplexTypeScenarioShouldFail()

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/EnumerableOfStringIsInsensitiveScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/EnumerableOfStringIsInsensitiveScenario.cs
@@ -6,7 +6,7 @@ public class EnumerableOfStringIsInsensitiveScenario
     public void EnumerableOfStringIsInsensitiveScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new[] { "foo" }.ShouldBe(new[] { "different" }, Case.Insensitive, "Some additional context"),
+                new[] { "foo" }.ShouldBe(["different"], Case.Insensitive, "Some additional context"),
 
             errorWithSource:
             """
@@ -39,6 +39,6 @@ public class EnumerableOfStringIsInsensitiveScenario
     [Fact]
     public void ShouldPass()
     {
-        new[] { "foo" }.ShouldBe(new[] { "FOo" }, Case.Insensitive);
+        new[] { "foo" }.ShouldBe(["FOo"], Case.Insensitive);
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/EnumerableOfStringIsSensitiveScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/EnumerableOfStringIsSensitiveScenario.cs
@@ -6,7 +6,7 @@ public class EnumerableOfStringIsSensitiveScenario
     public void EnumerableOfStringIsSensitiveScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new[] { "foo" }.ShouldBe(new[] { "FoO" }, Case.Sensitive, "Some additional context"),
+                new[] { "foo" }.ShouldBe(["FoO"], Case.Sensitive, "Some additional context"),
 
             errorWithSource:
             """
@@ -39,6 +39,6 @@ public class EnumerableOfStringIsSensitiveScenario
     [Fact]
     public void ShouldPass()
     {
-        new[] { "foo" }.ShouldBe(new[] { "foo" }, Case.Sensitive);
+        new[] { "foo" }.ShouldBe(["foo"], Case.Sensitive);
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/EnumerableOfStringScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/EnumerableOfStringScenario.cs
@@ -6,7 +6,7 @@ public class EnumerableOfStringScenario
     public void EnumerableOfStringScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new[] { "foo" }.ShouldBe(new[] { "foo2" }, "Some additional context"),
+                new[] { "foo" }.ShouldBe(["foo2"], "Some additional context"),
 
             errorWithSource:
             """
@@ -39,6 +39,6 @@ public class EnumerableOfStringScenario
     [Fact]
     public void ShouldPass()
     {
-        new[] { "foo" }.ShouldBe(new[] { "foo" });
+        new[] { "foo" }.ShouldBe(["foo"]);
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderFalseIEnumerableMethodYieldBreak.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderFalseIEnumerableMethodYieldBreak.cs
@@ -6,7 +6,7 @@ public class IgnoreOrderFalseIEnumerableMethodYieldBreak
     public void IgnoreOrderFalseIEnumerableMethodYieldBreakShouldFail()
     {
         Verify.ShouldFail(() =>
-                GetEmptyEnumerable().ShouldBe(new[] { 2, 4 }, false, "Some additional context"),
+                GetEmptyEnumerable().ShouldBe([2, 4], false, "Some additional context"),
 
             errorWithSource:
             """

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderFalseIEnumerableMethodYieldReturn.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderFalseIEnumerableMethodYieldReturn.cs
@@ -6,7 +6,7 @@ public class IgnoreOrderFalseIEnumerableMethodYieldReturn
     public void IgnoreOrderFalseIEnumerableMethodYieldReturnShouldFail()
     {
         Verify.ShouldFail(() =>
-                GetEnumerable().ShouldBe(new[] { 1, 2 }, false, "Some additional context"),
+                GetEnumerable().ShouldBe([1, 2], false, "Some additional context"),
 
             errorWithSource:
             """
@@ -39,7 +39,7 @@ public class IgnoreOrderFalseIEnumerableMethodYieldReturn
     [Fact]
     public void ShouldPass()
     {
-        GetEnumerable().ShouldBe(new[] { 1 });
+        GetEnumerable().ShouldBe([1]);
     }
 
     private static IEnumerable<int> GetEnumerable()

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderFalseScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderFalseScenario.cs
@@ -6,7 +6,7 @@ public class IgnoreOrderFalseScenario
     public void IgnoreOrderFalseScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new List<int> { 1, 4, 2 }.ShouldBe(new[] { 1, 2, 3 }, false, "Some additional context"),
+                new List<int> { 1, 4, 2 }.ShouldBe([1, 2, 3], false, "Some additional context"),
 
             errorWithSource:
             """
@@ -39,6 +39,6 @@ public class IgnoreOrderFalseScenario
     [Fact]
     public void ShouldPass()
     {
-        new List<int> { 1, 2, 3 }.ShouldBe(new[] { 1, 2, 3 }, ignoreOrder: false);
+        new List<int> { 1, 2, 3 }.ShouldBe([1, 2, 3], ignoreOrder: false);
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderFalseScenario2.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderFalseScenario2.cs
@@ -6,7 +6,7 @@ public class IgnoreOrderFalseScenario2
     public void IgnoreOrderFalseScenario2ShouldFail()
     {
         Verify.ShouldFail(() =>
-                new List<int> { 1, 3, 2 }.ShouldBe(new[] { 1, 2, 3 }, false, "Some additional context"),
+                new List<int> { 1, 3, 2 }.ShouldBe([1, 2, 3], false, "Some additional context"),
 
             errorWithSource:
             """
@@ -39,6 +39,6 @@ public class IgnoreOrderFalseScenario2
     [Fact]
     public void ShouldPass()
     {
-        new List<int> { 1, 2, 3 }.ShouldBe(new[] { 1, 2, 3 }, ignoreOrder: false);
+        new List<int> { 1, 2, 3 }.ShouldBe([1, 2, 3], ignoreOrder: false);
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderIEnumerableMethodYieldBreak.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderIEnumerableMethodYieldBreak.cs
@@ -6,7 +6,7 @@ public class IgnoreOrderIEnumerableMethodYieldBreak
     public void IgnoreOrderIEnumerableMethodYieldBreakShouldFail()
     {
         Verify.ShouldFail(() =>
-                GetEmptyEnumerable().ShouldBe(new[] { 2, 4 }, true, "Some additional context"),
+                GetEmptyEnumerable().ShouldBe([2, 4], true, "Some additional context"),
 
             errorWithSource:
             """

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderIEnumerableMethodYieldReturn.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderIEnumerableMethodYieldReturn.cs
@@ -6,7 +6,7 @@ public class IgnoreOrderIEnumerableMethodYieldReturn
     public void IgnoreOrderIEnumerableMethodYieldReturnShouldFail()
     {
         Verify.ShouldFail(() =>
-                GetEnumerable().ShouldBe(new[] { 1, 2 }, true, "Some additional context"),
+                GetEnumerable().ShouldBe([1, 2], true, "Some additional context"),
 
             errorWithSource:
             """
@@ -40,7 +40,7 @@ public class IgnoreOrderIEnumerableMethodYieldReturn
     [Fact]
     public void ShouldPass()
     {
-        GetEnumerable().ShouldBe(new[] { 1 }, true);
+        GetEnumerable().ShouldBe([1], true);
     }
 
     private static IEnumerable<int> GetEnumerable()

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderScenario.cs
@@ -6,7 +6,7 @@ public class IgnoreOrderScenario
     public void IgnoreOrderScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new List<int> { 1, 4, 2 }.ShouldBe(new[] { 1, 2, 3 }, true, "Some additional context"),
+                new List<int> { 1, 4, 2 }.ShouldBe([1, 2, 3], true, "Some additional context"),
 
             errorWithSource:
             """
@@ -48,6 +48,6 @@ public class IgnoreOrderScenario
     [Fact]
     public void ShouldPass()
     {
-        new List<int> { 1, 3, 2 }.ShouldBe(new[] { 1, 2, 3 }, ignoreOrder: true);
+        new List<int> { 1, 3, 2 }.ShouldBe([1, 2, 3], ignoreOrder: true);
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/IntegerArrayScenario.cs
@@ -6,7 +6,7 @@ public class IntegerArrayScenario
     public void IntegerArrayScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new[] { 99, 2, 3, 5 }.ShouldBe(new[] { 1, 2, 3, 4 }, "Some additional context"),
+                new[] { 99, 2, 3, 5 }.ShouldBe([1, 2, 3, 4], "Some additional context"),
 
             errorWithSource:
             """
@@ -39,6 +39,6 @@ public class IntegerArrayScenario
     [Fact]
     public void ShouldPass()
     {
-        new[] { 1, 2, 3, 4 }.ShouldBe(new[] { 1, 2, 3, 4 });
+        new[] { 1, 2, 3, 4 }.ShouldBe([1, 2, 3, 4]);
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/NonRetraversableEnumerable.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/NonRetraversableEnumerable.cs
@@ -4,10 +4,11 @@ public class NonRetraversableEnumerable
 {
     private static IEnumerable<int> CreateTestEnumerable()
     {
-        var foo = new TestEnumerable(new[] {
+        var foo = new TestEnumerable([
             new[] { 1, 2, 3 },
             new[] { 4, 5, 6 },
-            new[] { 7, 8, 9 } });
+            new[] { 7, 8, 9 }
+        ]);
 
         return foo.ReadLine();
     }
@@ -16,7 +17,7 @@ public class NonRetraversableEnumerable
     public void ActualEnumerableShouldOnlyBeTraversedOnce()
     {
         Verify.ShouldFail(
-            () => CreateTestEnumerable().ShouldBe(new[] { 3, 2, 1 }),
+            () => CreateTestEnumerable().ShouldBe([3, 2, 1]),
             errorWithSource:
             """
             CreateTestEnumerable()
@@ -42,7 +43,7 @@ public class NonRetraversableEnumerable
     public void ActualEnumerableShouldOnlyBeTraversedOnceWhenIgnoringOrder()
     {
         Verify.ShouldFail(
-            () => CreateTestEnumerable().ShouldBe(new[] { 2, 3, 4 }, ignoreOrder: true),
+            () => CreateTestEnumerable().ShouldBe([2, 3, 4], ignoreOrder: true),
             errorWithSource:
             """
             CreateTestEnumerable()
@@ -140,13 +141,13 @@ public class NonRetraversableEnumerable
         var fooEnum = CreateTestEnumerable();
 
         fooEnum.ShouldSatisfyAllConditions(
-            () => fooEnum.ShouldBe(new[] { 1, 2, 3 }),
+            () => fooEnum.ShouldBe([1, 2, 3]),
             () => fooEnum.First().ShouldBe(4),
             () => fooEnum.First().ShouldBe(5),
             () => fooEnum.First().ShouldBe(6),
             () => fooEnum.Any().ShouldBeFalse(),
             () => fooEnum.First().ShouldBe(7),
-            () => fooEnum.ShouldBe(new[] { 8, 9 }));
+            () => fooEnum.ShouldBe([8, 9]));
     }
 
     private class TestEnumerable

--- a/src/Shouldly.Tests/ShouldBe/ShouldBeEnumerableTypeScenarios.cs
+++ b/src/Shouldly.Tests/ShouldBe/ShouldBeEnumerableTypeScenarios.cs
@@ -85,7 +85,7 @@ public class ShouldBeEnumerableTypeScenarios
     public void DifferentOrderWithMissingItemFromExpectedScenario()
     {
         Verify.ShouldFail(() =>
-                new List<int> { 1, 3, 2 }.ShouldBe(new[] { 1, 3 }, true, "Some additional context"),
+                new List<int> { 1, 3, 2 }.ShouldBe([1, 3], true, "Some additional context"),
 
             errorWithSource:
             """
@@ -120,7 +120,7 @@ public class ShouldBeEnumerableTypeScenarios
     public void DifferentOrderWithMissingItemFromActualScenario()
     {
         Verify.ShouldFail(() =>
-                new List<int> { 1, 3 }.ShouldBe(new[] { 1, 2, 3 }, true, "Some additional context"),
+                new List<int> { 1, 3 }.ShouldBe([1, 2, 3], true, "Some additional context"),
 
             errorWithSource:
             """
@@ -155,7 +155,7 @@ public class ShouldBeEnumerableTypeScenarios
     public void DifferentCollectionTypeScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new List<int> { 1, 2, 3 }.ShouldBe(new[] { 1, 3, 2 }, false, "Some additional context"),
+                new List<int> { 1, 2, 3 }.ShouldBe([1, 3, 2], false, "Some additional context"),
 
             errorWithSource:
             """
@@ -191,7 +191,7 @@ public class ShouldBeEnumerableTypeScenarios
         IEnumerable<int>? something = null;
         // ReSharper disable once ExpressionIsAlwaysNull
         Verify.ShouldFail(() =>
-                something.ShouldBe(new[] { 1, 2, 3 }, "Some additional context"),
+                something.ShouldBe([1, 2, 3], "Some additional context"),
 
             errorWithSource:
             """
@@ -231,11 +231,11 @@ public class ShouldBeEnumerableTypeScenarios
 
         IList<IFoo> a = new List<IFoo> { foo };
 
-        a.ShouldBe(new IFoo[] { foo });
+        a.ShouldBe([foo]);
     }
 
     private interface IFoo { }
     private class Foo : IFoo { }
-    private readonly List<string> _thisOtherStringList = new() { "1", "3" };
-    private readonly List<string> _thisString = new() { "1", "2" };
+    private readonly List<string> _thisOtherStringList = ["1", "3"];
+    private readonly List<string> _thisString = ["1", "2"];
 }

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfDoubleScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfDoubleScenario.cs
@@ -7,7 +7,7 @@ public class EnumerableOfDoubleScenario
     public void EnumerableOfDoubleScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new[] { MathEx.PI, MathEx.PI }.ShouldBe(new[] { 3.24, 3.24 }, 0.01, "Some additional context"),
+                new[] { MathEx.PI, MathEx.PI }.ShouldBe([3.24, 3.24], 0.01, "Some additional context"),
 
             errorWithSource:
             """
@@ -44,6 +44,6 @@ public class EnumerableOfDoubleScenario
     [Fact]
     public void ShouldPass()
     {
-        new[] { MathEx.PI, MathEx.PI }.ShouldBe(new[] { 3.14, 3.14 }, 0.01);
+        new[] { MathEx.PI, MathEx.PI }.ShouldBe([3.14, 3.14], 0.01);
     }
 }

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfFloatScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/EnumerableOfFloatScenario.cs
@@ -7,7 +7,7 @@ public class EnumerableOfFloatScenario
     public void EnumerableOfFloatScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new[] { (float)MathEx.PI, (float)MathEx.PI }.ShouldBe(new[] { 3.24f, 3.24f }, 0.01, "Some additional context"),
+                new[] { (float)MathEx.PI, (float)MathEx.PI }.ShouldBe([3.24f, 3.24f], 0.01, "Some additional context"),
 
             errorWithSource:
             """
@@ -44,6 +44,6 @@ public class EnumerableOfFloatScenario
     [Fact]
     public void ShouldPass()
     {
-        new[] { (float)MathEx.PI, (float)MathEx.PI }.ShouldBe(new[] { 3.14f, 3.14f }, 0.01);
+        new[] { (float)MathEx.PI, (float)MathEx.PI }.ShouldBe([3.14f, 3.14f], 0.01);
     }
 }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -145,13 +145,13 @@ public class ObjectScenario
             Id = 5,
             Name = "Bob",
             Adjectives = new[] { "funny", "wise" },
-            Colors = new[] { "red", "blue" },
+            Colors = ["red", "blue"],
             Child = new()
             {
                 Id = 6,
                 Name = "Sally",
                 Adjectives = new[] { "ugly", "intelligent" },
-                Colors = new[] { "purple", "orange" }
+                Colors = ["purple", "orange"]
             }
         };
 
@@ -160,13 +160,13 @@ public class ObjectScenario
             Id = 5,
             Name = "Bob",
             Adjectives = new[] { "funny", "wise" },
-            Colors = new[] { "red", "blue" },
+            Colors = ["red", "blue"],
             Child = new()
             {
                 Id = 6,
                 Name = "Sally",
                 Adjectives = new[] { "beautiful", "intelligent" },
-                Colors = new[] { "purple", "orange" }
+                Colors = ["purple", "orange"]
             }
         };
 
@@ -216,13 +216,13 @@ public class ObjectScenario
             Id = 5,
             Name = "Bob",
             Adjectives = new[] { "funny", "wise" },
-            Colors = new[] { "red", "blue" },
+            Colors = ["red", "blue"],
             Child = new()
             {
                 Id = 6,
                 Name = "Sally",
                 Adjectives = new[] { "beautiful", "intelligent" },
-                Colors = new[] { "purple", "orange" }
+                Colors = ["purple", "orange"]
             }
         };
         subject.Child.Child = subject;
@@ -232,13 +232,13 @@ public class ObjectScenario
             Id = 5,
             Name = "Bob",
             Adjectives = new[] { "funny", "wise" },
-            Colors = new[] { "red", "blue" },
+            Colors = ["red", "blue"],
             Child = new()
             {
                 Id = 6,
                 Name = "Sally",
                 Adjectives = new[] { "beautiful", "dumb" },
-                Colors = new[] { "purple", "orange" }
+                Colors = ["purple", "orange"]
             }
         };
         expected.Child.Child = expected;
@@ -296,14 +296,14 @@ public class ObjectScenario
             Id = 5,
             Name = "Bob",
             Adjectives = new[] { "funny", "wise" },
-            Colors = new[] { "red", "blue" },
+            Colors = ["red", "blue"],
             TitleField = "Mr",
             Child = new()
             {
                 Id = 6,
                 Name = "Sally",
                 Adjectives = new[] { "beautiful", "intelligent" },
-                Colors = new[] { "purple", "orange" }
+                Colors = ["purple", "orange"]
             }
         };
 
@@ -313,13 +313,13 @@ public class ObjectScenario
             TitleField = "Mr",
             Name = "Bob",
             Adjectives = new[] { "funny", "wise" },
-            Colors = new[] { "red", "blue" },
+            Colors = ["red", "blue"],
             Child = new()
             {
                 Id = 6,
                 Name = "Sally",
                 Adjectives = new[] { "beautiful", "intelligent" },
-                Colors = new[] { "purple", "orange" }
+                Colors = ["purple", "orange"]
             }
         };
 
@@ -334,7 +334,7 @@ public class ObjectScenario
             Id = 5,
             Name = "Bob",
             Adjectives = new[] { "funny", "wise" },
-            Colors = new[] { "red", "blue" }
+            Colors = ["red", "blue"]
         };
         subject.Child = subject;
 
@@ -343,7 +343,7 @@ public class ObjectScenario
             Id = 5,
             Name = "Bob",
             Adjectives = new[] { "funny", "wise" },
-            Colors = new[] { "red", "blue" }
+            Colors = ["red", "blue"]
         };
         expected.Child = expected;
 

--- a/src/Shouldly.Tests/ShouldBeInOrder/DoubleArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/DoubleArrayScenario.cs
@@ -2,8 +2,8 @@
 
 public class DoubleArrayScenario
 {
-    private readonly double[] _ascendingTarget = { 1.1, 1.2, 1.3, 1.4, 1.5 };
-    private readonly double[] _descendingTarget = { 1.5, 1.4, 1.3, 1.2, 1.1 };
+    private readonly double[] _ascendingTarget = [1.1, 1.2, 1.3, 1.4, 1.5];
+    private readonly double[] _descendingTarget = [1.5, 1.4, 1.3, 1.2, 1.1];
 
     [Fact]
     [UseCulture("en-US")]

--- a/src/Shouldly.Tests/ShouldBeInOrder/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/IntegerArrayScenario.cs
@@ -2,8 +2,8 @@
 
 public class IntegerArrayScenario
 {
-    private readonly int[] _ascendingTarget = { 1, 2, 3, 4, 5 };
-    private readonly int[] _descendingTarget = { 5, 4, 3, 2, 1 };
+    private readonly int[] _ascendingTarget = [1, 2, 3, 4, 5];
+    private readonly int[] _descendingTarget = [5, 4, 3, 2, 1];
 
     [Fact]
     public void ShouldFailWithDefaultDirection()

--- a/src/Shouldly.Tests/ShouldBeInOrder/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeInOrder/StringArrayScenario.cs
@@ -2,8 +2,8 @@
 
 public class StringArrayScenario
 {
-    private readonly string[] _ascendingTarget = { "a", "b", "c", "d", "e" };
-    private readonly string[] _descendingTarget = { "e", "d", "c", "b", "a" };
+    private readonly string[] _ascendingTarget = ["a", "b", "c", "d", "e"];
+    private readonly string[] _descendingTarget = ["e", "d", "c", "b", "a"];
 
     [Fact]
     public void ShouldFailWithDefaultDirection()

--- a/src/Shouldly.Tests/ShouldBeOfTypes/BasicScenarios.cs
+++ b/src/Shouldly.Tests/ShouldBeOfTypes/BasicScenarios.cs
@@ -15,14 +15,14 @@ public class BasicScenarios
     {
         var arr = new object[] { new Added(), new Changed(), new Removed() };
 
-        arr.ShouldBeOfTypes(new[] { typeof(Added), typeof(Changed), typeof(Removed) }, "additional context");
+        arr.ShouldBeOfTypes([typeof(Added), typeof(Changed), typeof(Removed)], "additional context");
     }
 
     [Fact]
     public void FailsIfTypesDontMatchExactly()
     {
         Verify.ShouldFail(() =>
-                new object[] { new Added(), new Changed() }.ShouldBeOfTypes(new[] { typeof(Added), typeof(object) }, "Some additional context"),
+                new object[] { new Added(), new Changed() }.ShouldBeOfTypes([typeof(Added), typeof(object)], "Some additional context"),
 
             errorWithSource:
             """
@@ -54,7 +54,7 @@ Additional Info:
     public void FailsIfActualAndExpectedAreDifferentLengths()
     {
         Verify.ShouldFail(() =>
-                new object[] { new Added(), new Changed() }.ShouldBeOfTypes(new[] { typeof(Added) }, "Some additional context"),
+                new object[] { new Added(), new Changed() }.ShouldBeOfTypes([typeof(Added)], "Some additional context"),
 
             errorWithSource:
             """

--- a/src/Shouldly.Tests/ShouldBeOneOf/EnumScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeOneOf/EnumScenario.cs
@@ -7,7 +7,7 @@ public class EnumScenario
     {
         var someFlags = SomeFlags.Val1;
         Verify.ShouldFail(() =>
-                someFlags.ShouldBeOneOf(new[] { SomeFlags.Val2 }, "Some additional context"),
+                someFlags.ShouldBeOneOf([SomeFlags.Val2], "Some additional context"),
 
             errorWithSource:
             """

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/DecimalArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/DecimalArrayScenario.cs
@@ -6,7 +6,7 @@ public class DecimalArrayScenario
     public void DecimalArrayScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new[] { 1m, 2m, 5m }.ShouldBeSubsetOf(new[] { 2m, 3m, 4m }, "Some additional context"),
+                new[] { 1m, 2m, 5m }.ShouldBeSubsetOf([2m, 3m, 4m], "Some additional context"),
 
             errorWithSource:
             """
@@ -38,6 +38,6 @@ public class DecimalArrayScenario
     [Fact]
     public void ShouldPass()
     {
-        new[] { 1m }.ShouldBeSubsetOf(new[] { 1m, 2m, 3m });
+        new[] { 1m }.ShouldBeSubsetOf([1m, 2m, 3m]);
     }
 }

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/FloatArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/FloatArrayScenario.cs
@@ -6,7 +6,7 @@ public class FloatArrayScenario
     public void FloatArrayScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new[] { 1f, 2f, 5f }.ShouldBeSubsetOf(new[] { 2f, 3f, 4f }, "Some additional context"),
+                new[] { 1f, 2f, 5f }.ShouldBeSubsetOf([2f, 3f, 4f], "Some additional context"),
 
             errorWithSource:
             """
@@ -38,6 +38,6 @@ public class FloatArrayScenario
     [Fact]
     public void ShouldPass()
     {
-        new[] { 1f }.ShouldBeSubsetOf(new[] { 1f, 2f, 3f });
+        new[] { 1f }.ShouldBeSubsetOf([1f, 2f, 3f]);
     }
 }

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/IntegerArrayScenario.cs
@@ -6,7 +6,7 @@ public class IntegerArrayScenario
     public void IntegerArrayScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new[] { 1, 2, 5 }.ShouldBeSubsetOf(new[] { 2, 3, 4 }, "Some additional context"),
+                new[] { 1, 2, 5 }.ShouldBeSubsetOf([2, 3, 4], "Some additional context"),
 
             errorWithSource:
             """
@@ -38,6 +38,6 @@ public class IntegerArrayScenario
     [Fact]
     public void ShouldPass()
     {
-        new[] { 1 }.ShouldBeSubsetOf(new[] { 1, 2, 3 });
+        new[] { 1 }.ShouldBeSubsetOf([1, 2, 3]);
     }
 }

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/StringArrayScenario.cs
@@ -6,7 +6,7 @@ public class StringArrayScenario
     public void StringArrayScenarioShouldFail()
     {
         Verify.ShouldFail(() =>
-                new[] { "1", "2", "3" }.ShouldBeSubsetOf(new[] { "1", "2" }, "Some additional context"),
+                new[] { "1", "2", "3" }.ShouldBeSubsetOf(["1", "2"], "Some additional context"),
 
             errorWithSource:
             """
@@ -38,6 +38,6 @@ public class StringArrayScenario
     [Fact]
     public void ShouldPass()
     {
-        new[] { "1", "2", "3" }.ShouldBeSubsetOf(new[] { "1", "2", "3", "4" });
+        new[] { "1", "2", "3" }.ShouldBeSubsetOf(["1", "2", "3", "4"]);
     }
 }

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/SuccessScenarios.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/SuccessScenarios.cs
@@ -13,6 +13,6 @@ public class SuccessScenarios
     [Fact]
     public void EmptyArrayIsSubsetOfAnything()
     {
-        new int[0].ShouldBeSubsetOf(new[] { 1, 2, 3, 4 }, "Some additional context");
+        new int[0].ShouldBeSubsetOf([1, 2, 3, 4], "Some additional context");
     }
 }

--- a/src/Shouldly.Tests/ShouldCompleteInTests.cs
+++ b/src/Shouldly.Tests/ShouldCompleteInTests.cs
@@ -1,11 +1,9 @@
-﻿namespace Shouldly.Tests;
+﻿using static Shouldly.Tests.CommonWaitDurations;
+
+namespace Shouldly.Tests;
 
 public class ShouldCompleteInTests
 {
-    private static readonly TimeSpan ShortWait = TimeSpan.FromSeconds(0.5);
-    private static readonly TimeSpan LongWait = TimeSpan.FromSeconds(15);
-    private static readonly TimeSpan ImmediateTaskTimeout = TimeSpan.FromSeconds(2);
-    
     [Fact]
     public void ShouldCompleteIn_WhenFinishBeforeTimeout()
     {
@@ -25,10 +23,10 @@ public class ShouldCompleteInTests
                 "Some additional context"));
 
       ex.Message.ShouldContainWithoutWhitespace(
-            """
+            $"""
             Delegate
                 should complete in
-            00:00:00.5000000
+            {ShortWait}
                 but did not
             Additional Info:
             Some additional context
@@ -46,10 +44,10 @@ public class ShouldCompleteInTests
                 "Some additional context"));
 
         ex.Message.ShouldContainWithoutWhitespace(
-            """
+            $"""
             Task
                 should complete in
-            00:00:00.5000000
+            {ShortWait}
                 but did not
             Additional Info:
             Some additional context
@@ -92,10 +90,10 @@ public class ShouldCompleteInTests
                 "Some additional context"));
 
         ex.Message.ShouldContainWithoutWhitespace(
-            """
+            $"""
             Delegate
                 should complete in
-            00:00:00.5000000
+            {ShortWait}
                 but did not
             Additional Info:
             Some additional context
@@ -119,10 +117,10 @@ public class ShouldCompleteInTests
                 "Some additional context"));
 
         ex.Message.ShouldContainWithoutWhitespace(
-            """
+            $"""
             Task
                 should complete in
-            00:00:00.5000000
+            {ShortWait}
                 but did not
             Additional Info:
             Some additional context

--- a/src/Shouldly.Tests/ShouldContain/IntegerScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/IntegerScenario.cs
@@ -2,7 +2,7 @@
 
 public class IntegerScenario
 {
-    private readonly int[] _target = { 1, 2, 3, 4, 5 };
+    private readonly int[] _target = [1, 2, 3, 4, 5];
 
     [Fact]
     public void IntegerScenarioShouldFail()

--- a/src/Shouldly.Tests/ShouldContain/IntegerWithNegativeValuesScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/IntegerWithNegativeValuesScenario.cs
@@ -2,7 +2,7 @@
 
 public class IntegerWithNegativeValuesScenario
 {
-    private readonly int[] _target = { 2, 3, 4, 5, 4, 123665, 11234, -13562377 };
+    private readonly int[] _target = [2, 3, 4, 5, 4, 123665, 11234, -13562377];
 
     [Fact]
     public void IntegerWithNegativeValuesScenarioShouldFail()

--- a/src/Shouldly.Tests/ShouldContain/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/ObjectScenario.cs
@@ -9,7 +9,7 @@ public class ObjectScenario
         var b = new object();
         var c = new object();
         var d = new object();
-        var target = new[] { a, b, c };
+        object[] target = [a, b, c];
 
         Verify.ShouldFail(() =>
                 target.ShouldContain(d, "Some additional context"),
@@ -44,7 +44,7 @@ public class ObjectScenario
         var a = new object();
         var b = new object();
         var c = new object();
-        var target = new[] { a, b, c };
+        object[] target = [a, b, c];
         target.ShouldContain(b);
     }
 }

--- a/src/Shouldly.Tests/ShouldContain/PredicateClosureScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/PredicateClosureScenario.cs
@@ -6,7 +6,7 @@ public class PredicateClosureScenario
     public void PredicateClosureScenarioShouldFail()
     {
         var capturedOuterVar = 4;
-        var arr = new[] { 1, 2, 3 };
+        int[] arr = [1, 2, 3];
         Verify.ShouldFail(() =>
                 arr.ShouldContain(i => i > capturedOuterVar, "Some additional context"),
 

--- a/src/Shouldly.Tests/ShouldContain/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/StringArrayScenario.cs
@@ -2,7 +2,7 @@
 
 public class StringArrayScenario
 {
-    private readonly string[] _target = { "a", "b", "c" };
+    private readonly string[] _target = ["a", "b", "c"];
 
     [Fact]
     public void StringArrayScenarioShouldFail()

--- a/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
+++ b/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
@@ -165,7 +165,7 @@ Actual Code    | 70   111  111  ",
     [Fact]
     public async Task CanFindTestAttributeInAsync()
     {
-        await Task.Delay(200);
+        await Task.Yield();
 
         "testAttributes".ShouldMatchApproved(b => b.LocateTestMethodUsingAttribute<FactAttribute>());
     }
@@ -173,7 +173,7 @@ Actual Code    | 70   111  111  ",
     [Fact]
     public async Task HandlesAsync()
     {
-        await Task.Delay(200);
+        await Task.Yield();
 
         "Foo".ShouldMatchApproved();
     }

--- a/src/Shouldly.Tests/ShouldNotBeOneOf/EnumScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBeOneOf/EnumScenario.cs
@@ -7,7 +7,7 @@ public class EnumScenario
     {
         var someFlags = SomeFlags.Val1;
         Verify.ShouldFail(() =>
-                someFlags.ShouldNotBeOneOf(new[] { SomeFlags.Val1 }, "Some additional context"),
+                someFlags.ShouldNotBeOneOf([SomeFlags.Val1], "Some additional context"),
 
             errorWithSource:
             """

--- a/src/Shouldly.Tests/ShouldNotContain/IntegerScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/IntegerScenario.cs
@@ -2,7 +2,7 @@
 
 public class IntegerScenario
 {
-    private readonly int[] _target = { 1, 2, 3, 4, 5 };
+    private readonly int[] _target = [1, 2, 3, 4, 5];
 
     [Fact]
     public void IntegerScenarioShouldFail()

--- a/src/Shouldly.Tests/ShouldNotContain/IntegerWithNegativeValuesScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/IntegerWithNegativeValuesScenario.cs
@@ -2,7 +2,7 @@
 
 public class IntegerWithNegativeValuesScenario
 {
-    private readonly int[] _target = { 2, 3, 4, 5, 4, 123665, 11234, -13562377 };
+    private readonly int[] _target = [2, 3, 4, 5, 4, 123665, 11234, -13562377];
 
     [Fact]
     public void IntegerWithNegativeValuesScenarioShouldFail()

--- a/src/Shouldly.Tests/ShouldNotContain/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotContain/StringArrayScenario.cs
@@ -2,7 +2,7 @@
 
 public class StringArrayScenario
 {
-    private readonly string[] _target = { "a", "b", "c" };
+    private readonly string[] _target = ["a", "b", "c"];
 
     [Fact]
     public void StringArrayScenarioShouldFail()

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfTWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfTWithTimeoutScenario.cs
@@ -2,12 +2,12 @@ namespace Shouldly.Tests.ShouldNotThrow;
 
 public class FuncOfTaskOfTWithTimeoutScenario
 {
-    [Fact(Skip = "TODO: flaky test")]
+    [Fact]
     public void ShouldThrowAWobbly()
     {
         var task = Task.Run(async () =>
         {
-            await Task.Delay(TimeSpan.FromSeconds(5));
+            await Task.Delay(TimeSpan.FromSeconds(15));
             return "foo";
         });
 

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfTWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskOfTWithTimeoutScenario.cs
@@ -1,3 +1,5 @@
+using static Shouldly.Tests.CommonWaitDurations;
+
 namespace Shouldly.Tests.ShouldNotThrow;
 
 public class FuncOfTaskOfTWithTimeoutScenario
@@ -7,21 +9,21 @@ public class FuncOfTaskOfTWithTimeoutScenario
     {
         var task = Task.Run(async () =>
         {
-            await Task.Delay(TimeSpan.FromSeconds(15));
+            await Task.Delay(LongWait);
             return "foo";
         });
 
         var ex = Should.Throw<ShouldCompleteInException>(() =>
-            task.ShouldNotThrow(TimeSpan.FromSeconds(0.5), "Some additional context"));
+            task.ShouldNotThrow(ShortWait, "Some additional context"));
 
         ex.Message.ShouldContainWithoutWhitespace(ChuckedAWobblyErrorMessage);
     }
 
     private string ChuckedAWobblyErrorMessage =
-        """
+        $"""
         Task
                 should complete in
-            00:00:00.5000000
+            {ShortWait}
                 but did not
             Additional Info:
             Some additional context
@@ -32,7 +34,7 @@ public class FuncOfTaskOfTWithTimeoutScenario
     {
         var task = Task.Run(() => "foo");
 
-        var result = task.ShouldNotThrow(TimeSpan.FromSeconds(15));
+        var result = task.ShouldNotThrow(LongWait);
         result.ShouldBe("foo");
     }
 }

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
@@ -6,7 +6,7 @@ public class FuncOfTaskScenario
     [UseCulture("en-US")]
     public void FuncOfTaskScenarioShouldFail()
     {
-        var task = Task.Run(() => throw new RankException());
+        var task = Task.FromException(new RankException());
 
         Verify.ShouldFail(() =>
                 task.ShouldNotThrow("Some additional context"),
@@ -39,7 +39,7 @@ public class FuncOfTaskScenario
     [Fact]
     public void ShouldPass()
     {
-        var task = Task.Run(() => { });
+        var task = Task.CompletedTask;
 
         task.ShouldNotThrow();
     }

--- a/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/FuncOfTaskScenario.cs
@@ -6,7 +6,7 @@ public class FuncOfTaskScenario
     [UseCulture("en-US")]
     public void FuncOfTaskScenarioShouldFail()
     {
-        var task = Task.FromException(new RankException());
+        var task = Task.Run(() => throw new RankException());
 
         Verify.ShouldFail(() =>
                 task.ShouldNotThrow("Some additional context"),
@@ -39,7 +39,7 @@ public class FuncOfTaskScenario
     [Fact]
     public void ShouldPass()
     {
-        var task = Task.CompletedTask;
+        var task = Task.Run(() => { });
 
         task.ShouldNotThrow();
     }

--- a/src/Shouldly.Tests/ShouldNotThrow/TaskOfTWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/TaskOfTWithTimeoutScenario.cs
@@ -1,3 +1,5 @@
+using static Shouldly.Tests.CommonWaitDurations;
+
 namespace Shouldly.Tests.ShouldNotThrow;
 
 public class TaskOfTWithTimeoutScenario
@@ -7,7 +9,7 @@ public class TaskOfTWithTimeoutScenario
     {
         var task = Task.Run(async () =>
             {
-                await Task.Delay(TimeSpan.FromSeconds(15));
+                await Task.Delay(LongWait);
                 return "foo";
             });
 
@@ -31,7 +33,7 @@ public class TaskOfTWithTimeoutScenario
     {
         var task = Task.Run(() => "foo");
 
-        var result = task.ShouldNotThrow(TimeSpan.FromSeconds(15));
+        var result = task.ShouldNotThrow(LongWait);
         result.ShouldBe("foo");
     }
 }

--- a/src/Shouldly.Tests/ShouldNotThrow/TaskOfTWithTimeoutScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotThrow/TaskOfTWithTimeoutScenario.cs
@@ -5,9 +5,9 @@ public class TaskOfTWithTimeoutScenario
     [Fact]
     public void ShouldThrowAWobbly()
     {
-        var task = Task.Run(() =>
+        var task = Task.Run(async () =>
             {
-                Task.Delay(5000).Wait();
+                await Task.Delay(TimeSpan.FromSeconds(15));
                 return "foo";
             });
 

--- a/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
+++ b/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.Time.Testing;
+﻿#if NET8_0_OR_GREATER
+using Microsoft.Extensions.Time.Testing;
+#endif
 using Xunit.Sdk;
 
 namespace Shouldly.Tests.ShouldThrowAsync;
@@ -25,6 +27,7 @@ public class FuncOfTaskScenarioAsync
         }
     }
 
+#if NET8_0_OR_GREATER
     [Fact]
     public async Task ShouldThrowAWobbly_WhenATaskIsCancelled()
     {
@@ -42,6 +45,7 @@ public class FuncOfTaskScenarioAsync
         // Assert.
         result.ShouldNotBeNull();
     }
+#endif
 
     [Fact]
     public async Task ShouldThrowAWobbly_ExceptionTypePassedIn()

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -15,12 +15,14 @@
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.6.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
     <Reference Include="System.Runtime" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
     <Reference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 </Project>

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0;net48</TargetFrameworks>
     <Optimize>false</Optimize>
-    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="**\*.approved.cs;**\*.received.cs" />
@@ -23,7 +22,6 @@
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
     <Reference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 </Project>

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0;net48</TargetFrameworks>
     <Optimize>false</Optimize>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="**\*.approved.cs;**\*.received.cs" />

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.6.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="Polyfill" Version="5.6.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.6.0" />

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0;net48</TargetFrameworks>
     <Optimize>false</Optimize>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="**\*.approved.cs;**\*.received.cs" />

--- a/src/Shouldly.Tests/ShouldlyWebsiteExampleTests.cs
+++ b/src/Shouldly.Tests/ShouldlyWebsiteExampleTests.cs
@@ -34,12 +34,12 @@ public class ShouldlyWebsiteExampleTests
     {
         private static IList<string> GetMap()
         {
-            return new[]
-            {
+            return
+            [
                 "aoo",
                 "boo",
                 "coo"
-            };
+            ];
         }
 
         [Fact]
@@ -67,14 +67,14 @@ public class ShouldlyWebsiteExampleTests
         public void Shouldly_CompareTwoCollections()
         {
             TestHelpers.Should.Error(
-                () => new[] { 1, 2, 3 }.ShouldBe(new[] { 1, 2, 4 }),
+                () => new[] { 1, 2, 3 }.ShouldBe([1, 2, 4]),
                 "new[] {1, 2, 3} should be [1, 2, 4] but was [1, 2, 3] difference [1, 2, *3*]");
         }
 
         [Fact]
         public void Shouldly_CompareTwoCollections_HappyPath()
         {
-            new[] { 1, 2, 3 }.ShouldBe(new[] { 1, 2, 3 });
+            new[] { 1, 2, 3 }.ShouldBe([1, 2, 3]);
         }
     }
 

--- a/src/Shouldly.Tests/StackTraceTests.ExceptionThrower.cs
+++ b/src/Shouldly.Tests/StackTraceTests.ExceptionThrower.cs
@@ -1,4 +1,6 @@
-﻿namespace Shouldly.Tests;
+﻿using System.Diagnostics;
+
+namespace Shouldly.Tests;
 
 partial class StackTraceTests
 {
@@ -19,18 +21,19 @@ partial class StackTraceTests
             InShouldlyAssembly ? ThrowingAction.Method.Name :
                 ExceptionType.Name + " thrown directly";
 
-        public Exception? Catch()
+        public Exception Catch()
         {
             // Don’t rely on a framework for this in case of the outside chance that the framework manipulates the stack trace.
             try
             {
                 ThrowingAction.Invoke();
-                return null;
             }
             catch (Exception ex) when (ex.GetType() == ExceptionType)
             {
                 return ex;
             }
+
+            throw new UnreachableException($"`ExceptionThrower.Catch` should always catch and return an exception. In this case, ThrowingAction did not throw the expected exception (`{ExceptionType}`).");
         }
     }
 }

--- a/src/Shouldly.Tests/StackTraceTests.ExceptionThrower.cs
+++ b/src/Shouldly.Tests/StackTraceTests.ExceptionThrower.cs
@@ -33,7 +33,7 @@ partial class StackTraceTests
                 return ex;
             }
 
-            throw new UnreachableException($"`ExceptionThrower.Catch` should always catch and return an exception. In this case, ThrowingAction did not throw the expected exception (`{ExceptionType}`).");
+            throw new UnreachableException($"`ExceptionThrower.Catch` should always catch and return an exception. In this case, `ThrowingAction` did not throw the expected exception (`{ExceptionType}`).");
         }
     }
 }

--- a/src/Shouldly.Tests/StackTraceTests.ExceptionThrowerCollectionBuilder.cs
+++ b/src/Shouldly.Tests/StackTraceTests.ExceptionThrowerCollectionBuilder.cs
@@ -4,7 +4,7 @@ partial class StackTraceTests
 {
     private sealed class ExceptionThrowerCollectionBuilder
     {
-        private readonly List<ExceptionThrower> exceptionThrowers = new();
+        private readonly List<ExceptionThrower> exceptionThrowers = [];
 
         /// <param name="throwDirectly">Required to cover the code path where the stack trace is not trimmed.</param>
         /// <param name="throwInShouldlyAssembly">Required to cover the code path where the stack trace is trimmed.</param>

--- a/src/Shouldly.Tests/StackTraceTests.cs
+++ b/src/Shouldly.Tests/StackTraceTests.cs
@@ -2,7 +2,7 @@
 
 public static partial class StackTraceTests
 {
-    [Theory(Skip = "flaky test. intermittent null ref")]
+    [Theory]
     [MemberData(nameof(ExceptionThrowers))]
     public static void Top_stack_frame_is_user_code(ExceptionThrower exceptionThrower)
     {
@@ -13,7 +13,7 @@ public static partial class StackTraceTests
         stackTraceLines.First().ShouldContain(exceptionThrower.ThrowingAction.Method.Name);
     }
 
-    [Theory(Skip = "flaky test. intermittent null ref")]
+    [Theory]
     [MemberData(nameof(ExceptionThrowers))]
     public static void Stack_trace_is_trimmed_the_same_as_default_exception_stack_traces(ExceptionThrower exceptionThrower)
     {

--- a/src/Shouldly.Tests/StackTraceTests.cs
+++ b/src/Shouldly.Tests/StackTraceTests.cs
@@ -8,7 +8,7 @@ public static partial class StackTraceTests
     {
         var exception = exceptionThrower.Catch()!;
 
-        var stackTraceLines = exception.StackTrace!.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        var stackTraceLines = exception.StackTrace!.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
 
         stackTraceLines.First().ShouldContain(exceptionThrower.ThrowingAction.Method.Name);
     }
@@ -17,8 +17,8 @@ public static partial class StackTraceTests
     [MemberData(nameof(ExceptionThrowers))]
     public static void Stack_trace_is_trimmed_the_same_as_default_exception_stack_traces(ExceptionThrower exceptionThrower)
     {
-        var shouldlyException = exceptionThrower.Catch()!;
-        var defaultException = new ExceptionThrower(typeof(Exception), false, () => throw new()).Catch()!;
+        var shouldlyException = exceptionThrower.Catch();
+        var defaultException = new ExceptionThrower(typeof(Exception), false, () => throw new()).Catch();
 
         var shouldlyEndingWhitespace = GetEndingWhitespace(shouldlyException.StackTrace!);
         var defaultEndingWhitespace = GetEndingWhitespace(defaultException.StackTrace!);

--- a/src/Shouldly.Tests/StackTraceTests.cs
+++ b/src/Shouldly.Tests/StackTraceTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Shouldly.Tests;
+﻿using static Shouldly.Tests.CommonWaitDurations;
+
+namespace Shouldly.Tests;
 
 public static partial class StackTraceTests
 {
@@ -29,16 +31,16 @@ public static partial class StackTraceTests
     private static string GetEndingWhitespace(string value) =>
         value[value.TrimEnd().Length..];
 
-    public static IEnumerable<object[]> ExceptionThrowers()
+    public static TheoryData<ExceptionThrower> ExceptionThrowers()
     {
-        return new ExceptionThrowerCollectionBuilder()
+        return new TheoryData<ExceptionThrower>(new ExceptionThrowerCollectionBuilder()
             .Add<ShouldAssertException>(
                 throwDirectly: () => throw new ShouldAssertException(null),
-                throwInShouldlyAssembly: new Action[]
-                {
+                throwInShouldlyAssembly:
+                [
                     FailingUserCode_ShouldBeTrue,
                     FailingUserCode_ShouldContain
-                })
+                ])
 
             .Add<ShouldlyTimeoutException>(
                 throwDirectly: () => throw new ShouldlyTimeoutException(null, null))
@@ -50,8 +52,7 @@ public static partial class StackTraceTests
             .Add<ShouldMatchApprovedException>(
                 throwDirectly: () => throw new ShouldMatchApprovedException(null, null, null))
 
-            .Build()
-            .Select(exceptionThrower => new object[] { exceptionThrower });
+            .Build());
     }
 
     private static void FailingUserCode_ShouldBeTrue()
@@ -68,6 +69,6 @@ public static partial class StackTraceTests
     private static void FailingUserCode_CompleteIn()
     {
         // Throws a different exception type
-        Should.CompleteIn(Task.Delay(15), TimeSpan.Zero);
+        Should.CompleteIn(Task.Delay(LongWait), TimeSpan.Zero);
     }
 }

--- a/src/Shouldly/ShouldStaticClasses/ShouldCompleteInExtensions.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldCompleteInExtensions.cs
@@ -1,8 +1,16 @@
-﻿namespace Shouldly;
+﻿using System.Runtime.ExceptionServices;
+
+namespace Shouldly;
 
 public static partial class Should
 {
-    /*** CompleteIn(Action) ***/
+    /// <summary>
+    /// Asserts that the given action completes within the specified timeout.
+    /// </summary>
+    /// <param name="action">The action to execute.</param>
+    /// <param name="timeout">The maximum time allowed for the action to complete.</param>
+    /// <param name="customMessage">Optional custom message to use if the assertion fails.</param>
+    /// <exception cref="ShouldCompleteInException">Thrown when the action does not complete within the specified timeout.</exception>
     public static void CompleteIn(Action action, TimeSpan timeout, string? customMessage = null)
     {
         var actual = Task.Factory.StartNew(action, CancellationToken.None, TaskCreationOptions.None,
@@ -10,36 +18,72 @@ public static partial class Should
         CompleteIn(actual, timeout, customMessage, "Delegate");
     }
 
-    /*** CompleteIn(Func<T>) ***/
+    /// <summary>
+    /// Asserts that the given function completes within the specified timeout and returns its result.
+    /// </summary>
+    /// <typeparam name="T">The type of the result returned by the function.</typeparam>
+    /// <param name="function">The function to execute.</param>
+    /// <param name="timeout">The maximum time allowed for the function to complete.</param>
+    /// <param name="customMessage">Optional custom message to use if the assertion fails.</param>
+    /// <returns>The result of the function if it completes within the timeout.</returns>
+    /// <exception cref="ShouldCompleteInException">Thrown when the function does not complete within the specified timeout.</exception>
     public static T CompleteIn<T>(Func<T> function, TimeSpan timeout, string? customMessage = null)
     {
         var actual = Task.Factory.StartNew(function, CancellationToken.None, TaskCreationOptions.None,
             TaskScheduler.Default);
         CompleteIn(actual, timeout, customMessage, "Delegate");
-        return actual.Result;
+        return actual.GetAwaiter().GetResult();
     }
 
-    /*** CompleteIn(Func<Task>) ***/
+    /// <summary>
+    /// Asserts that the given asynchronous function completes within the specified timeout.
+    /// </summary>
+    /// <param name="actual">The asynchronous function to execute.</param>
+    /// <param name="timeout">The maximum time allowed for the function to complete.</param>
+    /// <param name="customMessage">Optional custom message to use if the assertion fails.</param>
+    /// <exception cref="ShouldCompleteInException">Thrown when the function does not complete within the specified timeout.</exception>
     public static void CompleteIn(Func<Task> actual, TimeSpan timeout, string? customMessage = null)
     {
         CompleteIn(actual(), timeout, customMessage, "Task");
     }
 
-    /*** CompleteIn(Func<Task<T>>) ***/
+    /// <summary>
+    /// Asserts that the given asynchronous function completes within the specified timeout and returns its result.
+    /// </summary>
+    /// <typeparam name="T">The type of the result returned by the asynchronous function.</typeparam>
+    /// <param name="actual">The asynchronous function to execute.</param>
+    /// <param name="timeout">The maximum time allowed for the function to complete.</param>
+    /// <param name="customMessage">Optional custom message to use if the assertion fails.</param>
+    /// <returns>The result of the asynchronous function if it completes within the timeout.</returns>
+    /// <exception cref="ShouldCompleteInException">Thrown when the function does not complete within the specified timeout.</exception>
     public static T CompleteIn<T>(Func<Task<T>> actual, TimeSpan timeout, string? customMessage = null)
     {
         var task = actual();
         CompleteIn(task, timeout, customMessage, "Task");
-        return task.Result;
+        return task.GetAwaiter().GetResult();
     }
 
-    /*** CompleteIn(Task<T>) ***/
+    /// <summary>
+    /// Asserts that the given task completes within the specified timeout.
+    /// </summary>
+    /// <param name="actual">The task to wait for completion.</param>
+    /// <param name="timeout">The maximum time allowed for the task to complete.</param>
+    /// <param name="customMessage">Optional custom message to use if the assertion fails.</param>
+    /// <exception cref="ShouldCompleteInException">Thrown when the task does not complete within the specified timeout.</exception>
     public static void CompleteIn(Task actual, TimeSpan timeout, string? customMessage = null)
     {
         CompleteIn(actual, timeout, customMessage, "Task");
     }
 
-    /*** CompleteIn(Task<T>) ***/
+    /// <summary>
+    /// Asserts that the given task completes within the specified timeout and returns its result.
+    /// </summary>
+    /// <typeparam name="T">The type of the result returned by the task.</typeparam>
+    /// <param name="actual">The task to wait for completion.</param>
+    /// <param name="timeout">The maximum time allowed for the task to complete.</param>
+    /// <param name="customMessage">Optional custom message to use if the assertion fails.</param>
+    /// <returns>The result of the task if it completes within the timeout.</returns>
+    /// <exception cref="ShouldCompleteInException">Thrown when the task does not complete within the specified timeout.</exception>
     public static T CompleteIn<T>(Task<T> actual, TimeSpan timeout, string? customMessage = null)
     {
         CompleteIn(actual, timeout, customMessage, "Task");
@@ -66,17 +110,7 @@ public static partial class Should
                 throw new ShouldCompleteInException(message, exception);
             }
 
-            PreserveStackTrace(inner);
-            throw inner;
+            ExceptionDispatchInfo.Capture(inner).Throw();
         }
-    }
-
-    private static void PreserveStackTrace(Exception exception)
-    {
-        // TODO Need to sort this out for core
-        var preserveStackTrace = typeof(Exception).GetMethod("InternalPreserveStackTrace",
-            BindingFlags.Instance | BindingFlags.NonPublic);
-
-        preserveStackTrace?.Invoke(exception, null);
     }
 }

--- a/src/Shouldly/ShouldStaticClasses/ShouldCompleteInExtensions.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldCompleteInExtensions.cs
@@ -32,7 +32,7 @@ public static partial class Should
         var actual = Task.Factory.StartNew(function, CancellationToken.None, TaskCreationOptions.None,
             TaskScheduler.Default);
         CompleteIn(actual, timeout, customMessage, "Delegate");
-        return actual.GetAwaiter().GetResult();
+        return actual.Result;
     }
 
     /// <summary>
@@ -60,7 +60,7 @@ public static partial class Should
     {
         var task = actual();
         CompleteIn(task, timeout, customMessage, "Task");
-        return task.GetAwaiter().GetResult();
+        return task.Result;
     }
 
     /// <summary>

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
@@ -9,8 +9,8 @@ public static partial class ShouldBeTestExtensions
 {
     [ContractAnnotation("actual:null,expected:notnull => halt;actual:notnull,expected:null => halt")]
     public static void ShouldBe<T>(
-        [NotNullIfNotNull("expected")] this T? actual,
-        [NotNullIfNotNull("actual")] T? expected,
+        [NotNullIfNotNull(nameof(expected))] this T? actual,
+        [NotNullIfNotNull(nameof(actual))] T? expected,
         string? customMessage = null)
     {
         if (ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName!) || typeof(T) == typeof(string))
@@ -20,8 +20,8 @@ public static partial class ShouldBeTestExtensions
     }
 
     public static void ShouldBe<T>(
-        [NotNullIfNotNull("expected")] this T? actual,
-        [NotNullIfNotNull("actual")] T? expected,
+        [NotNullIfNotNull(nameof(expected))] this T? actual,
+        [NotNullIfNotNull(nameof(actual))] T? expected,
         IEqualityComparer<T> comparer,
         string? customMessage = null)
     {
@@ -41,16 +41,16 @@ public static partial class ShouldBeTestExtensions
     }
 
     public static void ShouldBe<T>(
-        [NotNullIfNotNull("expected")] this IEnumerable<T>? actual,
-        [NotNullIfNotNull("actual")] IEnumerable<T>? expected,
+        [NotNullIfNotNull(nameof(expected))] this IEnumerable<T>? actual,
+        [NotNullIfNotNull(nameof(actual))] IEnumerable<T>? expected,
         bool ignoreOrder = false)
     {
         ShouldBe(actual, expected, ignoreOrder, (string?)null);
     }
 
     public static void ShouldBe<T>(
-        [NotNullIfNotNull("expected")] this IEnumerable<T>? actual,
-        [NotNullIfNotNull("actual")] IEnumerable<T>? expected,
+        [NotNullIfNotNull(nameof(expected))] this IEnumerable<T>? actual,
+        [NotNullIfNotNull(nameof(actual))] IEnumerable<T>? expected,
         bool ignoreOrder,
         string? customMessage)
     {
@@ -75,8 +75,8 @@ public static partial class ShouldBeTestExtensions
     }
 
     public static void ShouldBe<T>(
-        [NotNullIfNotNull("expected")] this IEnumerable<T>? actual,
-        [NotNullIfNotNull("actual")] IEnumerable<T>? expected,
+        [NotNullIfNotNull(nameof(expected))] this IEnumerable<T>? actual,
+        [NotNullIfNotNull(nameof(actual))] IEnumerable<T>? expected,
         IEqualityComparer<T> comparer,
         bool ignoreOrder = false,
         string? customMessage = null)
@@ -97,8 +97,8 @@ public static partial class ShouldBeTestExtensions
     }
 
     public static void ShouldBeSameAs(
-        [NotNullIfNotNull("expected")] this object? actual,
-        [NotNullIfNotNull("actual")] object? expected,
+        [NotNullIfNotNull(nameof(expected))] this object? actual,
+        [NotNullIfNotNull(nameof(actual))] object? expected,
         string? customMessage = null)
     {
         actual.AssertAwesomely(v => Is.Same(v, expected), actual, expected, customMessage);

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -6,16 +6,16 @@ public static partial class ObjectGraphTestExtensions
     private const BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.Instance;
 
     public static void ShouldBeEquivalentTo(
-        [NotNullIfNotNull("expected")] this object? actual,
-        [NotNullIfNotNull("actual")] object? expected,
+        [NotNullIfNotNull(nameof(expected))] this object? actual,
+        [NotNullIfNotNull(nameof(actual))] object? expected,
         string? customMessage = null)
     {
         CompareObjects(actual, expected, new List<string>(), new Dictionary<object, IList<object?>>(), customMessage);
     }
 
     private static void CompareObjects(
-        [NotNullIfNotNull("expected")] this object? actual,
-        [NotNullIfNotNull("actual")] object? expected,
+        [NotNullIfNotNull(nameof(expected))] this object? actual,
+        [NotNullIfNotNull(nameof(actual))] object? expected,
         IList<string> path,
         IDictionary<object, IList<object?>> previousComparisons,
         string? customMessage,

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringShouldBeTestExtensions.cs
@@ -10,8 +10,8 @@ public static partial class ShouldBeStringTestExtensions
     /// Perform a string comparison with sensitivity options
     /// </summary>
     public static void ShouldBe(
-        [NotNullIfNotNull("expected")] this string? actual,
-        [NotNullIfNotNull("actual")] string? expected,
+        [NotNullIfNotNull(nameof(expected))] this string? actual,
+        [NotNullIfNotNull(nameof(actual))] string? expected,
         string? customMessage = null)
     {
         // ReSharper disable once IntroduceOptionalParameters.Global
@@ -22,16 +22,16 @@ public static partial class ShouldBeStringTestExtensions
     /// Perform a string comparison with sensitivity options
     /// </summary>
     public static void ShouldBe(
-        [NotNullIfNotNull("expected")] this string? actual,
-        [NotNullIfNotNull("actual")] string? expected,
+        [NotNullIfNotNull(nameof(expected))] this string? actual,
+        [NotNullIfNotNull(nameof(actual))] string? expected,
         StringCompareShould options)
     {
         ShouldBe(actual, expected, (string?)null, options);
     }
 
     public static void ShouldBe(
-        [NotNullIfNotNull("expected")] this string? actual,
-        [NotNullIfNotNull("actual")] string? expected,
+        [NotNullIfNotNull(nameof(expected))] this string? actual,
+        [NotNullIfNotNull(nameof(actual))] string? expected,
         string? customMessage,
         StringCompareShould options)
     {


### PR DESCRIPTION
* Use `nameof()` for parameter names in attributes
* Use `TimeProvider` in one of the tests where the sequence of events is important
* Use consistent wait durations in more places
* Make wait durations more aggressive, but when running under CI make them more lenient
* Un-skip more tests
* Add xmldoc comments here and there
* Fixed flaky tests
* Use `TheoryData<>` rather than `IEnumerable<object>`
* Use collection expressions everywhere in test project