### PR TITLE
Support IReadOnlyDictionary<K, V>

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "sdk": {
-    "version": "8.0.303",
+    "version": "9.0.100-preview.7.24407.12",
     "allowPrerelease": true,
     "rollForward": "latestFeature"
   }

--- a/src/DeterministicTests/DeterministicTests.csproj
+++ b/src/DeterministicTests/DeterministicTests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\Shouldly\buildTransitive\Shouldly.targets" />
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <LangVersion>11</LangVersion>
+    <LangVersion>13</LangVersion>
     <Nullable>enable</Nullable>
     <Version>4.2.1</Version>
     <AnalysisLevel>5</AnalysisLevel>

--- a/src/DocumentationExamples/DocumentationExamples.csproj
+++ b/src/DocumentationExamples/DocumentationExamples.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DocumentationExamples/DocumentationExamples.csproj
+++ b/src/DocumentationExamples/DocumentationExamples.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -165,28 +165,24 @@ namespace Shouldly
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeDictionaryTestExtensions
     {
-        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
-            where TKey :  notnull { }
         public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
             where TKey :  notnull { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
-            where TKey :  notnull { }
-        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
             where TKey :  notnull { }
         public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
             where TKey :  notnull { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
-            where TKey :  notnull { }
-        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
             where TKey :  notnull { }
         public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
             where TKey :  notnull { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
-            where TKey :  notnull { }
-        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
             where TKey :  notnull { }
         public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
             where TKey :  notnull { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
             where TKey :  notnull { }
     }

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -165,13 +165,29 @@ namespace Shouldly
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeDictionaryTestExtensions
     {
+        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
+            where TKey :  notnull { }
         public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
+            where TKey :  notnull { }
+        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
+            where TKey :  notnull { }
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
             where TKey :  notnull { }
         public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
             where TKey :  notnull { }
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
+            where TKey :  notnull { }
+        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
+            where TKey :  notnull { }
         public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
             where TKey :  notnull { }
+        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
+            where TKey :  notnull { }
+        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.Dictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
+            where TKey :  notnull { }
         public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
+            where TKey :  notnull { }
+        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
             where TKey :  notnull { }
     }
     [Shouldly.ShouldlyMethods]

--- a/src/Shouldly.Tests/Dictionaries/DictionaryTestData.cs
+++ b/src/Shouldly.Tests/Dictionaries/DictionaryTestData.cs
@@ -1,0 +1,36 @@
+﻿namespace Shouldly.Tests.Dictionaries;
+
+internal static class DictionaryTestData
+{
+    public static Guid GuidKey { get; } = new("edae0d73-8e4c-4251-85c8-e5497c7ccad1");
+    public static Guid GuidValue { get; } = new("fa1e5f58-578f-43d4-b4d6-67eae06a5d17");
+    public static Guid MissingGuidKey { get; } = new("1924e617-2fc2-47ae-ad38-b6f30ec2226b");
+    public static Guid MissingGuidValue { get; } = new("f08a0b08-c9f4-49bb-a4d4-be06e88b69c8");
+    public static MyThing ThingKey { get; } = new();
+    public static MyThing ThingValue { get; } = new();
+
+    public static Dictionary<MyThing, MyThing> ClassDictionary() => new(_classDictionary);
+    public static Dictionary<Guid, Guid> GuidDictionary() => new(_guidDictionary);
+    public static Dictionary<string, string> StringDictionary() => new(_stringDictionary);
+
+    public static IDictionary<MyThing, MyThing> ClassIDictionary() => ClassDictionary();
+    public static IDictionary<Guid, Guid> GuidIDictionary() => GuidDictionary();
+    public static IDictionary<string, string> StringIDictionary() => StringDictionary();
+
+    public static IReadOnlyDictionary<MyThing, MyThing> ClassIReadOnlyDictionary() => ClassDictionary();
+    public static IReadOnlyDictionary<Guid, Guid> GuidIReadOnlyDictionary() => GuidDictionary();
+    public static IReadOnlyDictionary<string, string> StringIReadOnlyDictionary() => StringDictionary();
+
+    private static readonly Dictionary<MyThing, MyThing> _classDictionary = new()
+    {
+        { ThingKey, ThingValue }
+    };
+    private static readonly Dictionary<Guid, Guid> _guidDictionary = new()
+    {
+        { GuidKey, GuidValue }
+    };
+    private static readonly Dictionary<string, string> _stringDictionary = new()
+    {
+        { "Foo", "Bar" },
+    };
+}

--- a/src/Shouldly.Tests/Dictionaries/ShouldContainKey.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldContainKey.cs
@@ -154,6 +154,7 @@ Additional Info:
     Some additional context");
     }
 
+#if NET9_0_OR_GREATER
     [Fact]
     public void ClassScenarioShouldFailForIReadOnlyDictionary()
     {
@@ -228,6 +229,7 @@ Additional Info:
 Additional Info:
     Some additional context");
     }
+#endif
 
     [Fact]
     public void ShouldPass()
@@ -240,8 +242,10 @@ Additional Info:
         GuidIDictionary().ShouldContainKey(GuidKey);
         StringIDictionary().ShouldContainKey("Foo");
 
+#if NET9_0_OR_GREATER
         ClassIReadOnlyDictionary().ShouldContainKey(ThingKey);
         GuidIReadOnlyDictionary().ShouldContainKey(GuidKey);
         StringIReadOnlyDictionary().ShouldContainKey("Foo");
+#endif
     }
 }

--- a/src/Shouldly.Tests/Dictionaries/ShouldContainKey.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldContainKey.cs
@@ -1,15 +1,17 @@
 ﻿namespace Shouldly.Tests.Dictionaries;
 
+using static DictionaryTestData;
+
 public class ShouldContainKey
 {
     [Fact]
-    public void ClassScenarioShouldFail()
+    public void ClassScenarioShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _classDictionary.ShouldContainKey(new(), "Some additional context"),
+                ClassDictionary().ShouldContainKey(new(), "Some additional context"),
 
             errorWithSource:
-            @"_classDictionary
+            @"ClassDictionary()
     should contain key
 Shouldly.Tests.TestHelpers.MyThing (000000)
     but does not
@@ -28,24 +30,24 @@ Additional Info:
     }
 
     [Fact]
-    public void GuidScenarioShouldFail()
+    public void GuidScenarioShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _guidDictionary.ShouldContainKey(_missingGuid, "Some additional context"),
+                GuidDictionary().ShouldContainKey(MissingGuidKey, "Some additional context"),
 
             errorWithSource:
-            @"_guidDictionary
+            @"GuidDictionary()
     should contain key
-5250646b-4c46-4b0e-86d8-e1421f2a0ea2
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
     but does not
 
 Additional Info:
     Some additional context",
 
             errorWithoutSource:
-            @"[[468a57a7-ca19-4b76-a1e3-3040719392bc => a9db46cc-9d3c-4595-ae1b-8e33de4cc6e5]]
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
     should contain key
-5250646b-4c46-4b0e-86d8-e1421f2a0ea2
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
     but does not
 
 Additional Info:
@@ -53,13 +55,13 @@ Additional Info:
     }
 
     [Fact]
-    public void StringScenarioShouldFail()
+    public void StringScenarioShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _stringDictionary.ShouldContainKey("bar", "Some additional context"),
+                StringDictionary().ShouldContainKey("bar", "Some additional context"),
 
             errorWithSource:
-            @"_stringDictionary
+            @"StringDictionary()
     should contain key
 ""bar""
     but does not
@@ -68,7 +70,157 @@ Additional Info:
     Some additional context",
 
             errorWithoutSource:
-            @"[[""Foo"" => """"]]
+            @"[[""Foo"" => ""Bar""]]
+    should contain key
+""bar""
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ClassScenarioShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIDictionary().ShouldContainKey(new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassIDictionary()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void GuidScenarioShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                GuidIDictionary().ShouldContainKey(MissingGuidKey, "Some additional context"),
+
+            errorWithSource:
+            @"GuidIDictionary()
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                StringIDictionary().ShouldContainKey("bar", "Some additional context"),
+
+            errorWithSource:
+            @"StringIDictionary()
+    should contain key
+""bar""
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should contain key
+""bar""
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ClassScenarioShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIReadOnlyDictionary().ShouldContainKey(new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassIReadOnlyDictionary()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void GuidScenarioShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                GuidIReadOnlyDictionary().ShouldContainKey(MissingGuidKey, "Some additional context"),
+
+            errorWithSource:
+            @"GuidIReadOnlyDictionary()
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                StringIReadOnlyDictionary().ShouldContainKey("bar", "Some additional context"),
+
+            errorWithSource:
+            @"StringIReadOnlyDictionary()
+    should contain key
+""bar""
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
     should contain key
 ""bar""
     but does not
@@ -80,27 +232,16 @@ Additional Info:
     [Fact]
     public void ShouldPass()
     {
-        _classDictionary.ShouldContainKey(ThingKey);
-        _guidDictionary.ShouldContainKey(GuidKey);
-        _stringDictionary.ShouldContainKey("Foo");
+        ClassDictionary().ShouldContainKey(ThingKey);
+        GuidDictionary().ShouldContainKey(GuidKey);
+        StringDictionary().ShouldContainKey("Foo");
+
+        ClassIDictionary().ShouldContainKey(ThingKey);
+        GuidIDictionary().ShouldContainKey(GuidKey);
+        StringIDictionary().ShouldContainKey("Foo");
+
+        ClassIReadOnlyDictionary().ShouldContainKey(ThingKey);
+        GuidIReadOnlyDictionary().ShouldContainKey(GuidKey);
+        StringIReadOnlyDictionary().ShouldContainKey("Foo");
     }
-
-    private static readonly MyThing ThingKey = new();
-    private readonly Dictionary<MyThing, MyThing> _classDictionary = new()
-    {
-        { ThingKey, new() }
-    };
-
-    private readonly Dictionary<Guid, Guid> _guidDictionary = new()
-    {
-        { GuidKey, new("a9db46cc-9d3c-4595-ae1b-8e33de4cc6e5") }
-    };
-
-    private static readonly Guid GuidKey = new("468a57a7-ca19-4b76-a1e3-3040719392bc");
-    private readonly Guid _missingGuid = new("5250646b-4c46-4b0e-86d8-e1421f2a0ea2");
-
-    private readonly Dictionary<string, string> _stringDictionary = new()
-    {
-        { "Foo", "" }
-    };
 }

--- a/src/Shouldly.Tests/Dictionaries/ShouldContainKeyAndValue.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldContainKeyAndValue.cs
@@ -1,15 +1,17 @@
 ﻿namespace Shouldly.Tests.Dictionaries;
 
+using static DictionaryTestData;
+
 public class ShouldContainKeyAndValue
 {
     [Fact]
-    public void ShouldContainKeyAndValueWithClassesShouldFail()
+    public void ShouldContainKeyAndValueWithClassesShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _classDictionary.ShouldContainKeyAndValue(new(), new(), "Some additional context"),
+                ClassDictionary().ShouldContainKeyAndValue(new(), new(), "Some additional context"),
 
             errorWithSource:
-            @"_classDictionary
+            @"ClassDictionary()
     should contain key
 Shouldly.Tests.TestHelpers.MyThing (000000)
     with value
@@ -32,13 +34,13 @@ Additional Info:
     }
 
     [Fact]
-    public void GuidScenarioShouldFail()
+    public void GuidScenarioShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _guidDictionary.ShouldContainKeyAndValue(_missingGuidKey, _missingGuidValue, "Some additional context"),
+                GuidDictionary().ShouldContainKeyAndValue(MissingGuidKey, MissingGuidValue, "Some additional context"),
 
             errorWithSource:
-            @"_guidDictionary
+            @"GuidDictionary()
     should contain key
 1924e617-2fc2-47ae-ad38-b6f30ec2226b
     with value
@@ -49,7 +51,7 @@ Additional Info:
     Some additional context",
 
             errorWithoutSource:
-            @"[[efc7ee91-6b19-4dff-88a8-affae77ad870 => b951fb9f-07c3-4060-bd80-055e63946497]]
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
     should contain key
 1924e617-2fc2-47ae-ad38-b6f30ec2226b
     with value
@@ -61,13 +63,13 @@ Additional Info:
     }
 
     [Fact]
-    public void OnlyKeyMatchesShouldFail()
+    public void OnlyKeyMatchesShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _classDictionary.ShouldContainKeyAndValue(ThingKey, new(), "Some additional context"),
+                ClassDictionary().ShouldContainKeyAndValue(ThingKey, new(), "Some additional context"),
 
             errorWithSource:
-            @"_classDictionary
+            @"ClassDictionary()
     should contain key
 Shouldly.Tests.TestHelpers.MyThing (000000)
     with value
@@ -92,13 +94,13 @@ Additional Info:
     }
 
     [Fact]
-    public void OnlyValueMatchesShouldFail()
+    public void OnlyValueMatchesShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _classDictionary.ShouldContainKeyAndValue(new(), ThingValue, "Some additional context"),
+                ClassDictionary().ShouldContainKeyAndValue(new(), ThingValue, "Some additional context"),
 
             errorWithSource:
-            @"_classDictionary
+            @"ClassDictionary()
     should contain key
 Shouldly.Tests.TestHelpers.MyThing (000000)
     with value
@@ -121,13 +123,13 @@ Additional Info:
     }
 
     [Fact]
-    public void StringScenarioShouldFail()
+    public void StringScenarioShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _stringDictionary.ShouldContainKeyAndValue("bar", "baz", "Some additional context"),
+                StringDictionary().ShouldContainKeyAndValue("bar", "baz", "Some additional context"),
 
             errorWithSource:
-            @"_stringDictionary
+            @"StringDictionary()
     should contain key
 ""bar""
     with value
@@ -150,7 +152,7 @@ Additional Info:
     }
 
     [Fact]
-    public void ValueIsNullShouldFail()
+    public void ValueIsNullShouldFailForDictionary()
     {
         var dictionaryWithNullValue = new Dictionary<MyThing, MyThing?>
         {
@@ -185,31 +187,382 @@ Additional Info:
     }
 
     [Fact]
-    public void ShouldPass()
+    public void ShouldContainKeyAndValueWithClassesShouldFailForIDictionary()
     {
-        _classDictionary.ShouldContainKeyAndValue(ThingKey, ThingValue);
-        _guidDictionary.ShouldContainKeyAndValue(GuidKey, GuidValue);
-        _stringDictionary.ShouldContainKeyAndValue("Foo", "Bar");
+        Verify.ShouldFail(() =>
+                ClassIDictionary().ShouldContainKeyAndValue(new(), new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassIDictionary()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
     }
 
-    private readonly Dictionary<MyThing, MyThing> _classDictionary = new()
+    [Fact]
+    public void GuidScenarioShouldFailForIDictionary()
     {
-        { ThingKey, ThingValue }
-    };
-    private readonly Dictionary<Guid, Guid> _guidDictionary = new()
-    {
-        { GuidKey, GuidValue }
-    };
-    private readonly Dictionary<string, string> _stringDictionary = new()
-    {
-        { "Foo", "Bar" }
-    };
+        Verify.ShouldFail(() =>
+                GuidIDictionary().ShouldContainKeyAndValue(MissingGuidKey, MissingGuidValue, "Some additional context"),
 
-    private static readonly MyThing ThingKey = new();
-    private static readonly MyThing ThingValue = new();
+            errorWithSource:
+            @"GuidIDictionary()
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    with value
+f08a0b08-c9f4-49bb-a4d4-be06e88b69c8
+    but the key does not exist
 
-    private static readonly Guid GuidKey = new("efc7ee91-6b19-4dff-88a8-affae77ad870");
-    private static readonly Guid GuidValue = new("b951fb9f-07c3-4060-bd80-055e63946497");
-    private readonly Guid _missingGuidKey = new("1924e617-2fc2-47ae-ad38-b6f30ec2226b");
-    private readonly Guid _missingGuidValue = new("f08a0b08-c9f4-49bb-a4d4-be06e88b69c8");
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    with value
+f08a0b08-c9f4-49bb-a4d4-be06e88b69c8
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void OnlyKeyMatchesShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIDictionary().ShouldContainKeyAndValue(ThingKey, new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassIDictionary()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+Shouldly.Tests.TestHelpers.MyThing (000000)
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+Shouldly.Tests.TestHelpers.MyThing (000000)
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void OnlyValueMatchesShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIDictionary().ShouldContainKeyAndValue(new(), ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIDictionary()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                StringIDictionary().ShouldContainKeyAndValue("bar", "baz", "Some additional context"),
+
+            errorWithSource:
+            @"StringIDictionary()
+    should contain key
+""bar""
+    with value
+""baz""
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should contain key
+""bar""
+    with value
+""baz""
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ValueIsNullShouldFailForIDictionary()
+    {
+        IDictionary<MyThing, MyThing?> dictionaryWithNullValue = new Dictionary<MyThing, MyThing?>
+        {
+            { ThingKey, null }
+        };
+        Verify.ShouldFail(() =>
+                dictionaryWithNullValue.ShouldContainKeyAndValue(ThingKey, new(), "Some additional context"),
+
+            errorWithSource:
+            @"dictionaryWithNullValue
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+null
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => null]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+null
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ShouldContainKeyAndValueWithClassesShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIReadOnlyDictionary().ShouldContainKeyAndValue(new(), new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassIReadOnlyDictionary()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void GuidScenarioShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                GuidIReadOnlyDictionary().ShouldContainKeyAndValue(MissingGuidKey, MissingGuidValue, "Some additional context"),
+
+            errorWithSource:
+            @"GuidIReadOnlyDictionary()
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    with value
+f08a0b08-c9f4-49bb-a4d4-be06e88b69c8
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    with value
+f08a0b08-c9f4-49bb-a4d4-be06e88b69c8
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void OnlyKeyMatchesShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIReadOnlyDictionary().ShouldContainKeyAndValue(ThingKey, new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassIReadOnlyDictionary()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+Shouldly.Tests.TestHelpers.MyThing (000000)
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+Shouldly.Tests.TestHelpers.MyThing (000000)
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void OnlyValueMatchesShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIReadOnlyDictionary().ShouldContainKeyAndValue(new(), ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIReadOnlyDictionary()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                StringIReadOnlyDictionary().ShouldContainKeyAndValue("bar", "baz", "Some additional context"),
+
+            errorWithSource:
+            @"StringIReadOnlyDictionary()
+    should contain key
+""bar""
+    with value
+""baz""
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should contain key
+""bar""
+    with value
+""baz""
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ValueIsNullShouldFailForIReadOnlyDictionary()
+    {
+        IReadOnlyDictionary<MyThing, MyThing?> dictionaryWithNullValue = new Dictionary<MyThing, MyThing?>
+        {
+            { ThingKey, null }
+        };
+        Verify.ShouldFail(() =>
+                dictionaryWithNullValue.ShouldContainKeyAndValue(ThingKey, new(), "Some additional context"),
+
+            errorWithSource:
+            @"dictionaryWithNullValue
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+null
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => null]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+null
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        ClassDictionary().ShouldContainKeyAndValue(ThingKey, ThingValue);
+        GuidDictionary().ShouldContainKeyAndValue(GuidKey, GuidValue);
+        StringDictionary().ShouldContainKeyAndValue("Foo", "Bar");
+
+        ClassIDictionary().ShouldContainKeyAndValue(ThingKey, ThingValue);
+        GuidIDictionary().ShouldContainKeyAndValue(GuidKey, GuidValue);
+        StringIDictionary().ShouldContainKeyAndValue("Foo", "Bar");
+
+        ClassIReadOnlyDictionary().ShouldContainKeyAndValue(ThingKey, ThingValue);
+        GuidIReadOnlyDictionary().ShouldContainKeyAndValue(GuidKey, GuidValue);
+        StringIReadOnlyDictionary().ShouldContainKeyAndValue("Foo", "Bar");
+    }
 }

--- a/src/Shouldly.Tests/Dictionaries/ShouldContainKeyAndValue.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldContainKeyAndValue.cs
@@ -368,6 +368,7 @@ Additional Info:
     Some additional context");
     }
 
+#if NET9_0_OR_GREATER
     [Fact]
     public void ShouldContainKeyAndValueWithClassesShouldFailForIReadOnlyDictionary()
     {
@@ -549,6 +550,7 @@ null
 Additional Info:
     Some additional context");
     }
+#endif
 
     [Fact]
     public void ShouldPass()
@@ -561,8 +563,10 @@ Additional Info:
         GuidIDictionary().ShouldContainKeyAndValue(GuidKey, GuidValue);
         StringIDictionary().ShouldContainKeyAndValue("Foo", "Bar");
 
+#if NET9_0_OR_GREATER
         ClassIReadOnlyDictionary().ShouldContainKeyAndValue(ThingKey, ThingValue);
         GuidIReadOnlyDictionary().ShouldContainKeyAndValue(GuidKey, GuidValue);
         StringIReadOnlyDictionary().ShouldContainKeyAndValue("Foo", "Bar");
+#endif
     }
 }

--- a/src/Shouldly.Tests/Dictionaries/ShouldNotContainKey.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldNotContainKey.cs
@@ -154,6 +154,7 @@ Additional Info:
     Some additional context");
     }
 
+#if NET9_0_OR_GREATER
     [Fact]
     public void ShouldNotContainKeyClassScenarioShouldFailForIReadOnlyDictionary()
     {
@@ -228,6 +229,7 @@ Additional Info:
 Additional Info:
     Some additional context");
     }
+#endif
 
     [Fact]
     public void ShouldPass()
@@ -240,8 +242,10 @@ Additional Info:
         GuidIDictionary().ShouldNotContainKey(Guid.NewGuid());
         StringIDictionary().ShouldNotContainKey("bar");
 
+#if NET9_0_OR_GREATER
         ClassIReadOnlyDictionary().ShouldNotContainKey(new());
         GuidIReadOnlyDictionary().ShouldNotContainKey(Guid.NewGuid());
         StringIReadOnlyDictionary().ShouldNotContainKey("bar");
+#endif
     }
 }

--- a/src/Shouldly.Tests/Dictionaries/ShouldNotContainKey.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldNotContainKey.cs
@@ -1,15 +1,17 @@
 ﻿namespace Shouldly.Tests.Dictionaries;
 
+using static DictionaryTestData;
+
 public class ShouldNotContainKey
 {
     [Fact]
-    public void ShouldNotContainKeyClassScenarioShouldFail()
+    public void ShouldNotContainKeyClassScenarioShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _classDictionary.ShouldNotContainKey(ThingKey, "Some additional context"),
+                ClassDictionary().ShouldNotContainKey(ThingKey, "Some additional context"),
 
             errorWithSource:
-            @"_classDictionary
+            @"ClassDictionary()
     should not contain key
 Shouldly.Tests.TestHelpers.MyThing (000000)
     but does
@@ -28,24 +30,24 @@ Additional Info:
     }
 
     [Fact]
-    public void ShouldNotContainKeyGuidScenarioShouldFail()
+    public void ShouldNotContainKeyGuidScenarioShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _guidDictionary.ShouldNotContainKey(GuidKey, "Some additional context"),
+                GuidDictionary().ShouldNotContainKey(GuidKey, "Some additional context"),
 
             errorWithSource:
-            @"_guidDictionary
+            @"GuidDictionary()
     should not contain key
-89bdbe3d-3436-4749-bcb7-84264394026c
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
     but does
 
 Additional Info:
     Some additional context",
 
             errorWithoutSource:
-            @"[[89bdbe3d-3436-4749-bcb7-84264394026c => 96408719-fdd4-4212-8e54-4f4d7371300f]]
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
     should not contain key
-89bdbe3d-3436-4749-bcb7-84264394026c
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
     but does
 
 Additional Info:
@@ -53,13 +55,13 @@ Additional Info:
     }
 
     [Fact]
-    public void StringScenarioShouldFail()
+    public void StringScenarioShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _stringDictionary.ShouldNotContainKey("Foo", "Some additional context"),
+                StringDictionary().ShouldNotContainKey("Foo", "Some additional context"),
 
             errorWithSource:
-            @"_stringDictionary
+            @"StringDictionary()
     should not contain key
 ""Foo""
     but does
@@ -68,7 +70,157 @@ Additional Info:
     Some additional context",
 
             errorWithoutSource:
-            @"[[""Foo"" => """"]]
+            @"[[""Foo"" => ""Bar""]]
+    should not contain key
+""Foo""
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ShouldNotContainKeyClassScenarioShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIDictionary().ShouldNotContainKey(ThingKey, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIDictionary()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ShouldNotContainKeyGuidScenarioShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                GuidIDictionary().ShouldNotContainKey(GuidKey, "Some additional context"),
+
+            errorWithSource:
+            @"GuidIDictionary()
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                StringIDictionary().ShouldNotContainKey("Foo", "Some additional context"),
+
+            errorWithSource:
+            @"StringIDictionary()
+    should not contain key
+""Foo""
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should not contain key
+""Foo""
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ShouldNotContainKeyClassScenarioShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIReadOnlyDictionary().ShouldNotContainKey(ThingKey, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIReadOnlyDictionary()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ShouldNotContainKeyGuidScenarioShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                GuidIReadOnlyDictionary().ShouldNotContainKey(GuidKey, "Some additional context"),
+
+            errorWithSource:
+            @"GuidIReadOnlyDictionary()
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                StringIReadOnlyDictionary().ShouldNotContainKey("Foo", "Some additional context"),
+
+            errorWithSource:
+            @"StringIReadOnlyDictionary()
+    should not contain key
+""Foo""
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
     should not contain key
 ""Foo""
     but does
@@ -80,24 +232,16 @@ Additional Info:
     [Fact]
     public void ShouldPass()
     {
-        _classDictionary.ShouldNotContainKey(new());
-        _guidDictionary.ShouldNotContainKey(Guid.NewGuid());
-        _stringDictionary.ShouldNotContainKey("bar");
+        ClassDictionary().ShouldNotContainKey(new());
+        GuidDictionary().ShouldNotContainKey(Guid.NewGuid());
+        StringDictionary().ShouldNotContainKey("bar");
+
+        ClassIDictionary().ShouldNotContainKey(new());
+        GuidIDictionary().ShouldNotContainKey(Guid.NewGuid());
+        StringIDictionary().ShouldNotContainKey("bar");
+
+        ClassIReadOnlyDictionary().ShouldNotContainKey(new());
+        GuidIReadOnlyDictionary().ShouldNotContainKey(Guid.NewGuid());
+        StringIReadOnlyDictionary().ShouldNotContainKey("bar");
     }
-
-    private readonly Dictionary<MyThing, MyThing> _classDictionary = new()
-    {
-        { ThingKey, new() }
-    };
-    private readonly Dictionary<Guid, Guid> _guidDictionary = new()
-    {
-        { GuidKey, new("96408719-fdd4-4212-8e54-4f4d7371300f") }
-    };
-    private readonly Dictionary<string, string> _stringDictionary = new()
-    {
-        { "Foo", "" }
-    };
-
-    private static readonly Guid GuidKey = new("89bdbe3d-3436-4749-bcb7-84264394026c");
-    private static readonly MyThing ThingKey = new();
 }

--- a/src/Shouldly.Tests/Dictionaries/ShouldNotContainValueForKey.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldNotContainValueForKey.cs
@@ -1,15 +1,17 @@
 ﻿namespace Shouldly.Tests.Dictionaries;
 
+using static DictionaryTestData;
+
 public class ShouldNotContainValueForKey
 {
     [Fact]
-    public void ClassScenarioShouldFail()
+    public void ClassScenarioShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _classDictionary.ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
+                ClassDictionary().ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
 
             errorWithSource:
-            @"_classDictionary
+            @"ClassDictionary()
     should not contain key
 Shouldly.Tests.TestHelpers.MyThing (000000)
     with value
@@ -32,13 +34,13 @@ Additional Info:
     }
 
     [Fact]
-    public void GuidScenarioShouldFail()
+    public void GuidScenarioShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _guidDictionary.ShouldNotContainValueForKey(GuidKey, GuidValue, "Some additional context"),
+                GuidDictionary().ShouldNotContainValueForKey(GuidKey, GuidValue, "Some additional context"),
 
             errorWithSource:
-            @"_guidDictionary
+            @"GuidDictionary()
     should not contain key
 edae0d73-8e4c-4251-85c8-e5497c7ccad1
     with value
@@ -61,13 +63,13 @@ Additional Info:
     }
 
     [Fact]
-    public void KeyAndValueExistShouldFail()
+    public void KeyAndValueExistShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _classDictionary.ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
+                ClassDictionary().ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
 
             errorWithSource:
-            @"_classDictionary
+            @"ClassDictionary()
     should not contain key
 Shouldly.Tests.TestHelpers.MyThing (000000)
     with value
@@ -90,13 +92,13 @@ Additional Info:
     }
 
     [Fact]
-    public void NoKeyExistsShouldFail()
+    public void NoKeyExistsShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _classDictionary.ShouldNotContainValueForKey(new(), ThingValue, "Some additional context"),
+                ClassDictionary().ShouldNotContainValueForKey(new(), ThingValue, "Some additional context"),
 
             errorWithSource:
-            @"_classDictionary
+            @"ClassDictionary()
     should not contain key
 Shouldly.Tests.TestHelpers.MyThing (000000)
     with value
@@ -119,13 +121,13 @@ Additional Info:
     }
 
     [Fact]
-    public void StringScenarioShouldFail()
+    public void StringScenarioShouldFailForDictionary()
     {
         Verify.ShouldFail(() =>
-                _stringDictionary.ShouldNotContainValueForKey("Foo", "Bar", "Some additional context"),
+                StringDictionary().ShouldNotContainValueForKey("Foo", "Bar", "Some additional context"),
 
             errorWithSource:
-            @"_stringDictionary
+            @"StringDictionary()
     should not contain key
 ""Foo""
     with value
@@ -148,9 +150,366 @@ Additional Info:
     }
 
     [Fact]
-    public void ValueIsNullShouldFail()
+    public void ValueIsNullShouldFailForDictionary()
     {
         var dictionary = new Dictionary<MyThing, MyThing?>
+        {
+            { ThingKey, null }
+        };
+        Verify.ShouldFail(() =>
+                dictionary.ShouldNotContainValueForKey(ThingKey, null, "Some additional context"),
+
+            errorWithSource:
+            @"dictionary
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+null
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => null]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+null
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+
+    [Fact]
+    public void ClassScenarioShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIDictionary().ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIDictionary()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void GuidScenarioShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                GuidIDictionary().ShouldNotContainValueForKey(GuidKey, GuidValue, "Some additional context"),
+
+            errorWithSource:
+            @"GuidIDictionary()
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    with value
+fa1e5f58-578f-43d4-b4d6-67eae06a5d17
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    with value
+fa1e5f58-578f-43d4-b4d6-67eae06a5d17
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void KeyAndValueExistShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIDictionary().ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIDictionary()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void NoKeyExistsShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIDictionary().ShouldNotContainValueForKey(new(), ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIDictionary()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIDictionary()
+    {
+        Verify.ShouldFail(() =>
+                StringIDictionary().ShouldNotContainValueForKey("Foo", "Bar", "Some additional context"),
+
+            errorWithSource:
+            @"StringIDictionary()
+    should not contain key
+""Foo""
+    with value
+""Bar""
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should not contain key
+""Foo""
+    with value
+""Bar""
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ValueIsNullShouldFailForIDictionary()
+    {
+        IDictionary<MyThing, MyThing?> dictionary = new Dictionary<MyThing, MyThing?>
+        {
+            { ThingKey, null }
+        };
+        Verify.ShouldFail(() =>
+                dictionary.ShouldNotContainValueForKey(ThingKey, null, "Some additional context"),
+
+            errorWithSource:
+            @"dictionary
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+null
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => null]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+null
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ClassScenarioShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIReadOnlyDictionary().ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIReadOnlyDictionary()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void GuidScenarioShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                GuidIReadOnlyDictionary().ShouldNotContainValueForKey(GuidKey, GuidValue, "Some additional context"),
+
+            errorWithSource:
+            @"GuidIReadOnlyDictionary()
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    with value
+fa1e5f58-578f-43d4-b4d6-67eae06a5d17
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    with value
+fa1e5f58-578f-43d4-b4d6-67eae06a5d17
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void KeyAndValueExistShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIReadOnlyDictionary().ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIReadOnlyDictionary()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void NoKeyExistsShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                ClassIReadOnlyDictionary().ShouldNotContainValueForKey(new(), ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIReadOnlyDictionary()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIReadOnlyDictionary()
+    {
+        Verify.ShouldFail(() =>
+                StringIReadOnlyDictionary().ShouldNotContainValueForKey("Foo", "Bar", "Some additional context"),
+
+            errorWithSource:
+            @"StringIReadOnlyDictionary()
+    should not contain key
+""Foo""
+    with value
+""Bar""
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should not contain key
+""Foo""
+    with value
+""Bar""
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ValueIsNullShouldFailForIReadOnlyDictionary()
+    {
+        IReadOnlyDictionary<MyThing, MyThing?> dictionary = new Dictionary<MyThing, MyThing?>
         {
             { ThingKey, null }
         };
@@ -183,26 +542,16 @@ Additional Info:
     [Fact]
     public void ShouldPass()
     {
-        _classDictionary.ShouldNotContainValueForKey(ThingKey, new());
-        _guidDictionary.ShouldNotContainValueForKey(GuidKey, Guid.NewGuid());
-        _stringDictionary.ShouldNotContainValueForKey("Foo", "baz");
+        ClassDictionary().ShouldNotContainValueForKey(ThingKey, new());
+        GuidDictionary().ShouldNotContainValueForKey(GuidKey, Guid.NewGuid());
+        StringDictionary().ShouldNotContainValueForKey("Foo", "baz");
+
+        ClassIDictionary().ShouldNotContainValueForKey(ThingKey, new());
+        GuidIDictionary().ShouldNotContainValueForKey(GuidKey, Guid.NewGuid());
+        StringIDictionary().ShouldNotContainValueForKey("Foo", "baz");
+
+        ClassIReadOnlyDictionary().ShouldNotContainValueForKey(ThingKey, new());
+        GuidIReadOnlyDictionary().ShouldNotContainValueForKey(GuidKey, Guid.NewGuid());
+        StringIReadOnlyDictionary().ShouldNotContainValueForKey("Foo", "baz");
     }
-
-    private readonly Dictionary<MyThing, MyThing> _classDictionary = new()
-    {
-        { ThingKey, ThingValue }
-    };
-    private readonly Dictionary<Guid, Guid> _guidDictionary = new()
-    {
-        { GuidKey, GuidValue }
-    };
-    private readonly Dictionary<string, string> _stringDictionary = new()
-    {
-        { "Foo", "Bar" }
-    };
-
-    private static readonly Guid GuidKey = new("edae0d73-8e4c-4251-85c8-e5497c7ccad1");
-    private static readonly Guid GuidValue = new("fa1e5f58-578f-43d4-b4d6-67eae06a5d17");
-    private static readonly MyThing ThingKey = new();
-    private static readonly MyThing ThingValue = new();
 }

--- a/src/Shouldly.Tests/Dictionaries/ShouldNotContainValueForKey.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldNotContainValueForKey.cs
@@ -361,6 +361,7 @@ Additional Info:
     Some additional context");
     }
 
+#if NET9_0_OR_GREATER
     [Fact]
     public void ClassScenarioShouldFailForIReadOnlyDictionary()
     {
@@ -538,6 +539,7 @@ null
 Additional Info:
     Some additional context");
     }
+#endif
 
     [Fact]
     public void ShouldPass()
@@ -550,8 +552,10 @@ Additional Info:
         GuidIDictionary().ShouldNotContainValueForKey(GuidKey, Guid.NewGuid());
         StringIDictionary().ShouldNotContainValueForKey("Foo", "baz");
 
+#if NET9_0_OR_GREATER
         ClassIReadOnlyDictionary().ShouldNotContainValueForKey(ThingKey, new());
         GuidIReadOnlyDictionary().ShouldNotContainValueForKey(GuidKey, Guid.NewGuid());
         StringIReadOnlyDictionary().ShouldNotContainValueForKey("Foo", "baz");
+#endif
     }
 }

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net8.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net48</TargetFrameworks>
     <Optimize>false</Optimize>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="**\*.approved.cs;**\*.received.cs" />

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>net9.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net48</TargetFrameworks>
     <Optimize>false</Optimize>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="**\*.approved.cs;**\*.received.cs" />

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net9.0</TargetFrameworks>
     <Optimize>false</Optimize>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>embedded</DebugType>
@@ -23,6 +23,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <ContinuousIntegrationBuild Condition=" '$(CI)' == 'true' ">true</ContinuousIntegrationBuild>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1505</WarningsNotAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DiffEngine" Version="11.3.0" />

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -23,7 +23,6 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <ContinuousIntegrationBuild Condition=" '$(CI)' == 'true' ">true</ContinuousIntegrationBuild>
     <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1505</WarningsNotAsErrors>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DiffEngine" Version="11.3.0" />

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
@@ -1,4 +1,8 @@
-﻿namespace Shouldly;
+﻿#if NET9_0_OR_GREATER
+using System.Runtime.CompilerServices;
+#endif
+
+namespace Shouldly;
 
 [DebuggerStepThrough]
 [ShouldlyMethods]
@@ -32,6 +36,8 @@ public static partial class ShouldBeDictionaryTestExtensions
             throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key,  customMessage).ToString());
     }
 
+#if NET9_0_OR_GREATER
+    [OverloadResolutionPriority(1)]
     public static void ShouldContainKey<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
         where TKey : notnull
     {
@@ -39,6 +45,7 @@ public static partial class ShouldBeDictionaryTestExtensions
             throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
     }
 
+    [OverloadResolutionPriority(1)]
     public static void ShouldNotContainKey<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
         where TKey : notnull
     {
@@ -46,6 +53,7 @@ public static partial class ShouldBeDictionaryTestExtensions
             throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
     }
 
+    [OverloadResolutionPriority(1)]
     public static void ShouldContainKeyAndValue<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
         where TKey : notnull
     {
@@ -53,38 +61,12 @@ public static partial class ShouldBeDictionaryTestExtensions
             throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
     }
 
+    [OverloadResolutionPriority(1)]
     public static void ShouldNotContainValueForKey<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
         where TKey : notnull
     {
         if (!dictionary.ContainsKey(key) || Equals(dictionary[key], val))
             throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
     }
-
-    public static void ShouldContainKey<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
-        where TKey : notnull
-    {
-        if (!dictionary.ContainsKey(key))
-            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
-    }
-
-    public static void ShouldNotContainKey<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
-        where TKey : notnull
-    {
-        if (dictionary.ContainsKey(key))
-            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
-    }
-
-    public static void ShouldContainKeyAndValue<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
-        where TKey : notnull
-    {
-        if (!dictionary.ContainsKey(key) || !Equals(dictionary[key], val))
-            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
-    }
-
-    public static void ShouldNotContainValueForKey<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
-        where TKey : notnull
-    {
-        if (!dictionary.ContainsKey(key) || Equals(dictionary[key], val))
-            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
-    }
+#endif
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
@@ -31,4 +31,60 @@ public static partial class ShouldBeDictionaryTestExtensions
         if (!dictionary.ContainsKey(key) || Equals(dictionary[key], val))
             throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key,  customMessage).ToString());
     }
+
+    public static void ShouldContainKey<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
+        where TKey : notnull
+    {
+        if (!dictionary.ContainsKey(key))
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
+    }
+
+    public static void ShouldNotContainKey<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
+        where TKey : notnull
+    {
+        if (dictionary.ContainsKey(key))
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
+    }
+
+    public static void ShouldContainKeyAndValue<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
+        where TKey : notnull
+    {
+        if (!dictionary.ContainsKey(key) || !Equals(dictionary[key], val))
+            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
+    }
+
+    public static void ShouldNotContainValueForKey<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
+        where TKey : notnull
+    {
+        if (!dictionary.ContainsKey(key) || Equals(dictionary[key], val))
+            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
+    }
+
+    public static void ShouldContainKey<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
+        where TKey : notnull
+    {
+        if (!dictionary.ContainsKey(key))
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
+    }
+
+    public static void ShouldNotContainKey<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
+        where TKey : notnull
+    {
+        if (dictionary.ContainsKey(key))
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
+    }
+
+    public static void ShouldContainKeyAndValue<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
+        where TKey : notnull
+    {
+        if (!dictionary.ContainsKey(key) || !Equals(dictionary[key], val))
+            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
+    }
+
+    public static void ShouldNotContainValueForKey<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
+        where TKey : notnull
+    {
+        if (!dictionary.ContainsKey(key) || Equals(dictionary[key], val))
+            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
+    }
 }


### PR DESCRIPTION
- Add assertion methods for `IReadOnlyDictionary<K, V>` using `net9.0` and later only so that `[OverloadResolutionPriority]` can be used to avoid ambiguity caused by types that implement both dictionary interfaces.
- Update to .NET 9 SDK and C# 13.

Resolves #834.
