### PR TITLE
add ShouldNotBeEmpty() to Guid type

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -107,6 +107,7 @@ namespace Shouldly
     public static class GuidShouldBeTestExtensions
     {
         public static void ShouldBeEmpty(this System.Guid actual, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
+        public static void ShouldNotBeEmpty(this System.Guid actual, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
     }
     public interface IDiffViewer
     {

--- a/src/Shouldly.Tests/ShouldNotBeEmpty/GuidScenario.ShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldNotBeEmpty/GuidScenario.ShouldFail.approved.txt
@@ -1,0 +1,8 @@
+myGuid
+    should not be empty
+00000000-0000-0000-0000-000000000000
+    but was
+00000000-0000-0000-0000-000000000000
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldNotBeEmpty/GuidScenario.cs
+++ b/src/Shouldly.Tests/ShouldNotBeEmpty/GuidScenario.cs
@@ -1,0 +1,19 @@
+namespace Shouldly.Tests.ShouldNotBeEmpty;
+
+public class GuidScenario
+{
+    [Fact]
+    public void ShouldFail()
+    {
+        Guid myGuid = Guid.Empty;
+
+        Verify.ShouldFail(() =>
+            myGuid.ShouldNotBeEmpty("Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        Guid.NewGuid().ShouldNotBeEmpty();
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GuidShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GuidShouldBeTestExtensions.cs
@@ -17,5 +17,14 @@ public static partial class GuidShouldBeTestExtensions
     {
         actual.AssertAwesomely(v => Is.Equal(Guid.Empty, v), actual, Guid.Empty, customMessage, actualExpression: actualExpression);
     }
+
+    /// <summary>
+    /// Asserts that a Guid is not equal to <see cref="Guid.Empty"/>
+    /// </summary>
+    public static void ShouldNotBeEmpty(this Guid actual, string? customMessage = null,
+        [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
+    {
+        actual.AssertAwesomely(v => !Is.Equal(Guid.Empty, v), actual, Guid.Empty, customMessage, actualExpression: actualExpression);
+    }
 }
 


### PR DESCRIPTION
This change adds the ShouldNotBeEmpty() extension method for the Guid type, allowing a simple check whether the Guid is empty (Guid.Empty).