### PR TITLE
Fix IDE errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ indent_size = 4
 charset = utf-8
 
 # Redundant accessor body
-resharper_redundant_accessor_body_highlighting = error
+resharper_redundant_accessor_body_highlighting = warning
 
 # Replace with field keyword
 resharper_replace_with_field_keyword_highlighting = error
@@ -216,7 +216,7 @@ resharper_object_creation_when_type_not_evident = target_typed
 
 # ReSharper inspection severities
 resharper_arrange_object_creation_when_type_evident_highlighting = error
-resharper_arrange_object_creation_when_type_not_evident_highlighting = error
+resharper_arrange_object_creation_when_type_not_evident_highlighting = warning
 resharper_arrange_redundant_parentheses_highlighting = error
 resharper_arrange_static_member_qualifier_highlighting = error
 resharper_arrange_this_qualifier_highlighting = error
@@ -228,7 +228,7 @@ resharper_convert_to_using_declaration_highlighting = error
 resharper_css_not_resolved_highlighting = warning
 resharper_field_can_be_made_read_only_local_highlighting = none
 resharper_merge_into_logical_pattern_highlighting = warning
-resharper_merge_into_pattern_highlighting = error
+resharper_merge_into_pattern_highlighting = warning
 resharper_method_has_async_overload_highlighting = warning
 # because stop rider giving errors before source generators have run
 resharper_partial_type_with_single_part_highlighting = warning
@@ -244,7 +244,7 @@ resharper_redundant_lambda_signature_parentheses_highlighting = error
 resharper_replace_substring_with_range_indexer_highlighting = warning
 resharper_suggest_var_or_type_built_in_types_highlighting = error
 resharper_suggest_var_or_type_elsewhere_highlighting = error
-resharper_suggest_var_or_type_simple_types_highlighting = error
+resharper_suggest_var_or_type_simple_types_highlighting = warning
 resharper_unnecessary_whitespace_highlighting = error
 resharper_use_await_using_highlighting = warning
 resharper_use_deconstruction_highlighting = warning
@@ -275,10 +275,10 @@ csharp_style_var_when_type_is_apparent = true:error
 csharp_style_var_elsewhere = true:error
 
 # Prefer method-like constructs to have a block body
-csharp_style_expression_bodied_methods = true:error
-csharp_style_expression_bodied_local_functions = true:error
-csharp_style_expression_bodied_constructors = true:error
-csharp_style_expression_bodied_operators = true:error
+csharp_style_expression_bodied_methods = true:warning
+csharp_style_expression_bodied_local_functions = true:warning
+csharp_style_expression_bodied_constructors = true:warning
+csharp_style_expression_bodied_operators = true:warning
 resharper_place_expr_method_on_single_line = false
 
 # Prefer property-like constructs to have an expression-body
@@ -348,7 +348,7 @@ indent_size = 2
 
 # Verify settings
 [*.{received,verified}.{txt,xml,json,md,sql,csv,html,md}]
-charset = "utf-8-bom"
+charset = utf-8
 end_of_line = lf
 indent_size = unset
 indent_style = unset

--- a/.editorconfig
+++ b/.editorconfig
@@ -179,7 +179,7 @@ dotnet_diagnostic.CA1869.severity = error
 dotnet_diagnostic.CA1870.severity = error
 
 # Microsoft .NET properties
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false
 csharp_preferred_modifier_order = public, private, protected, internal, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async:suggestion
 resharper_namespace_body = file_scoped
 dotnet_naming_rule.private_constants_rule.severity = warning

--- a/src/Shouldly.Tests/InternalTests/DifferenceHighlighterHelpersTests.cs
+++ b/src/Shouldly.Tests/InternalTests/DifferenceHighlighterHelpersTests.cs
@@ -36,14 +36,16 @@ public class DifferenceHighlighterHelpersTests
     public void HighlightDifferencesBetween_DifferentTypes_DisplaysActualWithoutHighlight()
     {
         Should.Throw<ShouldAssertException>(() => new[] { "hi", "mum" }.ShouldBe<object>(new[] { 1, 2 }))
-            .Message.ShouldContain("[*\"hi\"*, *\"mum\"*]");
+            .Message.ShouldContain("""[*"hi"*, *"mum"*]""");
     }
 
     [Fact]
     public void HighlightDifferencesBetween_NotEnumerables_DisplaysActualWithoutHighlight()
     {
         Should.Throw<ShouldAssertException>(() => "hello".ShouldBe("goodbye"))
-            .Message.ShouldContain("\"hello\"");
+            .Message.ShouldContain("""
+                                   "hello"
+                                   """);
     }
 
     [Fact]
@@ -57,7 +59,7 @@ public class DifferenceHighlighterHelpersTests
     public void HighlightDifferencesBetween_StringLists_HighlightsDifference()
     {
         Should.Throw<ShouldAssertException>(() => new[] { "rita", "sue", "betty" }.ShouldBe(["rita", "sue", "bob"]))
-            .Message.ShouldContain("[\"rita\", \"sue\", *\"betty\"*]");
+            .Message.ShouldContain("""["rita", "sue", *"betty"*]""");
     }
 
     [Fact]

--- a/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
+++ b/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
@@ -98,13 +98,13 @@ public class ShouldMatchApprovedScenarios
                  but was
              "Foo"
                  difference
-             Difference     |  |    |    |
-                            | \|/  \|/  \|/
-             Index          | 0    1    2
-             Expected Value | B    a    r
-             Actual Value   | F    o    o
-             Expected Code  | 66   97   114
-             Actual Code    | 70   111  111
+             Difference     |  |    |    |   
+                            | \|/  \|/  \|/  
+             Index          | 0    1    2    
+             Expected Value | B    a    r    
+             Actual Value   | F    o    o    
+             Expected Code  | 66   97   114  
+             Actual Code    | 70   111  111  
              """,
 
             errorWithoutSource:
@@ -118,13 +118,13 @@ public class ShouldMatchApprovedScenarios
              "Bar"
                  but was not
                  difference
-             Difference     |  |    |    |
-                            | \|/  \|/  \|/
-             Index          | 0    1    2
-             Expected Value | B    a    r
-             Actual Value   | F    o    o
-             Expected Code  | 66   97   114
-             Actual Code    | 70   111  111
+             Difference     |  |    |    |   
+                            | \|/  \|/  \|/  
+             Index          | 0    1    2    
+             Expected Value | B    a    r    
+             Actual Value   | F    o    o    
+             Expected Code  | 66   97   114  
+             Actual Code    | 70   111  111  
              """,
 
             messageScrubber:

--- a/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
+++ b/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-using DiffEngine;
 
 namespace Shouldly.Tests.ShouldMatchApproved;
 
@@ -69,7 +68,7 @@ public class ShouldMatchApprovedScenarios
 
         exception.ShouldNotBeNull();
         // text is limited to 5000 char. but then the diff results in 5000*2+some extraneous text
-        exception!.Message.Length.ShouldBeLessThan(12000);
+        exception.Message.Length.ShouldBeLessThan(12000);
     }
 
     [Fact]
@@ -99,13 +98,13 @@ public class ShouldMatchApprovedScenarios
                  but was
              "Foo"
                  difference
-             Difference     |  |    |    |   
-                            | \|/  \|/  \|/  
-             Index          | 0    1    2    
-             Expected Value | B    a    r    
-             Actual Value   | F    o    o    
-             Expected Code  | 66   97   114  
-             Actual Code    | 70   111  111  
+             Difference     |  |    |    |
+                            | \|/  \|/  \|/
+             Index          | 0    1    2
+             Expected Value | B    a    r
+             Actual Value   | F    o    o
+             Expected Code  | 66   97   114
+             Actual Code    | 70   111  111
              """,
 
             errorWithoutSource:
@@ -119,13 +118,13 @@ public class ShouldMatchApprovedScenarios
              "Bar"
                  but was not
                  difference
-             Difference     |  |    |    |   
-                            | \|/  \|/  \|/  
-             Index          | 0    1    2    
-             Expected Value | B    a    r    
-             Actual Value   | F    o    o    
-             Expected Code  | 66   97   114  
-             Actual Code    | 70   111  111  
+             Difference     |  |    |    |
+                            | \|/  \|/  \|/
+             Index          | 0    1    2
+             Expected Value | B    a    r
+             Actual Value   | F    o    o
+             Expected Code  | 66   97   114
+             Actual Code    | 70   111  111
              """,
 
             messageScrubber:

--- a/src/Shouldly.Tests/StackTraceTests.cs
+++ b/src/Shouldly.Tests/StackTraceTests.cs
@@ -8,7 +8,7 @@ public static partial class StackTraceTests
     [MemberData(nameof(ExceptionThrowers))]
     public static void Top_stack_frame_is_user_code(ExceptionThrower exceptionThrower)
     {
-        var exception = exceptionThrower.Catch()!;
+        var exception = exceptionThrower.Catch();
 
         var stackTraceLines = exception.StackTrace!.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
 

--- a/src/Shouldly/App_Packages/JetBrainsAnnotations/JetBrainsAnnotations.cs
+++ b/src/Shouldly/App_Packages/JetBrainsAnnotations/JetBrainsAnnotations.cs
@@ -22,7 +22,6 @@ SOFTWARE. */
 
 #nullable disable
 
-using System;
 #pragma warning disable 1591
 // ReSharper disable UnusedType.Global
 // ReSharper disable UnusedMember.Global
@@ -43,7 +42,7 @@ namespace JetBrains.Annotations
     /// </summary>
     /// <example><code>
     /// [CanBeNull] object Test() => null;
-    /// 
+    ///
     /// void UseTest() {
     ///   var p = Test();
     ///   var s = p.ToString(); // Warning: Possible 'System.NullReferenceException'
@@ -124,7 +123,7 @@ namespace JetBrains.Annotations
     /// <example><code>
     /// [StringFormatMethod("message")]
     /// void ShowError(string message, params object[] args) { /* do something */ }
-    /// 
+    ///
     /// void Foo() {
     ///   ShowError("Failed: {0}"); // Warning: Non-existing argument in format string
     /// }
@@ -152,7 +151,7 @@ namespace JetBrains.Annotations
     /// </summary>
     /// <example><code>
     /// void LogInfo([StructuredMessageTemplate]string message, params object[] args) { /* do something */ }
-    /// 
+    ///
     /// void Foo() {
     ///   LogInfo("User created: {username}"); // Warning: Non-existing argument in format string
     /// }
@@ -298,12 +297,12 @@ namespace JetBrains.Annotations
     /// <example><code>
     /// public class Foo : INotifyPropertyChanged {
     ///   public event PropertyChangedEventHandler PropertyChanged;
-    /// 
+    ///
     ///   [NotifyPropertyChangedInvocator]
     ///   protected virtual void NotifyChanged(string propertyName) { ... }
     ///
     ///   string _name;
-    /// 
+    ///
     ///   public string Name {
     ///     get { return _name; }
     ///     set { _name = value; NotifyChanged("LastName"); /* Warning */ }
@@ -429,7 +428,7 @@ namespace JetBrains.Annotations
     /// <example><code>
     /// [CannotApplyEqualityOperator]
     /// class NoEquality { }
-    /// 
+    ///
     /// class UsesNoEquality {
     ///   void Test() {
     ///     var ca1 = new NoEquality();
@@ -458,20 +457,20 @@ namespace JetBrains.Annotations
     /// </remarks>
     /// <example><code>
     /// struct StructWithDefaultEquality { }
-    /// 
+    ///
     /// class MySet&lt;[DefaultEqualityUsage] T&gt; { }
-    /// 
+    ///
     /// static class Extensions {
     ///     public static MySet&lt;T&gt; ToMySet&lt;[DefaultEqualityUsage] T&gt;(this IEnumerable&lt;T&gt; items) =&gt; new();
     /// }
-    /// 
+    ///
     /// class MyList&lt;T&gt; { public int IndexOf([DefaultEqualityUsage] T item) =&gt; 0; }
-    /// 
+    ///
     /// class UsesDefaultEquality {
     ///     void Test() {
     ///         var list = new MyList&lt;StructWithDefaultEquality&gt;();
     ///         list.IndexOf(new StructWithDefaultEquality()); // Warning: Default equality of struct 'StructWithDefaultEquality' is used
-    ///         
+    ///
     ///         var set = new MySet&lt;StructWithDefaultEquality&gt;(); // Warning: Default equality of struct 'StructWithDefaultEquality' is used
     ///         var set2 = new StructWithDefaultEquality[1].ToMySet(); // Warning: Default equality of struct 'StructWithDefaultEquality' is used
     ///     }
@@ -489,7 +488,7 @@ namespace JetBrains.Annotations
     /// <example><code>
     /// [BaseTypeRequired(typeof(IComponent)] // Specify requirement
     /// class ComponentAttribute : Attribute { }
-    /// 
+    ///
     /// [Component] // ComponentAttribute requires implementing IComponent interface
     /// class MyComponent : IComponent { }
     /// </code></example>
@@ -514,13 +513,13 @@ namespace JetBrains.Annotations
     /// <example><code>
     /// [UsedImplicitly]
     /// public class TypeConverter {}
-    /// 
+    ///
     /// public class SummaryData
     /// {
     ///   [UsedImplicitly(ImplicitUseKindFlags.InstantiatedWithFixedConstructorSignature)]
     ///   public SummaryData() {}
     /// }
-    /// 
+    ///
     /// [UsedImplicitly(ImplicitUseTargetFlags.WithInheritors | ImplicitUseTargetFlags.Default)]
     /// public interface IService {}
     /// </code></example>
@@ -680,7 +679,7 @@ namespace JetBrains.Annotations
     /// </summary>
     /// <example><code>
     /// [Pure] int Multiply(int x, int y) => x * y;
-    /// 
+    ///
     /// void M() {
     ///   Multiply(123, 42); // Warning: Return value of pure method is not used
     /// }
@@ -811,7 +810,7 @@ namespace JetBrains.Annotations
     /// <example><code>
     /// class Foo {
     ///   [ProvidesContext] IBarService _barService = ...;
-    /// 
+    ///
     ///   void ProcessNode(INode node) {
     ///     DoSomething(node, node.GetGlobalServices().Bar);
     ///     //              ^ Warning: use value of '_barService' field
@@ -2154,7 +2153,7 @@ namespace JetBrains.Annotations
     /// {
     ///   protected T Component { get; }
     /// }
-    /// 
+    ///
     /// public class CalculatorAdditionTests : BaseTestClass&lt;Calculator&gt;
     /// {
     ///   [Test]

--- a/src/Shouldly/Case.cs
+++ b/src/Shouldly/Case.cs
@@ -9,7 +9,7 @@ public enum Case
     /// Perform case-sensitive string comparison
     /// </summary>
     Sensitive,
-    
+
     /// <summary>
     /// Perform case-insensitive string comparison
     /// </summary>

--- a/src/Shouldly/Internals/IShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/IShouldlyAssertionContext.cs
@@ -9,47 +9,47 @@ public interface IShouldlyAssertionContext
     /// The name of the should method being called
     /// </summary>
     string ShouldMethod { get; set; }
-    
+
     /// <summary>
     /// The code part being evaluated
     /// </summary>
     string? CodePart { get; set; }
-    
+
     /// <summary>
     /// The file name where the assertion is made
     /// </summary>
     string? FileName { get; set; }
-    
+
     /// <summary>
     /// The line number where the assertion is made
     /// </summary>
     int? LineNumber { get; set; }
-    
+
     /// <summary>
     /// The key being used in the assertion
     /// </summary>
     object? Key { get; set; }
-    
+
     /// <summary>
     /// The expected value in the assertion
     /// </summary>
     object? Expected { get; set; }
-    
+
     /// <summary>
     /// The actual value in the assertion
     /// </summary>
     object? Actual { get; set; }
-    
+
     /// <summary>
     /// The tolerance for numeric comparisons
     /// </summary>
     object? Tolerance { get; set; }
-    
+
     /// <summary>
     /// The timeout for assertions that wait for a condition
     /// </summary>
     TimeSpan? Timeout { get; set; }
-    
+
     /// <summary>
     /// Whether to ignore the order when comparing collections
     /// </summary>
@@ -64,7 +64,7 @@ public interface IShouldlyAssertionContext
     /// Whether the actual value is relevant for the assertion
     /// </summary>
     bool HasRelevantActual { get; set; }
-    
+
     /// <summary>
     /// Whether the key is relevant for the assertion
     /// </summary>
@@ -74,47 +74,47 @@ public interface IShouldlyAssertionContext
     /// Whether the assertion is negated (e.g., ShouldNotBe instead of ShouldBe)
     /// </summary>
     bool IsNegatedAssertion { get; }
-    
+
     /// <summary>
     /// Custom message to display when the assertion fails
     /// </summary>
     string? CustomMessage { get; set; }
-    
+
     /// <summary>
     /// Case sensitivity setting for string comparisons
     /// </summary>
     Case? CaseSensitivity { get; set; }
-    
+
     /// <summary>
     /// Whether the code part matches the actual value
     /// </summary>
     bool CodePartMatchesActual { get; }
-    
+
     /// <summary>
     /// Filter expression for collection assertions
     /// </summary>
     Expression? Filter { get; set; }
-    
+
     /// <summary>
     /// The expected match count for collection assertions
     /// </summary>
     int? MatchCount { get; set; }
-    
+
     /// <summary>
     /// The sort direction for ordered collection assertions
     /// </summary>
     SortDirection SortDirection { get; set; }
-    
+
     /// <summary>
     /// The index of the out-of-order element in collection assertions
     /// </summary>
     int OutOfOrderIndex { get; set; }
-    
+
     /// <summary>
     /// The out-of-order object in collection assertions
     /// </summary>
     object? OutOfOrderObject { get; set; }
-    
+
     /// <summary>
     /// The path to the property being asserted
     /// </summary>

--- a/src/Shouldly/ShouldMatchApprovedTestExtensions.cs
+++ b/src/Shouldly/ShouldMatchApprovedTestExtensions.cs
@@ -36,7 +36,7 @@ public static class ShouldMatchApprovedTestExtensions
         var outputFolder = testMethodInfo.SourceFileDirectory;
         if (string.IsNullOrEmpty(outputFolder))
             throw new($"Source information not available, make sure you are compiling with full debug information. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
-        if (DeterministicBuildHelpers.PathAppearsToBeDeterministic(outputFolder!))
+        if (DeterministicBuildHelpers.PathAppearsToBeDeterministic(outputFolder))
             throw new($"Unable to resolve source file from deterministic build source path. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
 
         if (!string.IsNullOrEmpty(config.ApprovalFileSubFolder))

--- a/src/Shouldly/ShouldMatchConfiguration.cs
+++ b/src/Shouldly/ShouldMatchConfiguration.cs
@@ -46,17 +46,17 @@ public class ShouldMatchConfiguration
     /// Options for string comparison
     /// </summary>
     public StringCompareShould StringCompareOptions { get; set; } = StringCompareShould.IgnoreLineEndings;
-    
+
     /// <summary>
     /// Optional discriminator to add to the filename
     /// </summary>
     public string? FilenameDiscriminator { get; set; }
-    
+
     /// <summary>
     /// Whether to prevent showing a diff when the test fails
     /// </summary>
     public bool PreventDiff { get; set; } = false;
-    
+
     /// <summary>
     /// The diff viewer to use when the test fails
     /// </summary>
@@ -71,7 +71,7 @@ public class ShouldMatchConfiguration
     /// The test method finder to use to locate the test method
     /// </summary>
     public ITestMethodFinder TestMethodFinder { get; set; } = new FirstNonShouldlyMethodFinder();
-    
+
     /// <summary>
     /// Optional subfolder for approval files
     /// </summary>

--- a/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
+++ b/src/Shouldly/ShouldStaticClasses/DynamicShould.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel;
 using System.Dynamic;
 using JetBrains.Annotations;
 

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrow.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrow.cs
@@ -6,7 +6,6 @@ namespace Shouldly;
 [ShouldlyMethods]
 public static partial class Should
 {
-    /*** Should.Throw(Action) ***/
     /// <summary>
     /// Verifies that the provided action throws an exception of type <typeparamref name="TException"/>
     /// </summary>
@@ -37,7 +36,6 @@ public static partial class Should
         throw new ShouldAssertException(new ShouldlyThrowMessage(typeof(TException), customMessage: customMessage, shouldlyMethod).ToString());
     }
 
-    /*** Should.Throw(Action) ***/
     /// <summary>
     /// Verifies that the provided action throws an exception of the specified type
     /// </summary>
@@ -65,7 +63,6 @@ public static partial class Should
         throw new ShouldAssertException(new ShouldlyThrowMessage(exceptionType, customMessage: customMessage, shouldlyMethod).ToString());
     }
 
-    /*** Should.Throw(Func<T>) ***/
     /// <summary>
     /// Verifies that the provided function throws an exception of type <typeparamref name="TException"/>
     /// </summary>
@@ -96,7 +93,6 @@ public static partial class Should
         throw new ShouldAssertException(new ShouldlyThrowMessage(typeof(TException), customMessage: customMessage, shouldlyMethod).ToString());
     }
 
-    /*** Should.Throw(Func<T>) ***/
     /// <summary>
     /// Verifies that the provided function throws an exception of the specified type
     /// </summary>
@@ -131,7 +127,6 @@ public static partial class Should
         throw new ShouldAssertException(new ShouldlyThrowMessage(exceptionType, customMessage: customMessage, shouldlyMethod).ToString());
     }
 
-    /*** Should.NotThrow(Action) ***/
     /// <summary>
     /// Verifies that the provided action does not throw any exceptions
     /// </summary>
@@ -154,7 +149,6 @@ public static partial class Should
         }
     }
 
-    /*** Should.NotThrow(Func<T>) ***/
     /// <summary>
     /// Verifies that the provided function does not throw any exceptions and returns its result
     /// </summary>

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
@@ -4,7 +4,6 @@ namespace Shouldly;
 
 public static partial class Should
 {
-    /*** Should.Throw(Task) ***/
     /// <summary>
     /// Verifies that the provided task throws an exception of type <typeparamref name="TException"/>
     /// </summary>
@@ -22,7 +21,6 @@ public static partial class Should
     public static Exception Throw(Task actual, Type exceptionType, string? customMessage = null) =>
         ThrowInternal(() => actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage, exceptionType);
 
-    /*** Should.Throw(Func<Task>) ***/
     /// <summary>
     /// Verifies that the provided task function throws an exception of type <typeparamref name="TException"/>
     /// </summary>
@@ -31,14 +29,12 @@ public static partial class Should
         where TException : Exception =>
         Throw<TException>(actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
 
-    /*** Should.Throw(Func<Task>) ***/
     /// <summary>
     /// Verifies that the provided task function throws an exception of the specified type
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static Exception Throw([InstantHandle] Func<Task> actual, Type exceptionType, string? customMessage = null) => ThrowInternal(actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage, exceptionType);
 
-    /*** Should.Throw(Task, TimeSpan) ***/
     /// <summary>
     /// Verifies that the provided task throws an exception of type <typeparamref name="TException"/> within the specified timeout
     /// </summary>
@@ -47,7 +43,6 @@ public static partial class Should
         where TException : Exception =>
         Throw<TException>(() => actual, timeoutAfter, customMessage);
 
-    /*** Should.Throw(Task, TimeSpan) ***/
     /// <summary>
     /// Verifies that the provided task throws an exception of the specified type within the specified timeout
     /// </summary>
@@ -57,7 +52,6 @@ public static partial class Should
         return ThrowInternal(() => actual, timeoutAfter, customMessage, exceptionType);
     }
 
-    /*** Should.Throw(Func<Task>, TimeSpan) ***/
     /// <summary>
     /// Verifies that the provided task function throws an exception of type <typeparamref name="TException"/> within the specified timeout
     /// </summary>
@@ -93,7 +87,6 @@ public static partial class Should
         throw new ShouldAssertException(new TaskShouldlyThrowMessage(typeof(TException), customMessage, shouldlyMethod).ToString());
     }
 
-    /*** Should.Throw(Func<Task>, TimeSpan) ***/
     /// <summary>
     /// Verifies that the provided task function throws an exception of the specified type within the specified timeout
     /// </summary>
@@ -137,7 +130,6 @@ public static partial class Should
         throw new ShouldAssertException(new TaskShouldlyThrowMessage(exceptionType, customMessage, shouldlyMethod).ToString());
     }
 
-    /*** Should.NotThrow(Task) ***/
     /// <summary>
     /// Verifies that the provided task does not throw any exceptions
     /// </summary>
@@ -147,7 +139,6 @@ public static partial class Should
         NotThrowInternal(() => action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
     }
 
-    /*** Should.NotThrow(Task<T>) ***/
     /// <summary>
     /// Verifies that the provided task does not throw any exceptions and returns its result
     /// </summary>
@@ -157,7 +148,6 @@ public static partial class Should
         return NotThrow(() => action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
     }
 
-    /*** Should.NotThrow(Func<Task>) ***/
     /// <summary>
     /// Verifies that the provided task function does not throw any exceptions
     /// </summary>
@@ -167,7 +157,6 @@ public static partial class Should
         NotThrowInternal(action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
     }
 
-    /*** Should.NotThrow(Task, TimeSpan) ***/
     /// <summary>
     /// Verifies that the provided task does not throw any exceptions within the specified timeout
     /// </summary>
@@ -177,7 +166,6 @@ public static partial class Should
         NotThrowInternal(() => action, timeoutAfter, customMessage);
     }
 
-    /*** Should.NotThrow(Func<Task>, TimeSpan) ***/
     /// <summary>
     /// Verifies that the provided task function does not throw any exceptions within the specified timeout
     /// </summary>
@@ -208,7 +196,6 @@ public static partial class Should
         }
     }
 
-    /*** Should.NotThrow(Func<Task<T>>) ***/
     /// <summary>
     /// Verifies that the provided task function does not throw any exceptions and returns its result
     /// </summary>
@@ -216,7 +203,6 @@ public static partial class Should
     public static T NotThrow<T>([InstantHandle] Func<Task<T>> action, string? customMessage = null) =>
         NotThrow(action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
 
-    /*** Should.NotThrow(Task<T>, TimeSpan) ***/
     /// <summary>
     /// Verifies that the provided task does not throw any exceptions within the specified timeout and returns its result
     /// </summary>
@@ -224,7 +210,6 @@ public static partial class Should
     public static T NotThrow<T>(Task<T> action, TimeSpan timeoutAfter, string? customMessage = null) =>
         NotThrow(() => action, timeoutAfter, customMessage);
 
-    /*** Should.NotThrow(Func<Task<T>>, TimeSpan) ***/
     /// <summary>
     /// Verifies that the provided task function does not throw any exceptions within the specified timeout and returns its result
     /// </summary>

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
@@ -4,7 +4,6 @@ namespace Shouldly;
 
 public static partial class Should
 {
-    /*** Should.ThrowAsync(Task) ***/
     /// <summary>
     /// Asynchronously verifies that the provided task throws an exception of type <typeparamref name="TException"/>
     /// </summary>
@@ -24,7 +23,6 @@ public static partial class Should
         return ThrowAsync(() => task, exceptionType, customMessage);
     }
 
-    /*** Should.ThrowAsync(Func<Task>) ***/
     /// <summary>
     /// Asynchronously verifies that the provided task function throws an exception of type <typeparamref name="TException"/>
     /// </summary>
@@ -76,7 +74,6 @@ public static partial class Should
         }
     }
 
-    /*** Should.ThrowAsync(Func<Task>) ***/
     /// <summary>
     /// Asynchronously verifies that the provided task function throws an exception of the specified type
     /// </summary>
@@ -104,7 +101,6 @@ public static partial class Should
         });
     }
 
-    /*** Should.NotThrowAsync(Task) ***/
     /// <summary>
     /// Asynchronously verifies that the provided task does not throw any exceptions
     /// </summary>
@@ -114,7 +110,6 @@ public static partial class Should
         return NotThrowAsyncInternal(() => task, customMessage);
     }
 
-    /*** Should.NotThrowAsync(Func<Task>) ***/
     /// <summary>
     /// Asynchronously verifies that the provided task function does not throw any exceptions
     /// </summary>

--- a/src/Shouldly/ShouldlyConfiguration.cs
+++ b/src/Shouldly/ShouldlyConfiguration.cs
@@ -56,7 +56,7 @@ public static partial class ShouldlyConfiguration
     /// Default tolerance used for floating point comparisons
     /// </summary>
     public static double DefaultFloatingPointTolerance = 0.0d;
-    
+
     /// <summary>
     /// Default timeout period for asynchronous operations
     /// </summary>

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GuidShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GuidShouldBeTestExtensions.cs
@@ -10,7 +10,7 @@ namespace Shouldly;
 public static partial class GuidShouldBeTestExtensions
 {
     /// <summary>
-    /// Asserts that a Guid is equal to <see cref="Guid.Empty"/> 
+    /// Asserts that a Guid is equal to <see cref="Guid.Empty"/>
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void ShouldBeEmpty(this Guid actual, string? customMessage = null)

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringStartEndTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringStartEndTestExtensions.cs
@@ -24,7 +24,6 @@ public static partial class ShouldBeStringTestExtensions
         Debug.Assert(actual != null);
     }
 
-    /*** ShouldNotStartWith ***/
     /// <summary>
     /// Asserts that a string does not start with another string
     /// </summary>
@@ -34,7 +33,6 @@ public static partial class ShouldBeStringTestExtensions
         actual.AssertAwesomely(v => !Is.StringStartingWithUsingCaseSensitivity(v, expected, caseSensitivity), actual, expected, customMessage);
     }
 
-    /*** ShouldNotEndWith ***/
     /// <summary>
     /// Asserts that a string does not end with another string
     /// </summary>

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
@@ -1,8 +1,4 @@
-
 using System.ComponentModel;
-#if NET9_0_OR_GREATER
-using System.Runtime.CompilerServices;
-#endif
 
 namespace Shouldly;
 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldNotThrowTaskAsyncExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldNotThrowTaskAsyncExtensions.cs
@@ -10,7 +10,6 @@ namespace Shouldly;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class ShouldNotThrowTaskAsyncExtensions
 {
-    /*** ShouldNotThrowAsync(Task) ***/
     /// <summary>
     /// Asynchronously verifies that the Task completes without throwing any exceptions.
     /// </summary>
@@ -18,7 +17,6 @@ public static partial class ShouldNotThrowTaskAsyncExtensions
     public static Task ShouldNotThrowAsync(this Task task, string? customMessage = null) =>
         Should.NotThrowAsync(task, customMessage);
 
-    /*** ShouldNotThrowAsync(Func<Task>) ***/
     /// <summary>
     /// Asynchronously verifies that the function returning a Task completes without throwing any exceptions.
     /// </summary>

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowExtensions.cs
@@ -10,7 +10,6 @@ namespace Shouldly;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class ShouldThrowExtensions
 {
-    /*** ShouldThrow(Action) ***/
     /// <summary>
     /// Verifies that the action throws a <typeparamref name="TException"/> exception.
     /// </summary>
@@ -19,7 +18,6 @@ public static partial class ShouldThrowExtensions
         where TException : Exception =>
         Should.ThrowInternal<TException>(actual, customMessage);
 
-    /*** ShouldThrow(Func<T>) ***/
     /// <summary>
     /// Verifies that the function throws a <typeparamref name="TException"/> exception.
     /// </summary>
@@ -28,7 +26,6 @@ public static partial class ShouldThrowExtensions
         where TException : Exception =>
         Should.ThrowInternal<TException>(actual, customMessage);
 
-    /*** ShouldThrow(Action) ***/
     /// <summary>
     /// Verifies that the action throws an exception of the specified type.
     /// </summary>
@@ -36,7 +33,6 @@ public static partial class ShouldThrowExtensions
     public static Exception ShouldThrow(this Action actual, Type exceptionType, string? customMessage = null) =>
         Should.ThrowInternal(actual, customMessage, exceptionType);
 
-    /*** ShouldThrow(Func<T>) ***/
     /// <summary>
     /// Verifies that the function throws an exception of the specified type.
     /// </summary>
@@ -44,7 +40,6 @@ public static partial class ShouldThrowExtensions
     public static Exception ShouldThrow(this Func<object?> actual, Type exceptionType, string? customMessage = null) =>
         Should.ThrowInternal(actual, customMessage, exceptionType);
 
-    /*** ShouldNotThrow(Action) ***/
     /// <summary>
     /// Verifies that the action completes without throwing any exceptions.
     /// </summary>
@@ -52,7 +47,6 @@ public static partial class ShouldThrowExtensions
     public static void ShouldNotThrow(this Action action, string? customMessage = null) =>
         Should.NotThrowInternal(action, customMessage);
 
-    /*** ShouldNotThrow(Func<T>) ***/
     /// <summary>
     /// Verifies that the function completes without throwing any exceptions and returns the result.
     /// </summary>

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowTaskAsyncExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowTaskAsyncExtensions.cs
@@ -10,7 +10,6 @@ namespace Shouldly;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class ShouldThrowAsyncExtensions
 {
-    /*** ShouldThrowAsync(Task) ***/
     /// <summary>
     /// Asynchronously verifies that the Task throws a <typeparamref name="TException"/> exception.
     /// </summary>
@@ -19,7 +18,6 @@ public static partial class ShouldThrowAsyncExtensions
         where TException : Exception =>
         Should.ThrowAsync<TException>(task, customMessage);
 
-    /*** ShouldThrowAsync(Task) ***/
     /// <summary>
     /// Asynchronously verifies that the Task throws an exception of the specified type.
     /// </summary>
@@ -27,7 +25,6 @@ public static partial class ShouldThrowAsyncExtensions
     public static Task<Exception> ShouldThrowAsync(this Task task, Type exceptionType, string? customMessage = null) =>
         Should.ThrowAsync(task, exceptionType, customMessage);
 
-    /*** ShouldThrowAsync(Func<Task>) ***/
     /// <summary>
     /// Asynchronously verifies that the function returning a Task throws an <typeparamref name="TException"/> exception.
     /// </summary>
@@ -36,7 +33,6 @@ public static partial class ShouldThrowAsyncExtensions
         where TException : Exception =>
         Should.ThrowAsync<TException>(actual, customMessage);
 
-    /*** ShouldThrowAsync(Func<Task>) ***/
     /// <summary>
     /// Asynchronously verifies that the function returning a Task throws an exception of the specified type.
     /// </summary>

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowTaskExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldThrowTaskExtensions.cs
@@ -10,7 +10,6 @@ namespace Shouldly;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class ShouldThrowTaskExtensions
 {
-    /*** ShouldThrow(Task) ***/
     /// <summary>
     /// Verifies that the Task throws a <typeparamref name="TException"/> exception.
     /// </summary>
@@ -21,7 +20,6 @@ public static partial class ShouldThrowTaskExtensions
         return ShouldThrow<TException>(() => actual, customMessage);
     }
 
-    /*** ShouldThrow(Task) ***/
     /// <summary>
     /// Verifies that the Task throws an exception of the specified type.
     /// </summary>
@@ -40,7 +38,6 @@ public static partial class ShouldThrowTaskExtensions
         return ShouldThrow(() => actual, customMessage, exceptionType);
     }
 
-    /*** ShouldThrow(Func<Task>) ***/
     /// <summary>
     /// Verifies that the function returning a Task throws a <typeparamref name="TException"/> exception.
     /// </summary>
@@ -49,7 +46,6 @@ public static partial class ShouldThrowTaskExtensions
         where TException : Exception =>
         ShouldThrow<TException>(actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
 
-    /*** ShouldThrow(Func<Task>) ***/
     /// <summary>
     /// Verifies that the function returning a Task throws an exception of the specified type.
     /// </summary>
@@ -64,7 +60,6 @@ public static partial class ShouldThrowTaskExtensions
     public static Exception ShouldThrow(this Func<Task> actual, string? customMessage, Type exceptionType) =>
         ShouldThrow(actual, ShouldlyConfiguration.DefaultTaskTimeout, customMessage, exceptionType);
 
-    /*** ShouldThrow(Task, TimeSpan) ***/
     /// <summary>
     /// Verifies that the Task throws a <typeparamref name="TException"/> exception within the specified timeout.
     /// </summary>
@@ -75,7 +70,6 @@ public static partial class ShouldThrowTaskExtensions
         return ShouldThrow<TException>(() => actual, timeoutAfter, customMessage);
     }
 
-    /*** ShouldThrow(Task, TimeSpan) ***/
     /// <summary>
     /// Verifies that the Task throws an exception of the specified type within the specified timeout.
     /// </summary>
@@ -94,7 +88,6 @@ public static partial class ShouldThrowTaskExtensions
         return ShouldThrow(() => actual, timeoutAfter, customMessage, exceptionType);
     }
 
-    /*** ShouldThrow(Func<Task>, TimeSpan) ***/
     /// <summary>
     /// Verifies that the function returning a Task throws a <typeparamref name="TException"/> exception within the specified timeout.
     /// </summary>
@@ -103,7 +96,6 @@ public static partial class ShouldThrowTaskExtensions
         where TException : Exception =>
         Should.ThrowInternal<TException>(actual, timeoutAfter, customMessage);
 
-    /*** ShouldThrow(Func<Task>, TimeSpan) ***/
     /// <summary>
     /// Verifies that the function returning a Task throws an exception of the specified type within the specified timeout.
     /// </summary>
@@ -118,7 +110,6 @@ public static partial class ShouldThrowTaskExtensions
     public static Exception ShouldThrow(this Func<Task> actual, TimeSpan timeoutAfter, string? customMessage, Type exceptionType) =>
         Should.ThrowInternal(actual, timeoutAfter, customMessage, exceptionType);
 
-    /*** ShouldNotThrow(Task) ***/
     /// <summary>
     /// Verifies that the Task completes without throwing any exceptions.
     /// </summary>
@@ -128,7 +119,6 @@ public static partial class ShouldThrowTaskExtensions
         Should.NotThrowInternal(() => action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
     }
 
-    /*** ShouldNotThrow(Task<T>) ***/
     /// <summary>
     /// Verifies that the Task completes without throwing any exceptions and returns the result.
     /// </summary>
@@ -138,7 +128,6 @@ public static partial class ShouldThrowTaskExtensions
         return ShouldNotThrow(() => action, customMessage);
     }
 
-    /*** ShouldNotThrow(Func<Task>) ***/
     /// <summary>
     /// Verifies that the function returning a Task completes without throwing any exceptions.
     /// </summary>
@@ -148,7 +137,6 @@ public static partial class ShouldThrowTaskExtensions
         Should.NotThrowInternal(action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
     }
 
-    /*** ShouldNotThrow(Task, TimeSpan) ***/
     /// <summary>
     /// Verifies that the Task completes without throwing any exceptions within the specified timeout.
     /// </summary>
@@ -158,7 +146,6 @@ public static partial class ShouldThrowTaskExtensions
         ShouldNotThrow(() => action, timeoutAfter, customMessage);
     }
 
-    /*** ShouldNotThrow(Func<Task>, TimeSpan) ***/
     /// <summary>
     /// Verifies that the function returning a Task completes without throwing any exceptions within the specified timeout.
     /// </summary>
@@ -168,7 +155,6 @@ public static partial class ShouldThrowTaskExtensions
         Should.NotThrowInternal(action, timeoutAfter, customMessage);
     }
 
-    /*** ShouldNotThrow(Func<Task<T>>) ***/
     /// <summary>
     /// Verifies that the function returning a Task completes without throwing any exceptions and returns the result.
     /// </summary>
@@ -176,7 +162,6 @@ public static partial class ShouldThrowTaskExtensions
     public static T ShouldNotThrow<T>(this Func<Task<T>> action, string? customMessage = null) =>
         Should.NotThrowInternal(action, ShouldlyConfiguration.DefaultTaskTimeout, customMessage);
 
-    /*** ShouldNotThrow(Task<T>, TimeSpan) ***/
     /// <summary>
     /// Verifies that the Task completes without throwing any exceptions within the specified timeout and returns the result.
     /// </summary>
@@ -184,7 +169,6 @@ public static partial class ShouldThrowTaskExtensions
     public static T ShouldNotThrow<T>(this Task<T> action, TimeSpan timeoutAfter, string? customMessage = null) =>
         ShouldNotThrow(() => action, timeoutAfter, customMessage);
 
-    /*** ShouldNotThrow(Func<Task<T>>, TimeSpan) ***/
     /// <summary>
     /// Verifies that the function returning a Task completes without throwing any exceptions within the specified timeout and returns the result.
     /// </summary>

--- a/src/Shouldly/SortDirection.cs
+++ b/src/Shouldly/SortDirection.cs
@@ -9,7 +9,7 @@ public enum SortDirection
     /// Sort in ascending order (smallest to largest)
     /// </summary>
     Ascending = 0,
-    
+
     /// <summary>
     /// Sort in descending order (largest to smallest)
     /// </summary>

--- a/src/Shouldly/StringCompareShould.cs
+++ b/src/Shouldly/StringCompareShould.cs
@@ -10,7 +10,7 @@ public enum StringCompareShould
     /// Ignore case differences when comparing strings
     /// </summary>
     IgnoreCase = 1,
-    
+
     /// <summary>
     /// Ignore line ending differences when comparing strings
     /// </summary>

--- a/src/Shouldly/TestMethodInfo.cs
+++ b/src/Shouldly/TestMethodInfo.cs
@@ -68,12 +68,12 @@ public class TestMethodInfo
     /// The directory containing the source file of the test method
     /// </summary>
     public string? SourceFileDirectory { get; }
-    
+
     /// <summary>
     /// The name of the test method
     /// </summary>
     public string? MethodName { get; }
-    
+
     /// <summary>
     /// The name of the type declaring the test method
     /// </summary>


### PR DESCRIPTION
The `.editorconfig` changes recently are a welcome addition, but they added a lot of error level checks for code which already violates these checks. This PR either lowers the level to warning from error, or makes the necessary change to the code.