### PR TITLE
Added ShouldBeEmpty method for Guid #1062

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -65,6 +65,11 @@ namespace Shouldly
     {
         public ExpectedShouldlyMessage(object? expected, string? customMessage, [System.Runtime.CompilerServices.CallerMemberName] string shouldlyMethod = null) { }
     }
+    [Shouldly.ShouldlyMethods]
+    public static class GuidShouldBeTestExtensions
+    {
+        public static void ShouldBeEmpty(this System.Guid actual, string? customMessage = null) { }
+    }
     public interface IShouldlyAssertionContext
     {
         object? Actual { get; set; }

--- a/src/Shouldly.Tests/ShouldBeEmpty/GuidScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEmpty/GuidScenario.cs
@@ -1,0 +1,42 @@
+﻿namespace Shouldly.Tests.ShouldBeEmpty;
+
+public class GuidScenario
+{
+    [Fact]
+    public void ShouldFail()
+    {
+        Guid myGuid = new Guid(1,2,3,4,5,6,7,8,9,10,11);
+
+        Verify.ShouldFail(() =>
+                myGuid.ShouldBeEmpty("Some additional context"),
+
+            errorWithSource:
+            """
+            myGuid
+                should be empty
+            00000000-0000-0000-0000-000000000000
+                but was
+            00000001-0002-0003-0405-060708090a0b
+
+            Additional Info:
+                Some additional context
+            """,
+
+            errorWithoutSource:
+            """
+            00000001-0002-0003-0405-060708090a0b
+                should be empty
+            00000000-0000-0000-0000-000000000000
+                but was not
+            
+            Additional Info:
+                Some additional context
+            """);
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        Guid.Empty.ShouldBeEmpty();
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GuidShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GuidShouldBeTestExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+
+namespace Shouldly;
+
+[ShouldlyMethods]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static partial class GuidShouldBeTestExtensions
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ShouldBeEmpty(this Guid actual, string? customMessage = null)
+    {
+        actual.AssertAwesomely(v => Is.Equal(Guid.Empty, v), actual, Guid.Empty, customMessage);
+    }
+}
+


### PR DESCRIPTION
Provides a `ShouldBeEmpty' method for Guid.

Fixes [#1062](https://github.com/shouldly/shouldly/issues/1062)