### PR TITLE
Add xunit v3 marker interfaces

### DIFF
--- a/src/Shouldly/Internals/XunitV3Markers/IAssertionException.cs
+++ b/src/Shouldly/Internals/XunitV3Markers/IAssertionException.cs
@@ -1,0 +1,6 @@
+namespace Shouldly.Internals.XunitV3Markers;
+
+/// <summary>
+/// This is a marker interface to allow xUnit.net v3 to detect a test has failed caused by an assertion.
+/// </summary>
+internal interface IAssertionException;

--- a/src/Shouldly/Internals/XunitV3Markers/ITestTimeoutException.cs
+++ b/src/Shouldly/Internals/XunitV3Markers/ITestTimeoutException.cs
@@ -1,0 +1,6 @@
+namespace Shouldly.Internals.XunitV3Markers;
+
+/// <summary>
+/// This is a marker interface to allow xUnit.net v3 to detect a test has failed caused by a timeout.
+/// </summary>
+internal interface ITestTimeoutException;

--- a/src/Shouldly/ShouldAssertException.cs
+++ b/src/Shouldly/ShouldAssertException.cs
@@ -1,9 +1,10 @@
 ﻿using Shouldly.Internals;
+using Shouldly.Internals.XunitV3Markers;
 
 namespace Shouldly;
 
 [Serializable]
-public class ShouldAssertException : Exception
+public class ShouldAssertException : Exception, IAssertionException
 {
     public ShouldAssertException(string? message) : base(message)
     {

--- a/src/Shouldly/ShouldlyTimeoutException.cs
+++ b/src/Shouldly/ShouldlyTimeoutException.cs
@@ -1,8 +1,9 @@
 ﻿using Shouldly.Internals;
+using Shouldly.Internals.XunitV3Markers;
 
 namespace Shouldly;
 
-public class ShouldlyTimeoutException : TimeoutException
+public class ShouldlyTimeoutException : TimeoutException, ITestTimeoutException
 {
     public ShouldlyTimeoutException()
     {


### PR DESCRIPTION
Fixes #996 

I've tested locally with an ad-hoc test project. Not sure of a better way to test other than doing `dotnet run -- -reporter json`, which outputs:
```json
// ...
"Cause": "Assertion",
// ...
```
and 
```json
// ...
"Cause": "Timeout",
// ...
```
accordingly.