### PR TITLE
fix PackageLicenseExpression in nuget

### DIFF
--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -14,7 +14,7 @@
     <PackageTags>test;unit;testing;TDD;AAA;should;testunit;rspec;assert;assertion;framework</PackageTags>
     <PackageIcon>assets/logo_128x128.png</PackageIcon>
     <PackageProjectUrl>https://docs.shouldly.org</PackageProjectUrl>
-    <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/shouldly/shouldly.git</RepositoryUrl>
     <PackageReleaseNotes>https://github.com/shouldly/shouldly/releases/tag/$(Version)</PackageReleaseNotes>


### PR DESCRIPTION
The PackageLicenseExpression was incorrectly using the BSD2 expression. This does not correcly match the projects license of BSD3 https://github.com/shouldly/shouldly?tab=License-1-ov-file 

fixes #941

This effectively makes it clear that clause 3 applies to both the packaged nuget and the source code consistently

> 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.