### PR TITLE
Feature: ISet & IDictionary Support For ShouldBeEquivalentTo()

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.cs
@@ -1,0 +1,251 @@
+using System.Text.RegularExpressions;
+
+namespace Shouldly.Tests.ShouldBeEquivalentTo;
+
+public class DictionaryScenario
+{
+    [Fact]
+    public void ShouldFailWhenDictionaryIsTooShort()
+    {
+        var subject = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 5
+        };
+        var expected = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 5,
+            [4] = 8
+        };
+        Verify.ShouldFail(() =>
+                subject.ShouldBeEquivalentTo(expected, "Some additional context"),
+
+            errorWithSource:
+            """
+            Comparing object equivalence, at path:
+            subject [System.Collections.Generic.Dictionary[[System.Int32],[System.Int32]]]
+                Keys
+
+                Expected value to be
+            [1, 2, 3, 4]
+                but was
+            [1, 2, 3]
+
+            Additional Info:
+                Some additional context; [4] is expected but not found
+            """,
+
+            errorWithoutSource:
+            """
+            Comparing object equivalence, at path:
+            <root> [System.Collections.Generic.Dictionary[[System.Int32],[System.Int32]]]
+                Keys
+
+                Expected value to be
+            [1, 2, 3, 4]
+                but was
+            [1, 2, 3]
+
+            Additional Info:
+                Some additional context; [4] is expected but not found
+            """,
+
+            MessageScrubber);
+    }
+
+     [Fact]
+     public void ShouldFailWhenDictionaryIsTooLong()
+     {
+        var subject = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 5,
+            [4] = 8,
+            [5] = 13
+        };
+        var expected = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 5,
+            [4] = 8
+        };
+        Verify.ShouldFail(() =>
+                subject.ShouldBeEquivalentTo(expected, "Some additional context"),
+
+            errorWithSource:
+            """
+            Comparing object equivalence, at path:
+            subject [System.Collections.Generic.Dictionary[[System.Int32],[System.Int32]]]
+                Keys
+
+                Expected value to be
+            [1, 2, 3, 4]
+                but was
+            [1, 2, 3, 4, 5]
+
+            Additional Info:
+                Some additional context; [5] is not expected but found
+            """,
+
+            errorWithoutSource:
+            """
+            Comparing object equivalence, at path:
+            <root> [System.Collections.Generic.Dictionary[[System.Int32],[System.Int32]]]
+                Keys
+
+                Expected value to be
+            [1, 2, 3, 4]
+                but was
+            [1, 2, 3, 4, 5]
+
+            Additional Info:
+                Some additional context; [5] is not expected but found
+            """,
+
+            MessageScrubber);
+     }
+
+     [Fact]
+     public void ShouldFailWhenDictionaryDoNotMatchKeys()
+     {
+        var subject = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [5] = 5,
+            [6] = 8
+        };
+        var expected = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 5,
+            [4] = 8
+        };
+        Verify.ShouldFail(() =>
+                subject.ShouldBeEquivalentTo(expected, "Some additional context"),
+
+            errorWithSource:
+            """
+            Comparing object equivalence, at path:
+            subject [System.Collections.Generic.Dictionary[[System.Int32],[System.Int32]]]
+                Keys
+
+                Expected value to be
+            [1, 2, 3, 4]
+                but was
+            [1, 2, 5, 6]
+
+            Additional Info:
+                Some additional context; [3, 4] is expected but not found; [5, 6] is not expected but found
+            """,
+
+            errorWithoutSource:
+            """
+            Comparing object equivalence, at path:
+            <root> [System.Collections.Generic.Dictionary[[System.Int32],[System.Int32]]]
+                Keys
+
+                Expected value to be
+            [1, 2, 3, 4]
+                but was
+            [1, 2, 5, 6]
+
+            Additional Info:
+                Some additional context; [3, 4] is expected but not found; [5, 6] is not expected but found
+            """,
+
+            MessageScrubber);
+     }
+
+     [Fact]
+     public void ShouldFailWhenDictionaryDoNotMatchValue()
+     {
+        var subject = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 13,
+            [4] = 8
+        };
+        var expected = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 5,
+            [4] = 8
+        };
+        Verify.ShouldFail(() =>
+                subject.ShouldBeEquivalentTo(expected, "Some additional context"),
+
+            errorWithSource:
+            """
+            Comparing object equivalence, at path:
+            subject [System.Collections.Generic.Dictionary[[System.Int32],[System.Int32]]]
+                Value [3] [System.Int32]
+
+                Expected value to be
+            5
+                but was
+            13
+
+            Additional Info:
+                Some additional context
+            """,
+
+            errorWithoutSource:
+            """
+            Comparing object equivalence, at path:
+            <root> [System.Collections.Generic.Dictionary[[System.Int32],[System.Int32]]]
+                Value [3] [System.Int32]
+
+                Expected value to be
+            5
+                but was
+            13
+
+            Additional Info:
+                Some additional context
+            """,
+
+            MessageScrubber);
+     }
+
+     [Fact]
+     public void ShouldPass()
+     {
+        var subject = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [4] = 8,
+            [3] = 5,
+            [2] = 3
+        };
+        var expected = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 5,
+            [4] = 8
+        };
+         subject.ShouldBeEquivalentTo(expected);
+     }
+
+    private static string MessageScrubber(string original)
+    {
+        const string pattern1 = @"\[System\.Int32,[^\]]+\]";
+        const string replacement1 = "[System.Int32]";
+        const string pattern2 = @"Dictionary\`[0-9]+";
+        const string replacement2 = "Dictionary";
+
+        return Regex.Replace(
+            Regex.Replace(original, pattern1, replacement1),
+            pattern2,
+            replacement2);
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Text.RegularExpressions;
 
 namespace Shouldly.Tests.ShouldBeEquivalentTo;
@@ -217,7 +218,7 @@ public class DictionaryScenario
      }
 
      [Fact]
-     public void ShouldPass()
+     public void ShouldPassWhenDictionaryIsIDictionary()
      {
         var subject = new Dictionary<int, int>
         {
@@ -236,6 +237,30 @@ public class DictionaryScenario
          subject.ShouldBeEquivalentTo(expected);
      }
 
+     [Fact]
+     public void ShouldPassWhenDictionaryIsIReadOnlyDictionary()
+     {
+        var subject = new TestReadOnlyDictionary(
+           new Dictionary<int, int>
+            {
+                [1] = 2,
+                [4] = 8,
+                [3] = 5,
+                [2] = 3
+            }
+        );
+        var expected = new TestReadOnlyDictionary(
+            new Dictionary<int, int>
+            {
+                [1] = 2,
+                [2] = 3,
+                [3] = 5,
+                [4] = 8
+            }
+        );
+         subject.ShouldBeEquivalentTo(expected);
+     }
+
     private static string MessageScrubber(string original)
     {
         const string pattern1 = @"\[System\.Int32,[^\]]+\]";
@@ -247,5 +272,27 @@ public class DictionaryScenario
             Regex.Replace(original, pattern1, replacement1),
             pattern2,
             replacement2);
+    }
+
+    private class TestReadOnlyDictionary : IReadOnlyDictionary<int, int>
+    {
+        private readonly IDictionary<int, int> dictionary;
+
+        public TestReadOnlyDictionary(IDictionary<int, int> dictionary) => this.dictionary = dictionary;
+
+        public IEnumerator<KeyValuePair<int, int>> GetEnumerator() => dictionary.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => dictionary.GetEnumerator();
+
+        public int Count => dictionary.Count;
+
+        public bool ContainsKey(int key) => dictionary.ContainsKey(key);
+
+        public bool TryGetValue(int key, out int value) => dictionary.TryGetValue(key, out value);
+
+        public int this[int key] => dictionary[key];
+
+        public IEnumerable<int> Keys => dictionary.Keys;
+        public IEnumerable<int> Values => dictionary.Values;
     }
 }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.cs
@@ -14,7 +14,7 @@ public class SetScenario
             errorWithSource:
             """
             Comparing object equivalence, at path:
-            [1, 2, 3, 4] [System.Collections.Generic.HashSet`1[[System.Int32]]]
+            [1, 2, 3, 4] [System.Collections.Generic.HashSet[[System.Int32]]]
 
                 Expected value to be
             [1, 2, 3, 4, 5]
@@ -28,7 +28,7 @@ public class SetScenario
             errorWithoutSource:
             """
             Comparing object equivalence, at path:
-            <root> [System.Collections.Generic.HashSet`1[[System.Int32]]]
+            <root> [System.Collections.Generic.HashSet[[System.Int32]]]
 
                 Expected value to be
             [1, 2, 3, 4, 5]
@@ -52,7 +52,7 @@ public class SetScenario
             errorWithSource:
             """
             Comparing object equivalence, at path:
-            [1, 2, 3, 4, 5, 6] [System.Collections.Generic.HashSet`1[[System.Int32]]]
+            [1, 2, 3, 4, 5, 6] [System.Collections.Generic.HashSet[[System.Int32]]]
 
                 Expected value to be
             [1, 2, 3, 4, 5]
@@ -66,7 +66,7 @@ public class SetScenario
             errorWithoutSource:
             """
             Comparing object equivalence, at path:
-            <root> [System.Collections.Generic.HashSet`1[[System.Int32]]]
+            <root> [System.Collections.Generic.HashSet[[System.Int32]]]
 
                 Expected value to be
             [1, 2, 3, 4, 5]
@@ -90,7 +90,7 @@ public class SetScenario
             errorWithSource:
             """
             Comparing object equivalence, at path:
-            [1, 2, 6, 4, 3] [System.Collections.Generic.HashSet`1[[System.Int32]]]
+            [1, 2, 6, 4, 3] [System.Collections.Generic.HashSet[[System.Int32]]]
 
                 Expected value to be
             [1, 2, 3, 4, 5]
@@ -104,7 +104,7 @@ public class SetScenario
             errorWithoutSource:
             """
             Comparing object equivalence, at path:
-            <root> [System.Collections.Generic.HashSet`1[[System.Int32]]]
+            <root> [System.Collections.Generic.HashSet[[System.Int32]]]
 
                 Expected value to be
             [1, 2, 3, 4, 5]
@@ -127,9 +127,14 @@ public class SetScenario
 
     private static string MessageScrubber(string original)
     {
-        const string pattern = @"\[\[System\.Int32,[^\]]+\]\]";
-        const string replacement = "[[System.Int32]]";
+        const string pattern1 = @"\[System\.Int32,[^\]]+\]";
+        const string replacement1 = "[System.Int32]";
+        const string pattern2 = @"HashSet\`[0-9]";
+        const string replacement2 = "HashSet";
 
-        return Regex.Replace(original, pattern, replacement);
+        return Regex.Replace(
+            Regex.Replace(original, pattern1, replacement1),
+            pattern2,
+            replacement2);
     }
 }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.cs
@@ -1,0 +1,135 @@
+using System.Text.RegularExpressions;
+
+namespace Shouldly.Tests.ShouldBeEquivalentTo;
+
+public class SetScenario
+{
+    [Fact]
+    public void ShouldFailWhenSetIsTooShort()
+    {
+        var subject = new HashSet<int>{ 1, 2, 3, 4 };
+        Verify.ShouldFail(() =>
+                subject.ShouldBeEquivalentTo(new HashSet<int> { 1, 2, 3, 4, 5 }, "Some additional context"),
+
+            errorWithSource:
+            """
+            Comparing object equivalence, at path:
+            [1, 2, 3, 4] [System.Collections.Generic.HashSet`1[[System.Int32]]]
+
+                Expected value to be
+            [1, 2, 3, 4, 5]
+                but was
+            [1, 2, 3, 4]
+
+            Additional Info:
+                Some additional context; [5] is expected but not found
+            """,
+
+            errorWithoutSource:
+            """
+            Comparing object equivalence, at path:
+            <root> [System.Collections.Generic.HashSet`1[[System.Int32]]]
+
+                Expected value to be
+            [1, 2, 3, 4, 5]
+                but was
+            [1, 2, 3, 4]
+
+            Additional Info:
+                Some additional context; [5] is expected but not found
+            """,
+
+            MessageScrubber);
+    }
+
+    [Fact]
+    public void ShouldFailWhenSetIsTooLong()
+    {
+        var subject = new HashSet<int>{ 1, 2, 3, 4, 5, 6 };
+        Verify.ShouldFail(() =>
+                subject.ShouldBeEquivalentTo(new HashSet<int> { 1, 2, 3, 4, 5 }, "Some additional context"),
+
+            errorWithSource:
+            """
+            Comparing object equivalence, at path:
+            [1, 2, 3, 4, 5, 6] [System.Collections.Generic.HashSet`1[[System.Int32]]]
+
+                Expected value to be
+            [1, 2, 3, 4, 5]
+                but was
+            [1, 2, 3, 4, 5, 6]
+
+            Additional Info:
+                Some additional context; [6] is not expected but found
+            """,
+
+            errorWithoutSource:
+            """
+            Comparing object equivalence, at path:
+            <root> [System.Collections.Generic.HashSet`1[[System.Int32]]]
+
+                Expected value to be
+            [1, 2, 3, 4, 5]
+                but was
+            [1, 2, 3, 4, 5, 6]
+
+            Additional Info:
+                Some additional context; [6] is not expected but found
+            """,
+
+            MessageScrubber);
+    }
+
+    [Fact]
+    public void ShouldFailWhenSetDoNotMatch()
+    {
+        var subject = new HashSet<int>{ 1, 2, 6, 4, 3 };
+        Verify.ShouldFail(() =>
+                subject.ShouldBeEquivalentTo(new HashSet<int> { 1, 2, 3, 4, 5 }, "Some additional context"),
+
+            errorWithSource:
+            """
+            Comparing object equivalence, at path:
+            [1, 2, 6, 4, 3] [System.Collections.Generic.HashSet`1[[System.Int32]]]
+
+                Expected value to be
+            [1, 2, 3, 4, 5]
+                but was
+            [1, 2, 6, 4, 3]
+
+            Additional Info:
+                Some additional context; [5] is expected but not found; [6] is not expected but found
+            """,
+
+            errorWithoutSource:
+            """
+            Comparing object equivalence, at path:
+            <root> [System.Collections.Generic.HashSet`1[[System.Int32]]]
+
+                Expected value to be
+            [1, 2, 3, 4, 5]
+                but was
+            [1, 2, 6, 4, 3]
+
+            Additional Info:
+                Some additional context; [5] is expected but not found; [6] is not expected but found
+            """,
+
+            MessageScrubber);
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        var subject = new HashSet<int> { 1, 2, 6, 4, 5 };
+        subject.ShouldBeEquivalentTo(new HashSet<int> { 6, 2, 1, 5, 4 });
+    }
+
+    private static string MessageScrubber(string original)
+    {
+        const string pattern = @"\[\[System\.Int32,[^\]]+\]\]";
+        const string replacement = "[[System.Int32]]";
+
+        return Regex.Replace(original, pattern, replacement);
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.cs
@@ -1,3 +1,5 @@
+using System.Collections;
+using System.Collections.Immutable;
 using System.Text.RegularExpressions;
 
 namespace Shouldly.Tests.ShouldBeEquivalentTo;
@@ -119,10 +121,17 @@ public class SetScenario
     }
 
     [Fact]
-    public void ShouldPass()
+    public void ShouldPassWhenSetIsISet()
     {
         var subject = new HashSet<int> { 1, 2, 6, 4, 5 };
         subject.ShouldBeEquivalentTo(new HashSet<int> { 6, 2, 1, 5, 4 });
+    }
+
+    [Fact]
+    public void ShouldPassWhenSetIsIImmutableSet()
+    {
+        var subject = new TestImmutableSet([1, 2, 6, 4, 5]);
+        subject.ShouldBeEquivalentTo(new TestImmutableSet([6, 2, 1, 5, 4]));
     }
 
     private static string MessageScrubber(string original)
@@ -136,5 +145,87 @@ public class SetScenario
             Regex.Replace(original, pattern1, replacement1),
             pattern2,
             replacement2);
+    }
+
+    private class TestImmutableSet : IImmutableSet<int>
+    {
+        private readonly HashSet<int> set;
+
+        public TestImmutableSet(HashSet<int> set) =>
+            this.set = set;
+
+        public IEnumerator<int> GetEnumerator() => set.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public int Count => set.Count;
+
+        public IImmutableSet<int> Add(int value) =>
+            set.Contains(value) ? this : new([..set, value]);
+
+        public IImmutableSet<int> Clear() => new TestImmutableSet([]);
+
+        public bool Contains(int value) => set.Contains(value);
+
+        public IImmutableSet<int> Except(IEnumerable<int> other)
+        {
+            var newSet = new HashSet<int>(set);
+            newSet.ExceptWith(other);
+            return new TestImmutableSet(newSet);
+        }
+
+        public IImmutableSet<int> Intersect(IEnumerable<int> other)
+        {
+            var newSet = new HashSet<int>(set);
+            newSet.IntersectWith(other);
+            return new TestImmutableSet(newSet);
+        }
+
+        public bool IsProperSubsetOf(IEnumerable<int> other) => set.IsProperSubsetOf(other);
+
+        public bool IsProperSupersetOf(IEnumerable<int> other) => set.IsProperSupersetOf(other);
+
+        public bool IsSubsetOf(IEnumerable<int> other) => set.IsSubsetOf(other);
+
+        public bool IsSupersetOf(IEnumerable<int> other) => set.IsSupersetOf(other);
+
+        public bool Overlaps(IEnumerable<int> other) => set.Overlaps(other);
+
+        public IImmutableSet<int> Remove(int value)
+        {
+            if (!set.Contains(value))
+                return this;
+            var newSet = new HashSet<int>(set);
+            newSet.Remove(value);
+            return new TestImmutableSet(newSet);
+        }
+
+        public bool SetEquals(IEnumerable<int> other) => set.SetEquals(other);
+
+        public IImmutableSet<int> SymmetricExcept(IEnumerable<int> other)
+        {
+            var newSet = new HashSet<int>(set);
+            newSet.SymmetricExceptWith(other);
+            return new TestImmutableSet(newSet);
+        }
+
+        public bool TryGetValue(int equalValue, out int actualValue)
+        {
+            if (set.Contains(equalValue))
+            {
+                actualValue = equalValue;
+                return true;
+            }
+
+            actualValue = 0;
+            return false;
+        }
+
+        public IImmutableSet<int> Union(IEnumerable<int> other)
+        {
+            var newSet = new HashSet<int>(set);
+            newSet.UnionWith(other);
+            return new TestImmutableSet(newSet);
+        }
     }
 }

--- a/src/Shouldly.Tests/Shouldly.Tests.csproj
+++ b/src/Shouldly.Tests/Shouldly.Tests.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
     <PackageReference Include="PublicApiGenerator" Version="11.4.5" />
     <PackageReference Include="System.Memory" Version="4.6.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="9.0.1" />
     <PackageReference Include="Polyfill" Version="7.21.0" PrivateAssets="all" />
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.3" PrivateAssets="All" />
     <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" PrivateAssets="all" />
     <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[8.0.0]" />
   </ItemGroup>

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 
 namespace Shouldly;
 
@@ -36,10 +36,7 @@ public static partial class ObjectGraphTestExtensions
         }
         else if (type.IsSet(out var setType))
         {
-            typeof(ObjectGraphTestExtensions)
-                .GetMethod(nameof(CompareSets), BindingFlags.NonPublic | BindingFlags.Static)!
-                .MakeGenericMethod(setType)
-                .Invoke(null, [actual, expected, path, previousComparisons, customMessage, shouldlyMethod]);
+            CompareSets(setType, actual, expected, path, previousComparisons, customMessage, shouldlyMethod);
         }
         else if (typeof(IEnumerable).IsAssignableFrom(type))
         {
@@ -137,7 +134,24 @@ public static partial class ObjectGraphTestExtensions
             ThrowException(actual, expected, path, customMessage, shouldlyMethod);
     }
 
-    private static void CompareSets<T>(ISet<T> actual, ISet<T> expected,
+    private static void CompareSets(Type setType, object? actual, object? expected,
+        IEnumerable<string> path, IDictionary<object, IList<object?>> previousComparisons,
+        string? customMessage, [CallerMemberName] string shouldlyMethod = null!)
+    {
+        try
+        {
+            typeof(ObjectGraphTestExtensions)
+                .GetMethod(nameof(CompareTypedSets), BindingFlags.NonPublic | BindingFlags.Static)!
+                .MakeGenericMethod(setType)
+                .Invoke(null, [actual, expected, path, previousComparisons, customMessage, shouldlyMethod]);
+        }
+        catch (TargetInvocationException e)
+        {
+            throw e.InnerException!;
+        }
+    }
+
+    private static void CompareTypedSets<T>(ISet<T> actual, ISet<T> expected,
         IEnumerable<string> path, IDictionary<object, IList<object?>> previousComparisons,
         string? customMessage, [CallerMemberName] string shouldlyMethod = null!)
     {

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -160,9 +160,7 @@ public static partial class ObjectGraphTestExtensions
             keysPath = path.Concat([
                 $"Value [{key.ToStringAwesomely() ?? "<Unknown>"}]"
             ]);
-            var actualValue = actual[key];
-            var expectedValue = expected[key];
-            CompareObjects(actualValue, expectedValue, keysPath.ToList(), previousComparisons, customMessage, shouldlyMethod);
+            CompareObjects(actual[key], expected[key], keysPath.ToList(), previousComparisons, customMessage, shouldlyMethod);
         }
     }
 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -117,6 +117,14 @@ public static partial class ObjectGraphTestExtensions
         {
             CompareStrings((string)actual, (string)expected, path, customMessage, shouldlyMethod);
         }
+        else if (typeof(IDictionary).IsAssignableFrom(type))
+        {
+            CompareDictionaries((IDictionary)actual, (IDictionary)expected, path, previousComparisons, customMessage, shouldlyMethod);
+        }
+        else if (type.IsSet(out var setType))
+        {
+            CompareSets(setType, actual, expected, path, previousComparisons, customMessage, shouldlyMethod);
+        }
         else if (typeof(IEnumerable).IsAssignableFrom(type))
         {
             CompareEnumerables((IEnumerable)actual, (IEnumerable)expected, path, previousComparisons, customMessage, shouldlyMethod);


### PR DESCRIPTION
# Issue Addressed

- https://github.com/shouldly/shouldly/issues/1077
- https://github.com/shouldly/shouldly/issues/1075
- Also makes the behaviour closer to the equivalent in FluentAssertion

# New Behaviour

Supports `ISet` and `IDictionary` to be checked for equivalence correctly.

```c#
var setA = new HashSet<int>{1, 2, 3, 4};
var setB = new HashSet<int>{4, 3, 2, 1};
setA.ShouldBeEquivalentTo(setB);  // this passes

var dictionaryA = new Dictionary<int, int>{{1, 11}, {2, 222}};
var dictionaryB = new Dictionary<int, int>{{2, 222}, {1, 11}};
dictionaryA.ShouldBeEquivalentTo(dictionaryB);  // this passes
```

# Previous Behaviour

`ISet` and `IDictionary` was treated as `IEnumerable` which means order of elements affect how sets are checked.

```c#
var setA = new HashSet<int>{1, 2, 3, 4};
var setB = new HashSet<int>{4, 3, 2, 1};
setA.ShouldBeEquivalentTo(setB);  // this does not pass

var dictionaryA = new Dictionary<int, int>{{1, 11}, {2, 222}};
var dictionaryB = new Dictionary<int, int>{{2, 222}, {1, 11}};
dictionaryA.ShouldBeEquivalentTo(dictionaryB);  // this does not pass
```