### PR TITLE
Fixes ShouldThrowAsync exception formatting

### DIFF
--- a/documentation/documentation/exceptions/throw.md
+++ b/documentation/documentation/exceptions/throw.md
@@ -40,13 +40,14 @@ var exception = await Should.ThrowAsync<DivideByZeroException>(() => doSomething
 <!-- endSnippet -->
 
 **Exception**
-
-Task `doSomething()`<!-- include: FuncOfTaskScenarioAsync.ShouldThrowAsync.approved.txt -->
+<!-- include: FuncOfTaskScenarioAsync.ShouldThrowAsync.approved.txt -->
+```
+Task `doSomething()`
     should throw
 System.DivideByZeroException
-    but did not<!-- endInclude -->
-
-
+    but did not
+```
+<!-- endInclude -->
 ## ShouldThrow Action Extension
 
 <!-- snippet: ShouldThrowExamples.ShouldThrowActionExtension.codeSample.approved.cs -->


### PR DESCRIPTION
It was not formatted into a block quote like the rest of the documentation. 

Also moved the Include to be in the correct location.