### PR TITLE
Support .NET Standard 2.0 for Shouldly.Approvals

### DIFF
--- a/src/Shouldly.Approvals/Shouldly.Approvals.csproj
+++ b/src/Shouldly.Approvals/Shouldly.Approvals.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
     <PackageReference Include="EmptyFiles" Version="8.8.0" PrivateAssets="None" />
     <PackageReference Include="DiffEngine" Version="15.10.1" />
     <None Include="..\..\assets\logo_128x128.png" Pack="true" PackagePath="assets" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="EmptyFiles" Version="4.4.0" PrivateAssets="None" />
+    <PackageReference Include="DiffEngine" Version="11.3.0" />
     <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" PrivateAssets="all" />
     <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[8.0.0]" />
   </ItemGroup>


### PR DESCRIPTION
Restores .NET Standard 2.0 compatibility for Shouldly.Approvals

See:
- #1081 