### PR TITLE
Feat/should contain same elements as

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -1,0 +1,20 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_call:
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install .NET 9 SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Verify .NET version
+        run: dotnet --info
+
+      # Optional: restore any required tools or workloads
+      - name: Restore tools
+        run: dotnet tool restore

--- a/.github/copilot_instructions.md
+++ b/.github/copilot_instructions.md
@@ -1,0 +1,102 @@
+# Copilot Agent Instructions for Shouldly Repository
+
+## Overview
+
+This document provides instructions for AI agents (like GitHub Copilot) working on this Shouldly repository fork.
+
+## Running Unit Tests in Copilot Agent Environment
+
+The Shouldly project is configured to target .NET 9.0, but many environments (including CI/CD runners) may only have .NET 8.0 SDK available. Here's how to handle this:
+
+### Prerequisites
+
+Check if .NET 9.0 SDK is available:
+```bash
+dotnet --version
+```
+
+If you see an error like "A compatible .NET SDK was not found" or it shows .NET 8.0, follow the steps below.
+
+### Steps to Run Tests with .NET 8.0
+
+1. **Temporarily modify `global.json`** to use available SDK:
+   ```json
+   {
+     "sdk": {
+       "version": "8.0.118",
+       "rollForward": "latestFeature"
+     }
+   }
+   ```
+
+2. **Update Language Version** in `src/Directory.Build.props`:
+   ```xml
+   <LangVersion>12</LangVersion>
+   ```
+   (Change from `13` to `12`)
+
+3. **Update Target Frameworks** in project files:
+   - `src/Shouldly/Shouldly.csproj`: Change `net9.0` to `net8.0` in TargetFrameworks
+   - `src/Shouldly.DiffEngine/Shouldly.DiffEngine.csproj`: Remove `net9.0` from TargetFrameworks
+   - `src/Shouldly.Tests/Shouldly.Tests.csproj`: Change `net9.0` to `net8.0`
+   - `src/DocumentationExamples/DocumentationExamples.csproj`: Change to `net8.0`
+   - `src/DeterministicTests/DeterministicTests.csproj`: Change to `net8.0`
+
+4. **Fix C# 12 compatibility issue** in `src/Shouldly.Tests/StackTraceTests.cs`:
+   ```csharp
+   // Change this line:
+   var stackTraceLines = exception.StackTrace!.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+   
+   // To this:
+   var stackTraceLines = exception.StackTrace!.Split(new char[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+   ```
+
+5. **Build and Test**:
+   ```bash
+   dotnet build
+   dotnet test --no-build
+   ```
+
+### Expected Test Results
+
+- Most tests should pass successfully
+- Some approval tests may fail due to path differences (this is expected in different environments)
+- Core functionality tests should all pass
+
+### Important Notes
+
+- **DO NOT COMMIT** these temporary changes for .NET 8.0 compatibility
+- These changes are only for testing purposes in environments without .NET 9.0
+- Always revert these changes after testing if you're working on the actual codebase
+- The original project should remain targeting .NET 9.0 for production
+
+### Reverting Changes After Testing
+
+```bash
+git checkout -- global.json src/Directory.Build.props src/Shouldly/Shouldly.csproj src/Shouldly.DiffEngine/Shouldly.DiffEngine.csproj src/Shouldly.Tests/Shouldly.Tests.csproj src/DocumentationExamples/DocumentationExamples.csproj src/DeterministicTests/DeterministicTests.csproj src/Shouldly.Tests/StackTraceTests.cs
+```
+
+## Alternative: Installing .NET 9.0 SDK
+
+If your environment supports it, you can install .NET 9.0 SDK instead:
+
+1. Visit https://dotnet.microsoft.com/download/dotnet/9.0
+2. Download and install the SDK for your platform
+3. Verify installation: `dotnet --version`
+4. Build and test normally: `dotnet build && dotnet test`
+
+## Test Project Structure
+
+- **Shouldly.Tests**: Main unit test project
+- **DocumentationExamples**: Example code used in documentation (some tests may fail in different environments)
+- **DeterministicTests**: Tests for deterministic behavior
+- **Shouldly**: Main library project
+- **Shouldly.DiffEngine**: Diff engine integration library
+
+## Common Issues
+
+1. **Path separator differences**: Some tests expect Windows paths (`\`) but run on Linux (`/`) - this is normal
+2. **Approval test failures**: Tests that compare output files may fail due to environment differences
+3. **Missing diff tools**: Some tests require diff tools that may not be available in all environments
+
+These issues are expected when running in different environments and don't indicate problems with your code changes.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 ![Shouldly Logo](https://raw.githubusercontent.com/shouldly/shouldly/master/assets/logo_350x84.png)  
 ========
 
+> **⚠️ PLAYGROUND REPOSITORY ⚠️**  
+> **This repository is a playground/fork and is NOT intended to be merged back to the original Shouldly project.**  
+> **For the official Shouldly library, please visit: https://github.com/shouldly/shouldly**
+
 [![CI](https://github.com/shouldly/shouldly/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/shouldly/shouldly/actions/workflows/CI.yml)
 [![NuGet](https://img.shields.io/nuget/dt/shouldly.svg)](https://www.nuget.org/packages/Shouldly) 
 [![NuGet](https://img.shields.io/nuget/vpre/shouldly.svg)](https://www.nuget.org/packages/Shouldly)

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -236,6 +236,8 @@ namespace Shouldly
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, string? customMessage = null) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, int expectedCount, string? customMessage = null) { }
         public static void ShouldContain<T>(this System.Collections.Generic.IEnumerable<T> actual, T expected, System.Collections.Generic.IEqualityComparer<T> comparer, string? customMessage = null) { }
+        public static void ShouldContainSameElementsAs<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, string? customMessage = null) { }
+        public static void ShouldContainSameElementsAs<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Collections.Generic.IEnumerable<T> expected, System.Collections.Generic.IEqualityComparer<T> comparer, string? customMessage = null) { }
         public static T ShouldHaveSingleItem<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage = null) { }
         public static void ShouldNotBeEmpty<T>([System.Diagnostics.CodeAnalysis.NotNull] this System.Collections.Generic.IEnumerable<T>? actual, string? customMessage = null) { }
         public static void ShouldNotContain<T>(this System.Collections.Generic.IEnumerable<T> actual, System.Linq.Expressions.Expression<System.Func<T, bool>> elementPredicate, string? customMessage = null) { }

--- a/src/Shouldly.Tests/ShouldContainSameElementsAs/ShouldContainSameElementsAsScenarios.cs
+++ b/src/Shouldly.Tests/ShouldContainSameElementsAs/ShouldContainSameElementsAsScenarios.cs
@@ -1,0 +1,106 @@
+namespace Shouldly.Tests.ShouldContainSameElementsAs;
+
+public class ShouldContainSameElementsAsScenarios
+{
+    [Fact]
+    public void ShouldContainSameElementsAs_ShouldFail() =>
+        Verify.ShouldFail(() =>
+                new List<int> { 1, 4, 2 }.ShouldContainSameElementsAs([1, 2, 3], "Some additional context"),
+
+            errorWithSource:
+            """
+            new List<int> { 1, 4, 2 }
+                should contain same elements as (ignoring order)
+            [1, 2, 3]
+                but
+            new List<int> { 1, 4, 2 }
+                is missing
+            [3]
+                and
+            [1, 2, 3]
+                is missing
+            [4]
+
+            Additional Info:
+                Some additional context
+            """,
+
+            errorWithoutSource:
+            """
+            [1, 4, 2]
+                should contain same elements as (ignoring order)
+            [1, 2, 3]
+                but
+            [1, 4, 2]
+                is missing
+            [3]
+                and
+            [1, 2, 3]
+                is missing
+            [4]
+
+            Additional Info:
+                Some additional context
+            """);
+
+    [Fact]
+    public void ShouldPass() =>
+        new List<int> { 1, 3, 2 }.ShouldContainSameElementsAs([1, 2, 3]);
+
+    [Fact]
+    public void ComparerScenario_ShouldPass() =>
+        new[] { "A", "b" }.ShouldContainSameElementsAs(new[] { "b", "a" }, StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Duplicates_WithMatchingCounts_DifferentOrder_ShouldPass() =>
+        new List<int> { 1, 2, 1 }.ShouldContainSameElementsAs([1, 1, 2]);
+
+    [Fact]
+    public void MultiplicityMismatch_ActualHasExtra_ShouldFail() =>
+        Should.Throw<ShouldAssertException>(() =>
+            new List<int> { 1, 1, 2 }.ShouldContainSameElementsAs([1, 2], "Some additional context"));
+
+    [Fact]
+    public void BothEmpty_ShouldPass() =>
+        new List<int>().ShouldContainSameElementsAs(Array.Empty<int>());
+
+    [Fact]
+    public void EmptyActual_ShouldFail() =>
+        Should.Throw<ShouldAssertException>(() =>
+            new List<int>().ShouldContainSameElementsAs([1], "Some additional context"));
+
+    [Fact]
+    public void NullElements_Equal_ShouldPass() =>
+        new string?[] { null, "a" }.ShouldContainSameElementsAs(new string?[] { "a", null });
+
+    [Fact]
+    public void NullPresenceMismatch_ShouldFail() =>
+        Should.Throw<ShouldAssertException>(() =>
+            new string?[] { "a", null }.ShouldContainSameElementsAs(new string?[] { "a" }, "Some additional context"));
+
+    [Fact]
+    public void ComparerMultiplicityMismatch_ShouldFail() =>
+        Should.Throw<ShouldAssertException>(() =>
+            new[] { "a", "A" }.ShouldContainSameElementsAs(new[] { "a" }, StringComparer.OrdinalIgnoreCase, "Some additional context"));
+
+    [Fact]
+    public void LazyEnumerables_ShouldPass()
+    {
+        IEnumerable<int> Yield(params int[] items)
+        {
+            foreach (var i in items) yield return i;
+        }
+
+        Yield(1, 2, 3).ShouldContainSameElementsAs(Yield(3, 2, 1));
+    }
+
+    [Fact]
+    public void NumericSpecials_ShouldPass() =>
+        new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity }
+            .ShouldContainSameElementsAs(new[] { double.NegativeInfinity, double.NaN, double.PositiveInfinity });
+
+    [Fact]
+    public void Regression_ShouldContain_UnchangedGenerator_ShouldFail() =>
+        Should.Throw<ShouldAssertException>(() =>
+            new[] { 1, 2 }.ShouldContain(3, "Some additional context"));
+}

--- a/src/Shouldly/MessageGenerators/ShouldContainMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldContainMessageGenerator.cs
@@ -5,6 +5,7 @@ class ShouldContainMessageGenerator : ShouldlyMessageGenerator
     public override bool CanProcess(IShouldlyAssertionContext context) =>
         context.ShouldMethod.StartsWith("Should", StringComparison.Ordinal)
         && context.ShouldMethod.Contains("Contain")
+        && !context.IgnoreOrder
         && context.Expected is not Expression;
 
     public override string GenerateErrorMessage(IShouldlyAssertionContext context)

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -310,4 +310,17 @@ public static partial class ShouldBeEnumerableTestExtensions
     {
         actual.Select(x => x!.GetType()).ToArray().ShouldBe(expected, customMessage);
     }
+    /// <summary>
+    /// Asserts that the enumerable contains the same elements as the expected enumerable, regardless of order.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ShouldContainSameElementsAs<T>(this IEnumerable<T> actual, IEnumerable<T> expected, string? customMessage = null) =>
+        actual.AssertAwesomelyIgnoringOrder(v => Is.EqualIgnoreOrder(v, expected), actual, expected, customMessage);
+
+    /// <summary>
+    /// Asserts that the enumerable contains the same elements as the expected enumerable, regardless of order, using the specified comparer.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ShouldContainSameElementsAs<T>(this IEnumerable<T> actual, IEnumerable<T> expected, IEqualityComparer<T> comparer, string? customMessage = null) =>
+        actual.AssertAwesomelyIgnoringOrder(v => Is.EqualIgnoreOrder(v, expected, comparer), actual, expected, customMessage);
 }


### PR DESCRIPTION
Adds a new assertion to compare sequences for same elements while ignoring order, with optional comparer support.
Routes ignoring-order failures to the ignoring-order message generator for clearer diffs.
Adds unit tests including duplicates, nulls, lazy sequences, and numeric specials.
Updates the approved public API snapshot.