### PR TITLE
add AssertionScope

### DIFF
--- a/src/Shouldly.Tests/ShouldWithScope/ShouldThrowAggregateExceptionWithMultipleAssertionsScenario.cs
+++ b/src/Shouldly.Tests/ShouldWithScope/ShouldThrowAggregateExceptionWithMultipleAssertionsScenario.cs
@@ -1,0 +1,30 @@
+using Shouldly.ShouldlyExtensionMethods;
+
+namespace Shouldly.Tests.ShouldWithScope;
+
+public class ShouldThrowAggregateExceptionWithMultipleAssertionsScenario
+{
+    [Fact]
+    public void ShouldPass()
+    {
+        var actualInt = 5;
+        var expectedInt = 6;
+        var actualString = "hello";
+        var expectedString = "world";
+
+        var action = new Action(() =>
+        {
+            using (new AssertionScope())
+            {
+                // Use the generic extension method for any assertion.
+                actualInt.ShouldWithScope(x => x.ShouldBe(expectedInt));
+                actualString.ShouldWithScope(x => x.ShouldBe(expectedString));
+            }
+        });
+
+        var ex = action.ShouldThrow<AggregateShouldlyAssertionException>();
+        ex.ShouldBeOfType<AggregateShouldlyAssertionException>();
+        ex.ShouldNotBe(null);
+        ex.Errors.Count.ShouldBe(2);
+    }
+}

--- a/src/Shouldly.Tests/ShouldWithScope/ShouldThrowAggregateExceptionWithSingleAssertionScenario.cs
+++ b/src/Shouldly.Tests/ShouldWithScope/ShouldThrowAggregateExceptionWithSingleAssertionScenario.cs
@@ -1,0 +1,27 @@
+using Shouldly.ShouldlyExtensionMethods;
+
+namespace Shouldly.Tests.ShouldWithScope;
+
+public class ShouldThrowAggregateExceptionWithSingleAssertionScenario
+{
+    [Fact]
+    public void ShouldPass()
+    {
+        var actualString = "hello";
+        var expectedString = "world";
+
+        var action = new Action(() =>
+        {
+            using (new AssertionScope())
+            {
+                // Use the generic extension method for any assertion.
+                actualString.ShouldWithScope(x => x.ShouldBe(expectedString));
+            }
+        });
+
+        var ex = action.ShouldThrow<AggregateShouldlyAssertionException>();
+        ex.ShouldBeOfType<AggregateShouldlyAssertionException>();
+        ex.ShouldNotBe(null);
+        ex.Errors.Count.ShouldBe(1);
+    }
+}

--- a/src/Shouldly/AggregateShouldlyAssertionException.cs
+++ b/src/Shouldly/AggregateShouldlyAssertionException.cs
@@ -1,0 +1,10 @@
+namespace Shouldly;
+
+public class AggregateShouldlyAssertionException : Exception
+{
+    public IReadOnlyList<string> Errors { get; }
+
+    public AggregateShouldlyAssertionException(IEnumerable<string> errors)
+        : base("Multiple assertion failures occurred:" + Environment.NewLine + string.Join(Environment.NewLine, errors))
+        => Errors = new List<string>(errors);
+}

--- a/src/Shouldly/AssertionScope.cs
+++ b/src/Shouldly/AssertionScope.cs
@@ -1,0 +1,37 @@
+namespace Shouldly;
+
+public class AssertionScope : IDisposable
+{
+    private static readonly AsyncLocal<AssertionScope?> currentScope = new AsyncLocal<AssertionScope?>();
+
+    private readonly List<string> errors = new List<string>();
+
+    public AssertionScope() =>
+        // Set this instance as the current scope using AsyncLocal.
+        currentScope.Value = this;
+
+    // This method is called by assertion extensions when a failure occurs.
+    public static void AddFailure(string message)
+    {
+        if (currentScope.Value != null)
+        {
+            currentScope.Value.errors.Add(message);
+        }
+        else
+        {
+            // No active scope: throw immediately.
+            throw new ShouldAssertException(message);
+        }
+    }
+
+    public void Dispose()
+    {
+        // Clear the current scope.
+        currentScope.Value = null;
+
+        if (errors.Count > 0)
+        {
+            throw new AggregateShouldlyAssertionException(errors);
+        }
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldlyAssertionScopeExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldlyAssertionScopeExtensions.cs
@@ -1,0 +1,23 @@
+namespace Shouldly.ShouldlyExtensionMethods;
+
+public static class ShouldlyAssertionScopeExtensions
+{
+    /// <summary>
+    /// Executes an assertion on the current object and captures any assertion failure in the active AssertionScope.
+    /// </summary>
+    /// <typeparam name="T">Type of the object to assert on.</typeparam>
+    /// <param name="actual">The actual value to be asserted.</param>
+    /// <param name="assertion">A lambda that performs the assertion (e.g. x => x.ShouldBe(expected)).</param>
+    public static void ShouldWithScope<T>(this T actual, Action<T> assertion)
+    {
+        try
+        {
+            assertion(actual);
+        }
+        catch (ShouldAssertException ex)
+        {
+            // Capture the assertion failure in the active scope.
+            AssertionScope.AddFailure(ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
Add `AssertionScope` for Aggregated Error.

Sample Use:
```csharp
using (new AssertionScope())
{
    // Use the generic extension method for any assertion.
    actualInt.ShouldWithScope(x => x.ShouldBe(expectedInt));
    actualString.ShouldWithScope(x => x.ShouldBe(expectedString));
}
```