### PR TITLE
Fix ShouldBeEquivalentTo using incorrect types on complex objects

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -33,6 +33,11 @@ namespace Shouldly
         public static TException Throw<TException>(System.Action actual, string? customMessage = null)
             where TException : System.Exception { }
     }
+    public class EquivalencyOptions
+    {
+        public EquivalencyOptions() { }
+        public bool CompareUsingRuntimeTypes { get; set; }
+    }
     public class ExpectedActualIgnoreOrderShouldlyMessage : Shouldly.ShouldlyMessage
     {
         public ExpectedActualIgnoreOrderShouldlyMessage(object? expected, object? actual, string? customMessage, [System.Runtime.CompilerServices.CallerMemberName] string shouldlyMethod = null) { }
@@ -99,6 +104,7 @@ namespace Shouldly
     public static class ObjectGraphTestExtensions
     {
         public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, string? customMessage = null) { }
+        public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, Shouldly.EquivalencyOptions options, string? customMessage = null) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class Should

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -1,4 +1,4 @@
-﻿namespace Shouldly.Tests.ShouldBeEquivalentTo;
+namespace Shouldly.Tests.ShouldBeEquivalentTo;
 
 public class ObjectScenario
 {
@@ -178,7 +178,7 @@ public class ObjectScenario
             Comparing object equivalence, at path:
             subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
                 Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
-                    Adjectives [System.String[]]
+                    Adjectives [System.Collections.IEnumerable]
                         Element [0] [System.String]
             
                 Expected value to be
@@ -195,7 +195,7 @@ public class ObjectScenario
             Comparing object equivalence, at path:
             <root> [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
                 Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
-                    Adjectives [System.String[]]
+                    Adjectives [System.Collections.IEnumerable]
                         Element [0] [System.String]
             
                 Expected value to be
@@ -251,7 +251,7 @@ public class ObjectScenario
             Comparing object equivalence, at path:
             subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
                 Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
-                    Adjectives [System.String[]]
+                    Adjectives [System.Collections.IEnumerable]
                         Element [1] [System.String]
             
                 Expected value to be
@@ -268,7 +268,7 @@ public class ObjectScenario
             Comparing object equivalence, at path:
             <root> [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
                 Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
-                    Adjectives [System.String[]]
+                    Adjectives [System.Collections.IEnumerable]
                         Element [1] [System.String]
             
                 Expected value to be
@@ -319,6 +319,44 @@ public class ObjectScenario
                 Id = 6,
                 Name = "Sally",
                 Adjectives = new[] { "beautiful", "intelligent" },
+                Colors = ["purple", "orange"]
+            }
+        };
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldPassWhenComplexObjectContainsPropertiesWithDifferentTypes()
+    {
+        var subject = new FakeObject
+        {
+            Id = 5,
+            Name = "Bob",
+            Adjectives = new[] { "funny", "wise" },
+            Colors = ["red", "blue"],
+            TitleField = "Mr",
+            Child = new()
+            {
+                Id = 6,
+                Name = "Sally",
+                Adjectives = new[] { "beautiful", "intelligent" },
+                Colors = ["purple", "orange"]
+            }
+        };
+
+        var expected = new FakeObject
+        {
+            Id = 5,
+            TitleField = "Mr",
+            Name = "Bob",
+            Adjectives = new List<string> { "funny", "wise" }.Where(_ => true),
+            Colors = new [] {"red", "blue"}.AsReadOnly(),
+            Child = new()
+            {
+                Id = 6,
+                Name = "Sally",
+                Adjectives = new List<string> { "beautiful", "intelligent" },
                 Colors = ["purple", "orange"]
             }
         };

--- a/src/Shouldly/EquivalencyOptions.cs
+++ b/src/Shouldly/EquivalencyOptions.cs
@@ -1,0 +1,6 @@
+﻿namespace Shouldly;
+
+public class EquivalencyOptions
+{
+    public bool CompareUsingRuntimeTypes { get; set; } = false;
+}


### PR DESCRIPTION
# This PR fixes

Incorrect types used when comparing 2 instances of a class.

It was trying to use the type of the `actual` object instead of the type specified in the class, this caused issues with enumerable types that are frequently assigned in different but compatible ways.

This forces the use of the type declared for the property/field instead of relying on the type of the `actual` object.

Should fix the issues reported in https://github.com/shouldly/shouldly/issues/1034#issuecomment-2595206327

## Notes

The newly included test intentionally makes use of different kinds of objects while still respecting the types.