### PR TITLE
Provide simple As extension

### DIFF
--- a/src/Shouldly.Tests/ExtensionsTests.cs
+++ b/src/Shouldly.Tests/ExtensionsTests.cs
@@ -1,0 +1,27 @@
+﻿namespace Shouldly.Tests;
+
+public class ExtensionsTests
+{
+    [Fact]
+    public void Should_Cast_To_Object()
+    {
+        Should.NotThrow(
+            () => 1.As<object>());
+    }
+
+    [Fact]
+    public void Should_Cast_To_Type()
+    {
+        object person = new MyThing();
+        Should.NotThrow(
+            () => person.As<MyThing>().ShouldNotBeNull());
+    }
+
+    [Fact]
+    public void Should_Return_Null()
+    {
+        object person = new MyThing();
+        Should.NotThrow(
+            () => person.As<MyDecoratedThing>().ShouldBeNull());
+    }
+}

--- a/src/Shouldly/Extensions.cs
+++ b/src/Shouldly/Extensions.cs
@@ -1,0 +1,17 @@
+﻿namespace Shouldly;
+
+/// <summary>
+/// Common extensions
+/// </summary>
+public static class Extensions
+{
+    /// <summary>
+    /// Casts the subject to the specified type if possible, otherwise returns null.
+    /// </summary>
+    /// <typeparam name="TTo">The type to cast the subject to.</typeparam>
+    /// <param name="subject">The subject to be casted.</param>
+    public static TTo? As<TTo>(this object? subject)
+    {
+        return subject is TTo to ? to : default;
+    }
+}


### PR DESCRIPTION
Provides a simple `As<MyType>()' extension to don't break the fluent API.

So instead of
```csharp
((PersonList)myContainer.Result).ShouldContain("test");
````
you can write
```csharp
myContainer.Result.As<PersonList>().ShouldContain("test");
```