### PR TITLE
Extend the ShouldContainKey methods

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -167,20 +167,28 @@ namespace Shouldly
     {
         public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
             where TKey :  notnull { }
+        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> dictionary, TKey key, string? customMessage = null)
+            where TKey :  notnull { }
         [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
             where TKey :  notnull { }
         public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
+            where TKey :  notnull { }
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> dictionary, TKey key, TValue val, string? customMessage = null)
             where TKey :  notnull { }
         [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
             where TKey :  notnull { }
         public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
             where TKey :  notnull { }
+        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> dictionary, TKey key, string? customMessage = null)
+            where TKey :  notnull { }
         [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null)
             where TKey :  notnull { }
         public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)
+            where TKey :  notnull { }
+        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> dictionary, TKey key, TValue val, string? customMessage = null)
             where TKey :  notnull { }
         [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null)

--- a/src/Shouldly.Tests/Dictionaries/DictionaryTestData.cs
+++ b/src/Shouldly.Tests/Dictionaries/DictionaryTestData.cs
@@ -21,6 +21,14 @@ internal static class DictionaryTestData
     public static IReadOnlyDictionary<Guid, Guid> GuidIReadOnlyDictionary() => GuidDictionary();
     public static IReadOnlyDictionary<string, string> StringIReadOnlyDictionary() => StringDictionary();
 
+    public static List<KeyValuePair<MyThing, MyThing>> ClassKeyValuePairList() => new(_classDictionary);
+    public static List<KeyValuePair<Guid, Guid>> GuidKeyValuePairList() => new(_guidDictionary);
+    public static List<KeyValuePair<string, string>> StringKeyValuePairList() => new(_stringDictionary);
+
+    public static IEnumerable<KeyValuePair<MyThing, MyThing>> ClassIEnumerableOfKeyValuePair() => ClassKeyValuePairList();
+    public static IEnumerable<KeyValuePair<Guid, Guid>> GuidIEnumerableOfKeyValuePair() => GuidKeyValuePairList();
+    public static IEnumerable<KeyValuePair<string, string>> StringIEnumerableOfKeyValuePair() => StringKeyValuePairList();
+
     private static readonly Dictionary<MyThing, MyThing> _classDictionary = new()
     {
         { ThingKey, ThingValue }

--- a/src/Shouldly.Tests/Dictionaries/ShouldContainKey.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldContainKey.cs
@@ -154,6 +154,156 @@ Additional Info:
     Some additional context");
     }
 
+    [Fact]
+    public void ClassScenarioShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                ClassKeyValuePairList().ShouldContainKey(new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassKeyValuePairList()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void GuidScenarioShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                GuidKeyValuePairList().ShouldContainKey(MissingGuidKey, "Some additional context"),
+
+            errorWithSource:
+            @"GuidKeyValuePairList()
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                StringKeyValuePairList().ShouldContainKey("bar", "Some additional context"),
+
+            errorWithSource:
+            @"StringKeyValuePairList()
+    should contain key
+""bar""
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should contain key
+""bar""
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ClassScenarioShouldFailForIEnumerableIfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                ClassIEnumerableOfKeyValuePair().ShouldContainKey(new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassIEnumerableOfKeyValuePair()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void GuidScenarioShouldFailForIEnumerableIfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                GuidIEnumerableOfKeyValuePair().ShouldContainKey(MissingGuidKey, "Some additional context"),
+
+            errorWithSource:
+            @"GuidIEnumerableOfKeyValuePair()
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIEnumerableIfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                StringIEnumerableOfKeyValuePair().ShouldContainKey("bar", "Some additional context"),
+
+            errorWithSource:
+            @"StringIEnumerableOfKeyValuePair()
+    should contain key
+""bar""
+    but does not
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should contain key
+""bar""
+    but does not
+
+Additional Info:
+    Some additional context");
+    }
+
 #if NET9_0_OR_GREATER
     [Fact]
     public void ClassScenarioShouldFailForIReadOnlyDictionary()
@@ -241,6 +391,14 @@ Additional Info:
         ClassIDictionary().ShouldContainKey(ThingKey);
         GuidIDictionary().ShouldContainKey(GuidKey);
         StringIDictionary().ShouldContainKey("Foo");
+
+        ClassKeyValuePairList().ShouldContainKey(ThingKey);
+        GuidKeyValuePairList().ShouldContainKey(GuidKey);
+        StringKeyValuePairList().ShouldContainKey("Foo");
+
+        ClassIEnumerableOfKeyValuePair().ShouldContainKey(ThingKey);
+        GuidIEnumerableOfKeyValuePair().ShouldContainKey(GuidKey);
+        StringIEnumerableOfKeyValuePair().ShouldContainKey("Foo");
 
 #if NET9_0_OR_GREATER
         ClassIReadOnlyDictionary().ShouldContainKey(ThingKey);

--- a/src/Shouldly.Tests/Dictionaries/ShouldContainKeyAndValue.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldContainKeyAndValue.cs
@@ -368,6 +368,370 @@ Additional Info:
     Some additional context");
     }
 
+    [Fact]
+    public void ShouldContainKeyAndValueWithClassesShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                ClassKeyValuePairList().ShouldContainKeyAndValue(new(), new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassKeyValuePairList()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void GuidScenarioShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                GuidKeyValuePairList().ShouldContainKeyAndValue(MissingGuidKey, MissingGuidValue, "Some additional context"),
+
+            errorWithSource:
+            @"GuidKeyValuePairList()
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    with value
+f08a0b08-c9f4-49bb-a4d4-be06e88b69c8
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    with value
+f08a0b08-c9f4-49bb-a4d4-be06e88b69c8
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void OnlyKeyMatchesShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                ClassKeyValuePairList().ShouldContainKeyAndValue(ThingKey, new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassKeyValuePairList()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+Shouldly.Tests.TestHelpers.MyThing (000000)
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+Shouldly.Tests.TestHelpers.MyThing (000000)
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void OnlyValueMatchesShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                ClassKeyValuePairList().ShouldContainKeyAndValue(new(), ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassKeyValuePairList()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                StringKeyValuePairList().ShouldContainKeyAndValue("bar", "baz", "Some additional context"),
+
+            errorWithSource:
+            @"StringKeyValuePairList()
+    should contain key
+""bar""
+    with value
+""baz""
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should contain key
+""bar""
+    with value
+""baz""
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ValueIsNullShouldFailForKeyValuePairList()
+    {
+        var dictionaryWithNullValue = new List<KeyValuePair<MyThing, MyThing?>>
+        {
+            new(ThingKey, null)
+        };
+        Verify.ShouldFail(() =>
+                dictionaryWithNullValue.ShouldContainKeyAndValue(ThingKey, new(), "Some additional context"),
+
+            errorWithSource:
+            @"dictionaryWithNullValue
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+null
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => null]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+null
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ShouldContainKeyAndValueWithClassesShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                ClassIEnumerableOfKeyValuePair().ShouldContainKeyAndValue(new(), new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassIEnumerableOfKeyValuePair()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void GuidScenarioShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                GuidIEnumerableOfKeyValuePair().ShouldContainKeyAndValue(MissingGuidKey, MissingGuidValue, "Some additional context"),
+
+            errorWithSource:
+            @"GuidIEnumerableOfKeyValuePair()
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    with value
+f08a0b08-c9f4-49bb-a4d4-be06e88b69c8
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should contain key
+1924e617-2fc2-47ae-ad38-b6f30ec2226b
+    with value
+f08a0b08-c9f4-49bb-a4d4-be06e88b69c8
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void OnlyKeyMatchesShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                ClassIEnumerableOfKeyValuePair().ShouldContainKeyAndValue(ThingKey, new(), "Some additional context"),
+
+            errorWithSource:
+            @"ClassIEnumerableOfKeyValuePair()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+Shouldly.Tests.TestHelpers.MyThing (000000)
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+Shouldly.Tests.TestHelpers.MyThing (000000)
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void OnlyValueMatchesShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                ClassIEnumerableOfKeyValuePair().ShouldContainKeyAndValue(new(), ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIEnumerableOfKeyValuePair()
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                StringIEnumerableOfKeyValuePair().ShouldContainKeyAndValue("bar", "baz", "Some additional context"),
+
+            errorWithSource:
+            @"StringIEnumerableOfKeyValuePair()
+    should contain key
+""bar""
+    with value
+""baz""
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should contain key
+""bar""
+    with value
+""baz""
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ValueIsNullShouldFailForIEnumerableOfKeyValuePair()
+    {
+        IEnumerable<KeyValuePair<MyThing, MyThing?>> dictionaryWithNullValue = new List<KeyValuePair<MyThing, MyThing?>>
+        {
+           new( ThingKey, null )
+        };
+        Verify.ShouldFail(() =>
+                dictionaryWithNullValue.ShouldContainKeyAndValue(ThingKey, new(), "Some additional context"),
+
+            errorWithSource:
+            @"dictionaryWithNullValue
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+null
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => null]]
+    should contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but value was
+null
+
+Additional Info:
+    Some additional context");
+    }
+
 #if NET9_0_OR_GREATER
     [Fact]
     public void ShouldContainKeyAndValueWithClassesShouldFailForIReadOnlyDictionary()

--- a/src/Shouldly.Tests/Dictionaries/ShouldNotContainKey.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldNotContainKey.cs
@@ -154,6 +154,156 @@ Additional Info:
     Some additional context");
     }
 
+    [Fact]
+    public void ShouldNotContainKeyClassScenarioShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                ClassKeyValuePairList().ShouldNotContainKey(ThingKey, "Some additional context"),
+
+            errorWithSource:
+            @"ClassKeyValuePairList()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ShouldNotContainKeyGuidScenarioShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                GuidKeyValuePairList().ShouldNotContainKey(GuidKey, "Some additional context"),
+
+            errorWithSource:
+            @"GuidKeyValuePairList()
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                StringKeyValuePairList().ShouldNotContainKey("Foo", "Some additional context"),
+
+            errorWithSource:
+            @"StringKeyValuePairList()
+    should not contain key
+""Foo""
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should not contain key
+""Foo""
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ShouldNotContainKeyClassScenarioShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                ClassIEnumerableOfKeyValuePair().ShouldNotContainKey(ThingKey, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIEnumerableOfKeyValuePair()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ShouldNotContainKeyGuidScenarioShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                GuidIEnumerableOfKeyValuePair().ShouldNotContainKey(GuidKey, "Some additional context"),
+
+            errorWithSource:
+            @"GuidIEnumerableOfKeyValuePair()
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                StringIEnumerableOfKeyValuePair().ShouldNotContainKey("Foo", "Some additional context"),
+
+            errorWithSource:
+            @"StringIEnumerableOfKeyValuePair()
+    should not contain key
+""Foo""
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should not contain key
+""Foo""
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
 #if NET9_0_OR_GREATER
     [Fact]
     public void ShouldNotContainKeyClassScenarioShouldFailForIReadOnlyDictionary()

--- a/src/Shouldly.Tests/Dictionaries/ShouldNotContainValueForKey.cs
+++ b/src/Shouldly.Tests/Dictionaries/ShouldNotContainValueForKey.cs
@@ -361,6 +361,363 @@ Additional Info:
     Some additional context");
     }
 
+    [Fact]
+    public void ClassScenarioShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                ClassKeyValuePairList().ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassKeyValuePairList()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void GuidScenarioShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                GuidKeyValuePairList().ShouldNotContainValueForKey(GuidKey, GuidValue, "Some additional context"),
+
+            errorWithSource:
+            @"GuidKeyValuePairList()
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    with value
+fa1e5f58-578f-43d4-b4d6-67eae06a5d17
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    with value
+fa1e5f58-578f-43d4-b4d6-67eae06a5d17
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void KeyAndValueExistShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                ClassKeyValuePairList().ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassKeyValuePairList()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void NoKeyExistsShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                ClassKeyValuePairList().ShouldNotContainValueForKey(new(), ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassKeyValuePairList()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForKeyValuePairList()
+    {
+        Verify.ShouldFail(() =>
+                StringKeyValuePairList().ShouldNotContainValueForKey("Foo", "Bar", "Some additional context"),
+
+            errorWithSource:
+            @"StringKeyValuePairList()
+    should not contain key
+""Foo""
+    with value
+""Bar""
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should not contain key
+""Foo""
+    with value
+""Bar""
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ValueIsNullShouldFailForKeyValuePairList()
+    {
+        var dictionary = new List<KeyValuePair<MyThing, MyThing?>>
+        {
+            new(ThingKey, null )
+        };
+        Verify.ShouldFail(() =>
+                dictionary.ShouldNotContainValueForKey(ThingKey, null, "Some additional context"),
+
+            errorWithSource:
+            @"dictionary
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+null
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => null]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+null
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+
+    [Fact]
+    public void ClassScenarioShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                ClassIEnumerableOfKeyValuePair().ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIEnumerableOfKeyValuePair()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void GuidScenarioShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                GuidIEnumerableOfKeyValuePair().ShouldNotContainValueForKey(GuidKey, GuidValue, "Some additional context"),
+
+            errorWithSource:
+            @"GuidIEnumerableOfKeyValuePair()
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    with value
+fa1e5f58-578f-43d4-b4d6-67eae06a5d17
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[edae0d73-8e4c-4251-85c8-e5497c7ccad1 => fa1e5f58-578f-43d4-b4d6-67eae06a5d17]]
+    should not contain key
+edae0d73-8e4c-4251-85c8-e5497c7ccad1
+    with value
+fa1e5f58-578f-43d4-b4d6-67eae06a5d17
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void KeyAndValueExistShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                ClassIEnumerableOfKeyValuePair().ShouldNotContainValueForKey(ThingKey, ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIEnumerableOfKeyValuePair()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void NoKeyExistsShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                ClassIEnumerableOfKeyValuePair().ShouldNotContainValueForKey(new(), ThingValue, "Some additional context"),
+
+            errorWithSource:
+            @"ClassIEnumerableOfKeyValuePair()
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => Shouldly.Tests.TestHelpers.MyThing (000000)]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    but the key does not exist
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void StringScenarioShouldFailForIEnumerableOfKeyValuePair()
+    {
+        Verify.ShouldFail(() =>
+                StringIEnumerableOfKeyValuePair().ShouldNotContainValueForKey("Foo", "Bar", "Some additional context"),
+
+            errorWithSource:
+            @"StringIEnumerableOfKeyValuePair()
+    should not contain key
+""Foo""
+    with value
+""Bar""
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[""Foo"" => ""Bar""]]
+    should not contain key
+""Foo""
+    with value
+""Bar""
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
+    [Fact]
+    public void ValueIsNullShouldFailForIEnumerableOfKeyValuePair()
+    {
+        IEnumerable<KeyValuePair<MyThing, MyThing?>> dictionary = new List<KeyValuePair<MyThing, MyThing?>>
+        {
+            new(ThingKey, null)
+        };
+        Verify.ShouldFail(() =>
+                dictionary.ShouldNotContainValueForKey(ThingKey, null, "Some additional context"),
+
+            errorWithSource:
+            @"dictionary
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+null
+    but does
+
+Additional Info:
+    Some additional context",
+
+            errorWithoutSource:
+            @"[[Shouldly.Tests.TestHelpers.MyThing (000000) => null]]
+    should not contain key
+Shouldly.Tests.TestHelpers.MyThing (000000)
+    with value
+null
+    but does
+
+Additional Info:
+    Some additional context");
+    }
+
 #if NET9_0_OR_GREATER
     [Fact]
     public void ClassScenarioShouldFailForIReadOnlyDictionary()

--- a/src/Shouldly/MessageGenerators/DictionaryShouldContainKeyAndValueMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryShouldContainKeyAndValueMessageGenerator.cs
@@ -9,7 +9,7 @@ class DictionaryShouldContainKeyAndValueMessageGenerator : ShouldlyMessageGenera
 
     public override string GenerateErrorMessage(IShouldlyAssertionContext context)
     {
-        Debug.Assert(context.Actual is IDictionary);
+        Debug.Assert(context.Actual is IDictionary || context.Actual is IEnumerable);
         Debug.Assert(context.Key is object);
 
         const string format =
@@ -21,7 +21,7 @@ class DictionaryShouldContainKeyAndValueMessageGenerator : ShouldlyMessageGenera
 {3}";
 
         var codePart = context.CodePart;
-        var dictionary = (IDictionary)context.Actual;
+        var dictionary = context.Actual as IDictionary ?? Convert((IEnumerable)context.Actual);
         var keyExists = dictionary.Contains(context.Key);
         var expected = context.Expected.ToStringAwesomely();
         var keyValue = context.Key.ToStringAwesomely();
@@ -36,5 +36,21 @@ class DictionaryShouldContainKeyAndValueMessageGenerator : ShouldlyMessageGenera
         }
 
         return string.Format(format, codePart, keyValue, expected, "    but the key does not exist");
+    }
+
+    internal static Dictionary<object, object?> Convert(IEnumerable list)
+    {
+        var result = new Dictionary<object, object?>();
+        PropertyInfo? keyProperty = null;
+        PropertyInfo? valueProperty = null;
+
+        foreach (var entry in list)
+        {
+            var key = (keyProperty ?? entry.GetType().GetProperty("Key"))?.GetValue(entry, null);
+            var value = (valueProperty ?? entry.GetType().GetProperty("Value"))?.GetValue(entry, null);
+            result.Add(key!, value);
+        }
+
+        return result;
     }
 }

--- a/src/Shouldly/MessageGenerators/DictionaryShouldNotContainValueForKeyMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryShouldNotContainValueForKeyMessageGenerator.cs
@@ -8,7 +8,7 @@ class DictionaryShouldNotContainValueForKeyMessageGenerator : ShouldlyMessageGen
 
     public override string GenerateErrorMessage(IShouldlyAssertionContext context)
     {
-        Debug.Assert(context.Actual is IDictionary);
+        Debug.Assert(context.Actual is IDictionary || context.Actual is IEnumerable);
         Debug.Assert(context.Key is object);
 
         const string format =
@@ -20,7 +20,7 @@ class DictionaryShouldNotContainValueForKeyMessageGenerator : ShouldlyMessageGen
     {3}";
 
         var codePart = context.CodePart;
-        var dictionary = (IDictionary)context.Actual;
+        var dictionary = context.Actual as IDictionary ?? DictionaryShouldContainKeyAndValueMessageGenerator.Convert((IEnumerable)context.Actual);
         var keyExists = dictionary.Contains(context.Key);
         var expected = context.Expected.ToStringAwesomely();
         var keyValue = context.Key.ToStringAwesomely();

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
@@ -1,4 +1,5 @@
-﻿#if NET9_0_OR_GREATER
+﻿
+#if NET9_0_OR_GREATER
 using System.Runtime.CompilerServices;
 #endif
 
@@ -33,7 +34,35 @@ public static partial class ShouldBeDictionaryTestExtensions
         where TKey : notnull
     {
         if (!dictionary.ContainsKey(key) || Equals(dictionary[key], val))
-            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key,  customMessage).ToString());
+            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
+    }
+
+    public static void ShouldContainKey<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key, string? customMessage = null)
+        where TKey : notnull
+    {
+        if (!dictionary.Any(entry => Equals(entry.Key, key)))
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
+    }
+
+    public static void ShouldNotContainKey<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key, string? customMessage = null)
+        where TKey : notnull
+    {
+        if (dictionary.Any(entry => Equals(entry.Key, key)))
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage).ToString());
+    }
+
+    public static void ShouldContainKeyAndValue<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key, TValue val, string? customMessage = null)
+       where TKey : notnull
+    {
+        if (!dictionary.Any(entry => Equals(entry.Key, key) && Equals(entry.Value, val)))
+            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
+    }
+
+    public static void ShouldNotContainValueForKey<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key, TValue val, string? customMessage = null)
+        where TKey : notnull
+    {
+        if (!dictionary.Any(entry => Equals(entry.Key, key)) || dictionary.Any(entry => Equals(entry.Key, key) && Equals(entry.Value, val)))
+            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage).ToString());
     }
 
 #if NET9_0_OR_GREATER


### PR DESCRIPTION
Extend the ShouldContainKey/Value methods for list of KeyValuePairs.

Many classes in the BCL or AspNetCore runtime do not use `IDictionary<Key,Value>`, they use `IEnumerable<KeyValuePair<Key,Value>>` instead.

This PR provides the `ShouldContainKey`, `ShouldContainKeyAndValue`, `ShouldNotContainKey` and `ShouldNotContainValueForKey` methods for those lists.