### PR TITLE
Feature/should be superset of

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -39,6 +39,7 @@
   * [Contain](documentation/enumerable/contain.md)
   * [Unique](documentation/enumerable/unique.md)
   * [SubsetOf](documentation/enumerable/subsetOf.md)
+  * [SupersetOf](documentation/enumerable/supersetOf.md)
   * [Have](documentation/enumerable/have.md)
 * [Dictionary](documentation/dictionary/README.md)
   * [ContainKey](documentation/dictionary/containKey.md)

--- a/documentation/documentation/enumerable/supersetOf.md
+++ b/documentation/documentation/enumerable/supersetOf.md
@@ -1,0 +1,30 @@
+# ShouldBeSupersetOf
+
+<!-- snippet: EnumerableShouldBeSupersetOfExamples.ShouldBeSupersetOf.codeSample.approved.cs -->
+<a id='snippet-EnumerableShouldBeSupersetOfExamples.ShouldBeSupersetOf.codeSample.approved.cs'></a>
+```cs
+var lisa = new Person { Name = "Lisa" };
+var bart = new Person { Name = "Bart" };
+var maggie = new Person { Name = "Maggie" };
+var homer = new Person { Name = "Homer" };
+var marge = new Person { Name = "Marge" };
+var ralph = new Person { Name = "Ralph" };
+var simpsonsKids = new List<Person> { bart, lisa, maggie, ralph };
+var simpsonsFamily = new List<Person> { lisa, bart, maggie, homer, marge };
+simpsonsFamily.ShouldBeSupersetOf(simpsonsKids);
+```
+<sup><a href='/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSupersetOfExamples.ShouldBeSupersetOf.codeSample.approved.cs#L1-L9' title='Snippet source file'>snippet source</a> | <a href='#snippet-EnumerableShouldBeSupersetOfExamples.ShouldBeSupersetOf.codeSample.approved.cs' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+**Exception**
+
+<!-- include: EnumerableShouldBeSupersetOfExamples.ShouldBeSupersetOf.exceptionText.approved.txt -->
+```
+simpsonsFamily
+    should be superset of
+[Lisa, Bart, Maggie, Homer, Marge]
+    but
+[Ralph]
+    is outside superset
+```
+<!-- endInclude -->

--- a/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSupersetOfExamples.ShouldBeSupersetOf.codeSample.approved.cs
+++ b/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSupersetOfExamples.ShouldBeSupersetOf.codeSample.approved.cs
@@ -1,0 +1,9 @@
+﻿var lisa = new Person { Name = "Lisa" };
+var bart = new Person { Name = "Bart" };
+var maggie = new Person { Name = "Maggie" };
+var homer = new Person { Name = "Homer" };
+var marge = new Person { Name = "Marge" };
+var ralph = new Person { Name = "Ralph" };
+var simpsonsKids = new List<Person> { bart, lisa, maggie, ralph };
+var simpsonsFamily = new List<Person> { lisa, bart, maggie, homer, marge };
+simpsonsFamily.ShouldBeSupersetOf(simpsonsKids);

--- a/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSupersetOfExamples.ShouldBeSupersetOf.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/EnumerableShouldBeSupersetOfExamples.ShouldBeSupersetOf.exceptionText.approved.txt
@@ -1,0 +1,8 @@
+﻿```
+simpsonsFamily
+    should be superset of
+[Bart, Lisa, Maggie, Ralph]
+    but
+[Ralph]
+    is outside superset
+```

--- a/src/DocumentationExamples/EnumerableShouldBeSupersetOfExamples.cs
+++ b/src/DocumentationExamples/EnumerableShouldBeSupersetOfExamples.cs
@@ -1,0 +1,27 @@
+public class EnumerableShouldBeSupersetOfExamples
+{
+    ITestOutputHelper _testOutputHelper;
+
+    public EnumerableShouldBeSupersetOfExamples(ITestOutputHelper testOutputHelper) =>
+        _testOutputHelper = testOutputHelper;
+
+    [Fact]
+    public void ShouldBeSupersetOf()
+    {
+        DocExampleWriter.Document(
+            () =>
+            {
+                var lisa = new Person { Name = "Lisa" };
+                var bart = new Person { Name = "Bart" };
+                var maggie = new Person { Name = "Maggie" };
+                var homer = new Person { Name = "Homer" };
+                var marge = new Person { Name = "Marge" };
+                var ralph = new Person { Name = "Ralph" };
+                var simpsonsKids = new List<Person> { bart, lisa, maggie, ralph };
+                var simpsonsFamily = new List<Person> { lisa, bart, maggie, homer, marge };
+
+                simpsonsFamily.ShouldBeSupersetOf(simpsonsKids);
+            },
+            _testOutputHelper);
+    }
+}

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -206,6 +206,8 @@ namespace Shouldly
         public static void ShouldBeOfTypes<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Type[] expected, string? customMessage) { }
         public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, string? customMessage = null) { }
         public static void ShouldBeSubsetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, System.Collections.Generic.IEqualityComparer<T> comparer, string? customMessage = null) { }
+        public static void ShouldBeSupersetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, string? customMessage = null) { }
+        public static void ShouldBeSupersetOf<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, System.Collections.Generic.IEqualityComparer<T> comparer, string? customMessage = null) { }
         public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEqualityComparer<T> comparer) { }
         public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual, string? customMessage = null) { }
         public static void ShouldBeUnique<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEqualityComparer<T> comparer, string? customMessage) { }

--- a/src/Shouldly.Tests/ShouldBeSupersetOf/ComparerScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSupersetOf/ComparerScenario.cs
@@ -1,0 +1,63 @@
+﻿namespace Shouldly.Tests.ShouldBe.ShouldBeSupersetOf;
+
+public class ComparerScenario
+{
+    [Fact]
+    public void ComparerEqualsShouldPass()
+    {
+        var comparison1 = new[]
+        {
+            new ComparableClass { Property = "Elephant", IgnoredProperty = "Dog" },
+            new ComparableClass { Property = "Lion", IgnoredProperty = "Spider" }
+        };
+        var comparison2 = new[]
+        {
+            new ComparableClass { Property = "Elephant", IgnoredProperty = "Duck" }
+        };
+
+        comparison1.ShouldBeSupersetOf(comparison2, new ComparableClassComparer());
+    }
+
+    [Fact]
+    public void ComparerNotEqualsShouldFail()
+    {
+        var comparison1 = new[]
+        {
+            new ComparableClass { Property = "Snake", IgnoredProperty = "Platypus" },
+            new ComparableClass { Property = "Cat", IgnoredProperty = "Ant" }
+        };
+        var comparison2 = new[]
+        {
+            new ComparableClass { Property = "Kangaroo", IgnoredProperty = "Whale" }
+        };
+
+        Verify.ShouldFail(() =>
+                comparison1.ShouldBeSupersetOf(comparison2, new ComparableClassComparer(), "Some additional context"),
+
+            errorWithSource:
+            """
+            comparison1
+                should be superset of
+            [Shouldly.Tests.TestHelpers.ComparableClass (000000)]
+                but
+            [Shouldly.Tests.TestHelpers.ComparableClass (000000)]
+                is outside superset
+
+            Additional Info:
+                Some additional context
+            """,
+
+            errorWithoutSource:
+            """
+            [Shouldly.Tests.TestHelpers.ComparableClass (000000), Shouldly.Tests.TestHelpers.ComparableClass (000000)]
+                should be superset of
+            [Shouldly.Tests.TestHelpers.ComparableClass (000000)]
+                but
+            [Shouldly.Tests.TestHelpers.ComparableClass (000000)]
+                is outside superset
+
+            Additional Info:
+                Some additional context
+            """);
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeSupersetOf/DecimalArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSupersetOf/DecimalArrayScenario.cs
@@ -1,0 +1,43 @@
+﻿namespace Shouldly.Tests.ShouldBeSupersetOf;
+
+public class DecimalArrayScenario
+{
+    [Fact]
+    public void DecimalArrayScenarioShouldFail()
+    {
+        Verify.ShouldFail(() =>
+                new[] { 2m, 3m, 4m }.ShouldBeSupersetOf([1m, 2m, 5m], "Some additional context"),
+
+            errorWithSource:
+            """
+            new[] { 2m, 3m, 4m }
+                should be superset of
+            [1m, 2m, 5m]
+                but
+            [1m, 5m]
+                are outside superset
+
+            Additional Info:
+                Some additional context
+            """,
+
+            errorWithoutSource:
+            """
+            [2m, 3m, 4m]
+                should be superset of
+            [1m, 2m, 5m]
+                but
+            [1m, 5m]
+                are outside superset
+
+            Additional Info:
+                Some additional context
+            """);
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        new[] { 1m, 2m, 3m }.ShouldBeSupersetOf([1m]);
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeSupersetOf/FloatArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSupersetOf/FloatArrayScenario.cs
@@ -1,0 +1,43 @@
+﻿namespace Shouldly.Tests.ShouldBeSupersetOf;
+
+public class FloatArrayScenario
+{
+    [Fact]
+    public void FloatArrayScenarioShouldFail()
+    {
+        Verify.ShouldFail(() =>
+                new[] { 2f, 3f, 4f }.ShouldBeSupersetOf([1f, 2f, 5f], "Some additional context"),
+
+            errorWithSource:
+            """
+            new[] { 2f, 3f, 4f }
+                should be superset of
+            [1f, 2f, 5f]
+                but
+            [1f, 5f]
+                are outside superset
+
+            Additional Info:
+                Some additional context
+            """,
+
+            errorWithoutSource:
+            """
+            [2f, 3f, 4f]
+                should be superset of
+            [1f, 2f, 5f]
+                but
+            [1f, 5f]
+                are outside superset
+
+            Additional Info:
+                Some additional context
+            """);
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        new[] { 1f, 2f, 3f }.ShouldBeSupersetOf([1f]);
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeSupersetOf/IntegerArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSupersetOf/IntegerArrayScenario.cs
@@ -1,0 +1,43 @@
+﻿namespace Shouldly.Tests.ShouldBeSupersetOf;
+
+public class IntegerArrayScenario
+{
+    [Fact]
+    public void IntegerArrayScenarioShouldFail()
+    {
+        Verify.ShouldFail(() =>
+                new[] { 2, 3, 4 }.ShouldBeSupersetOf([1, 2, 5], "Some additional context"),
+
+            errorWithSource:
+            """
+            new[] { 2, 3, 4 }
+                should be superset of
+            [1, 2, 5]
+                but
+            [1, 5]
+                are outside superset
+
+            Additional Info:
+                Some additional context
+            """,
+
+            errorWithoutSource:
+            """
+            [2, 3, 4]
+                should be superset of
+            [1, 2, 5]
+                but
+            [1, 5]
+                are outside superset
+
+            Additional Info:
+                Some additional context
+            """);
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        new[] { 1, 2, 3 }.ShouldBeSupersetOf([1]);
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeSupersetOf/ObjectArrayOfIntScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSupersetOf/ObjectArrayOfIntScenario.cs
@@ -1,0 +1,49 @@
+﻿namespace Shouldly.Tests.ShouldBeSupersetOf;
+
+public class ObjectArrayOfIntScenario
+{
+    [Fact]
+    public void ObjectArrayOfIntScenarioShouldFail()
+    {
+        var arr = new object[] { 1, 2 };
+        var arr2 = new object[] { 1, 2, 3 };
+
+        Verify.ShouldFail(() =>
+                arr.ShouldBeSupersetOf(arr2, "Some additional context"),
+
+            errorWithSource:
+            """
+            arr
+                should be superset of
+            [1, 2, 3]
+                but
+            [3]
+                is outside superset
+
+            Additional Info:
+                Some additional context
+            """,
+
+            errorWithoutSource:
+            """
+            [1, 2]
+                should be superset of
+            [1, 2, 3]
+                but
+            [3]
+                is outside superset
+
+            Additional Info:
+                Some additional context
+            """);
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        var arr = new object[] { 1, 2, 3, 4 };
+        var arr2 = new object[] { 1, 2, 3 };
+
+        arr.ShouldBeSupersetOf(arr2);
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeSupersetOf/StringArrayScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSupersetOf/StringArrayScenario.cs
@@ -1,0 +1,43 @@
+﻿namespace Shouldly.Tests.ShouldBeSupersetOf;
+
+public class StringArrayScenario
+{
+    [Fact]
+    public void StringArrayScenarioShouldFail()
+    {
+        Verify.ShouldFail(() =>
+                new[] { "1", "2" }.ShouldBeSupersetOf(["1", "2", "3"], "Some additional context"),
+
+            errorWithSource:
+            """
+            new[] { "1", "2" }
+                should be superset of
+            ["1", "2", "3"]
+                but
+            ["3"]
+                is outside superset
+
+            Additional Info:
+                Some additional context
+            """,
+
+            errorWithoutSource:
+            """
+            ["1", "2"]
+                should be superset of
+            ["1", "2", "3"]
+                but
+            ["3"]
+                is outside superset
+
+            Additional Info:
+                Some additional context
+            """);
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        new[] { "1", "2", "3", "4" }.ShouldBeSupersetOf(["1", "2", "3"]);
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeSupersetOf/SuccessScenarios.cs
+++ b/src/Shouldly.Tests/ShouldBeSupersetOf/SuccessScenarios.cs
@@ -1,0 +1,18 @@
+﻿namespace Shouldly.Tests.ShouldBeSupersetOf;
+
+public class SuccessScenarios
+{
+    [Fact]
+    public void ArrayIsSupoersetOfSelf()
+    {
+        var arr = new[] { 1 };
+
+        arr.ShouldBeSupersetOf(arr, "Some additional context");
+    }
+
+    [Fact]
+    public void AnythingIsSupersetOfEmptyArray()
+    {
+        new[]{1, 2, 3, 4}.ShouldBeSupersetOf([], "Some additional context");
+    }
+}

--- a/src/Shouldly/MessageGenerators/ShouldBeSupersetOfMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeSupersetOfMessageGenerator.cs
@@ -1,0 +1,30 @@
+namespace Shouldly.MessageGenerators;
+
+class ShouldBeSupersetOfMessageGenerator : ShouldlyMessageGenerator
+{
+    private static readonly Regex Validator = new("ShouldBeSupersetOf");
+
+    public override bool CanProcess(IShouldlyAssertionContext context) =>
+        Validator.IsMatch(context.ShouldMethod);
+
+    public override string GenerateErrorMessage(IShouldlyAssertionContext context)
+    {
+        var codePart = context.CodePart;
+        var expected = context.Expected.ToStringAwesomely();
+        var actualEnumerable = (context.Actual as IEnumerable ?? Enumerable.Empty<object>()).Cast<object>();
+        var expectedEnumerable = (context.Expected as IEnumerable ?? Enumerable.Empty<object>()).Cast<object>();
+
+        var extra = expectedEnumerable.Except(actualEnumerable).ToList();
+        var count = extra.Count;
+
+        return
+            $"""
+             {codePart}
+                 should be superset of
+             {expected}
+                 but
+             {extra.ToStringAwesomely()}
+                 {(count > 1 ? "are" : "is")} outside superset
+             """;
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -133,6 +133,28 @@ public static partial class ShouldBeEnumerableTestExtensions
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ShouldBeSupersetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected, string? customMessage = null)
+    {
+        if (actual.Equals(expected))
+            return;
+
+        var extra = expected.Except(actual);
+        if (extra.Any())
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ShouldBeSupersetOf<T>(this IEnumerable<T> actual, IEnumerable<T> expected, IEqualityComparer<T> comparer, string? customMessage = null)
+    {
+        if (actual.Equals(expected))
+            return;
+
+        var extra = expected.Except(actual, comparer);
+        if (extra.Any())
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage).ToString());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static void ShouldBeUnique<T>(this IEnumerable<T> actual, string? customMessage = null)
     {
         var duplicates = GetDuplicates(actual);

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -277,6 +277,7 @@ public abstract class ShouldlyMessage
         new ShouldBeIgnoringOrderMessageGenerator(),
         new ShouldSatisfyAllConditionsMessageGenerator(),
         new ShouldBeSubsetOfMessageGenerator(),
+        new ShouldBeSupersetOfMessageGenerator(),
         new ShouldHaveSingleItemMessageGenerator(),
         new ShouldBeBooleanMessageGenerator(),
         new ShouldNotThrowMessageGenerator(),
@@ -365,7 +366,7 @@ public abstract class ShouldlyMessage
         if (DifferenceHighlighter.CanHighlightDifferences(context))
         {
             message += $"""
-                        
+
                             difference
                         {DifferenceHighlighter.HighlightDifferences(context)}
                         """;


### PR DESCRIPTION
Implement ShouldBeSupersetOf test extension, analogue to ShouldBeSubsetOf.
Example usage:

```csharp
new[] {1, 2, 3}.ShouldBeSupersetOf([2, 3]);
```
