### PR TITLE
Fix handling of zero tolerances

### DIFF
--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeOffsetScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeOffsetScenario.cs
@@ -46,4 +46,11 @@ public class DateTimeOffsetScenario
         var date = new DateTimeOffset(new DateTime(2000, 6, 1), TimeSpan.Zero);
         date.ShouldBe(new(new DateTime(2000, 6, 1, 1, 0, 1), TimeSpan.Zero), TimeSpan.FromHours(1.5));
     }
+
+    [Fact]
+    public void ShouldPassWithZeroTolerance()
+    {
+        var date = new DateTimeOffset(new DateTime(2000, 6, 1), TimeSpan.Zero);
+        date.ShouldBe(date, TimeSpan.Zero);
+    }
 }

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/DateTimeScenario.cs
@@ -81,4 +81,11 @@ public class DateTimeScenario
         var date = new DateTime(2000, 6, 1);
         date.ShouldBe(new(2000, 6, 1, 1, 0, 1), TimeSpan.FromHours(1.5d));
     }
+
+    [Fact]
+    public void ShouldPassWithZeroTolerance()
+    {
+        var date = new DateTime(2000, 6, 1);
+        date.ShouldBe(date, TimeSpan.Zero);
+    }
 }

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/DecimalScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/DecimalScenario.cs
@@ -44,4 +44,11 @@ public class DecimalScenario
         const decimal pi = (decimal)MathEx.PI;
         pi.ShouldBe(3.14m, 0.01m);
     }
+
+    [Fact]
+    public void ShouldPassWithZeroTolerance()
+    {
+        const decimal pi = (decimal)MathEx.PI;
+        pi.ShouldBe(pi, 0);
+    }
 }

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/DoubleScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/DoubleScenario.cs
@@ -44,4 +44,11 @@ public class DoubleScenario
         const double pi = MathEx.PI;
         pi.ShouldBe(3.14d, 0.01d);
     }
+
+    [Fact]
+    public void ShouldPassWithZeroTolerance()
+    {
+        const double pi = MathEx.PI;
+        pi.ShouldBe(pi, 0);
+    }
 }

--- a/src/Shouldly.Tests/ShouldBe/WithTolerance/TimeSpanScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/WithTolerance/TimeSpanScenario.cs
@@ -43,4 +43,46 @@ public class TimeSpanScenario
         var timeSpan = TimeSpan.FromHours(1);
         timeSpan.ShouldBe(timeSpan.Add(TimeSpan.FromHours(1.1d)), TimeSpan.FromHours(1.5d));
     }
+
+    [Fact]
+    public void ShouldPassWithZeroTolerance()
+    {
+        var timeSpan = TimeSpan.FromHours(1);
+        timeSpan.ShouldBe(timeSpan, TimeSpan.Zero);
+    }
+
+    [Fact]
+    public void TimeSpanScenarioShouldFailWithZeroTolerance()
+    {
+        var timeSpan = TimeSpan.FromHours(1);
+        Verify.ShouldFail(() =>
+                timeSpan.ShouldNotBe(timeSpan, TimeSpan.Zero, "Some additional context"),
+
+            errorWithSource:
+            """
+            timeSpan
+                should not be within
+            00:00:00
+                of
+            01:00:00
+                but was
+            01:00:00
+
+            Additional Info:
+                Some additional context
+            """,
+
+            errorWithoutSource:
+            """
+            01:00:00
+                should not be within
+            00:00:00
+                of
+            01:00:00
+                but was not
+
+            Additional Info:
+                Some additional context
+            """);
+    }
 }

--- a/src/Shouldly/Internals/Is.cs
+++ b/src/Shouldly/Internals/Is.cs
@@ -150,18 +150,18 @@ static class Is
     }
 
     public static bool Equal(decimal actual, decimal expected, decimal tolerance) =>
-        Math.Abs(actual - expected) < tolerance;
+        Math.Abs(actual - expected) <= tolerance;
 
     public static bool Equal(double actual, double expected, double tolerance) =>
-        Math.Abs(actual - expected) < tolerance;
+        Math.Abs(actual - expected) <= tolerance;
 
     public static bool Equal(DateTime actual, DateTime expected, TimeSpan tolerance) =>
-        (actual - expected).Duration() < tolerance;
+        (actual - expected).Duration() <= tolerance;
 
     public static bool Equal(DateTimeOffset actual, DateTimeOffset expected, TimeSpan tolerance) =>
-        (actual - expected).Duration() < tolerance;
+        (actual - expected).Duration() <= tolerance;
 
-    public static bool Equal(TimeSpan actual, TimeSpan expected, TimeSpan tolerance) => (actual - expected).Duration() < tolerance;
+    public static bool Equal(TimeSpan actual, TimeSpan expected, TimeSpan tolerance) => (actual - expected).Duration() <= tolerance;
 
     public static bool StringMatchingRegex(string actual, [RegexPattern] string regexPattern) =>
         Regex.IsMatch(actual, regexPattern);


### PR DESCRIPTION
Fix assertions incorrectly failing when a tolerance of "zero" for the type is used.

I migrated Polly from FluentAssertions to Shouldly over the weekend and we had a test like this:

```csharp
value.Should().BeCloseTo(expected, TimeSpan.Zero); // value is a TimeSpan
```

Migrating to Shouldly, I changed this to:

```csharp
value.ShouldBe(expected, TimeSpan.Zero);
```

The test then failed despite the values being equal.

I guess the original author wanted to be explicit? This was easily resolved by just changing the assertion to `value.ShouldBe(expected)`.

This PR fixes that behaviour by changing `<` to `<=` for `TimeSpan`, as well as `decimal`, `double`, `DateTime` and `DateTimeOffset` that also have the same issue.

If non-zero tolerances being equal _shouldn't_ match, then an alternative fix could be to special-case "zero" for these cases in `Is`.
