### PR TITLE
Harden deterministic path resolution for coverage tool compatibility

### DIFF
--- a/src/Shouldly/Internals/DeterministicBuildHelpers.cs
+++ b/src/Shouldly/Internals/DeterministicBuildHelpers.cs
@@ -5,24 +5,7 @@ static class DeterministicBuildHelpers
     private static readonly Regex DeterministicPathRegex = new(@"^/_\d*/");
 
     private static readonly Lazy<IEnumerable<(string, string)>> LazySourcePathMap
-        = new(() =>
-        {
-            var shouldlySourcePathMap = Environment.GetEnvironmentVariable("SHOULDLY_SOURCE_PATH_MAP") ?? "";
-
-            // Fallback: read from ShouldlyPathMaps file in the output directory.
-            // This is needed for Microsoft Testing Platform (MTP) where the test exe is launched
-            // directly and doesn't inherit the env var set during MSBuild.
-            if (string.IsNullOrEmpty(shouldlySourcePathMap))
-            {
-                shouldlySourcePathMap = TryReadPathMapsFile() ?? "";
-            }
-
-            return shouldlySourcePathMap
-                .Split(',')
-                .Select(x => x.Split('='))
-                .Where(x => x.Length == 2)
-                .Select(x => (x[0], x[1]));
-        });
+        = new(ResolveSourcePathMappings);
 
     private static IEnumerable<(string, string)> SourcePathMap => LazySourcePathMap.Value;
 
@@ -41,18 +24,64 @@ static class DeterministicBuildHelpers
 
     internal static bool PathAppearsToBeDeterministic(string fileName) => DeterministicPathRegex.IsMatch(fileName);
 
+    private static IEnumerable<(string, string)> ResolveSourcePathMappings()
+    {
+        // Priority 1: Explicit env var override (only set manually by users)
+        var envVar = Environment.GetEnvironmentVariable("SHOULDLY_SOURCE_PATH_MAP") ?? "";
+        if (!string.IsNullOrEmpty(envVar))
+            return ParsePathMapFormat(envVar);
+
+        // Priority 2: Sidecar file written at build time
+        var fileContents = TryReadPathMapsFile();
+        if (fileContents != null)
+            return ParsePathMapFormat(fileContents);
+
+        // Priority 3: Runtime repo root discovery
+        var repoRoot = TryDiscoverRepoRoot();
+        if (repoRoot != null)
+            return GenerateRepoRootMappings(repoRoot);
+
+        return [];
+    }
+
+    private static IEnumerable<(string, string)> ParsePathMapFormat(string pathMap)
+    {
+        return pathMap
+            .Split(',')
+            .Select(x => x.Split('='))
+            .Where(x => x.Length == 2)
+            .Select(x => (x[0], x[1]));
+    }
+
     private static string? TryReadPathMapsFile()
     {
         try
         {
-            var baseDir = AppContext.BaseDirectory;
             var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
-            if (entryAssembly != null)
+            if (entryAssembly == null)
+                return null;
+
+            var assemblyName = entryAssembly.GetName().Name;
+            var fileName = $"ShouldlyPathMaps_{assemblyName}";
+
+            // Try AppContext.BaseDirectory first
+            var baseDir = AppContext.BaseDirectory;
+            var pathMapsFile = Path.Combine(baseDir, fileName);
+            if (File.Exists(pathMapsFile))
+                return File.ReadAllText(pathMapsFile).Trim();
+
+            // Fallback: try the directory containing the entry assembly.
+            // Under coverage tool hosts, AppContext.BaseDirectory may point elsewhere
+            // but Assembly.Location still points to the original output directory.
+            var assemblyLocation = entryAssembly.Location;
+            if (!string.IsNullOrEmpty(assemblyLocation))
             {
-                var pathMapsFile = Path.Combine(baseDir, $"ShouldlyPathMaps_{entryAssembly.GetName().Name}");
-                if (File.Exists(pathMapsFile))
+                var assemblyDir = Path.GetDirectoryName(assemblyLocation);
+                if (assemblyDir != null && assemblyDir != baseDir)
                 {
-                    return File.ReadAllText(pathMapsFile).Trim();
+                    pathMapsFile = Path.Combine(assemblyDir, fileName);
+                    if (File.Exists(pathMapsFile))
+                        return File.ReadAllText(pathMapsFile).Trim();
                 }
             }
         }
@@ -62,5 +91,45 @@ static class DeterministicBuildHelpers
         }
 
         return null;
+    }
+
+    private static string? TryDiscoverRepoRoot()
+    {
+        try
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null)
+            {
+                if (Directory.Exists(Path.Combine(dir.FullName, ".git")) ||
+                    File.Exists(Path.Combine(dir.FullName, "global.json")))
+                {
+                    return EnsureTrailingSlash(dir.FullName);
+                }
+
+                dir = dir.Parent;
+            }
+        }
+        catch
+        {
+            // Silently fail
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<(string, string)> GenerateRepoRootMappings(string repoRoot)
+    {
+        // Generate mappings for /_/ through /_9/ to cover numbered deterministic prefixes
+        yield return (repoRoot, "/_/");
+        for (var i = 0; i <= 9; i++)
+            yield return (repoRoot, $"/_{i}/");
+    }
+
+    private static string EnsureTrailingSlash(string path)
+    {
+        var separator = Path.DirectorySeparatorChar.ToString();
+        return path.EndsWith(separator, StringComparison.Ordinal)
+            ? path
+            : path + separator;
     }
 }

--- a/src/Shouldly/Internals/DeterministicBuildHelpers.cs
+++ b/src/Shouldly/Internals/DeterministicBuildHelpers.cs
@@ -70,16 +70,19 @@ static class DeterministicBuildHelpers
 
     private static string? TryReadPathMapsFile()
     {
-        try
-        {
-            // Scan candidate directories for all ShouldlyPathMaps_* files and merge them.
-            // We can't rely on the entry assembly name because under VSTest the entry
-            // assembly is "testhost", not the test project that the sidecar was written for.
-            // Multiple test assemblies may share an output directory, so we merge all mappings.
-            var allMappings = new List<string>();
+        // Scan candidate directories for all ShouldlyPathMaps_* files and merge them.
+        // We can't rely on the entry assembly name because under VSTest the entry
+        // assembly is "testhost", not the test project that the sidecar was written for.
+        // Multiple test assemblies may share an output directory, so we merge all mappings.
+        var allMappings = new List<string>();
 
-            foreach (var dir in GetCandidateDirectories())
+        foreach (var dir in GetCandidateDirectories())
+        {
+            try
             {
+                if (!Directory.Exists(dir))
+                    continue;
+
                 var matches = Directory.GetFiles(dir, "ShouldlyPathMaps_*")
                     .OrderBy(path => path, StringComparer.Ordinal);
 
@@ -90,16 +93,15 @@ static class DeterministicBuildHelpers
                         allMappings.Add(contents);
                 }
             }
-
-            if (allMappings.Count > 0)
-                return string.Join(",", allMappings);
-        }
-        catch
-        {
-            // Silently fail - source expressions just won't resolve deterministic paths
+            catch
+            {
+                // Continue to next candidate directory
+            }
         }
 
-        return null;
+        return allMappings.Count > 0
+            ? string.Join(",", allMappings)
+            : null;
     }
 
     private static IEnumerable<string> GetCandidateDirectories()

--- a/src/Shouldly/Internals/DeterministicBuildHelpers.cs
+++ b/src/Shouldly/Internals/DeterministicBuildHelpers.cs
@@ -32,7 +32,11 @@ static class DeterministicBuildHelpers
         {
             var match = DeterministicPathRegex.Match(fileName);
             if (match.Success)
-                return repoRoot + fileName.Remove(0, match.Length);
+            {
+                var candidate = repoRoot + fileName.Remove(0, match.Length);
+                if (File.Exists(candidate))
+                    return candidate;
+            }
         }
 
         return fileName;
@@ -68,15 +72,27 @@ static class DeterministicBuildHelpers
     {
         try
         {
-            // Scan candidate directories for any ShouldlyPathMaps_* file.
+            // Scan candidate directories for all ShouldlyPathMaps_* files and merge them.
             // We can't rely on the entry assembly name because under VSTest the entry
             // assembly is "testhost", not the test project that the sidecar was written for.
+            // Multiple test assemblies may share an output directory, so we merge all mappings.
+            var allMappings = new List<string>();
+
             foreach (var dir in GetCandidateDirectories())
             {
-                var match = Directory.GetFiles(dir, "ShouldlyPathMaps_*").FirstOrDefault();
-                if (match != null)
-                    return File.ReadAllText(match).Trim();
+                var matches = Directory.GetFiles(dir, "ShouldlyPathMaps_*")
+                    .OrderBy(path => path, StringComparer.Ordinal);
+
+                foreach (var match in matches)
+                {
+                    var contents = File.ReadAllText(match).Trim();
+                    if (!string.IsNullOrEmpty(contents))
+                        allMappings.Add(contents);
+                }
             }
+
+            if (allMappings.Count > 0)
+                return string.Join(",", allMappings);
         }
         catch
         {

--- a/src/Shouldly/Internals/DeterministicBuildHelpers.cs
+++ b/src/Shouldly/Internals/DeterministicBuildHelpers.cs
@@ -7,16 +7,32 @@ static class DeterministicBuildHelpers
     private static readonly Lazy<IEnumerable<(string, string)>> LazySourcePathMap
         = new(ResolveSourcePathMappings);
 
+    private static readonly Lazy<string?> LazyDiscoveredRepoRoot
+        = new(TryDiscoverRepoRoot);
+
     private static IEnumerable<(string, string)> SourcePathMap => LazySourcePathMap.Value;
 
     internal static string? ResolveDeterministicPaths(string? fileName)
     {
+        if (fileName == null)
+            return null;
+
         foreach (var (path, placeholder) in SourcePathMap)
         {
-            if (fileName?.StartsWith(placeholder, StringComparison.Ordinal) == true)
+            if (fileName.StartsWith(placeholder, StringComparison.Ordinal))
             {
                 return fileName.Replace(placeholder, path);
             }
+        }
+
+        // Last resort: if we discovered a repo root but have no explicit mappings,
+        // use regex to handle any numbered deterministic prefix (/_/, /_0/, /_10/, etc.)
+        var repoRoot = LazyDiscoveredRepoRoot.Value;
+        if (repoRoot != null)
+        {
+            var match = DeterministicPathRegex.Match(fileName);
+            if (match.Success)
+                return repoRoot + fileName.Remove(0, match.Length);
         }
 
         return fileName;
@@ -36,11 +52,6 @@ static class DeterministicBuildHelpers
         if (fileContents != null)
             return ParsePathMapFormat(fileContents);
 
-        // Priority 3: Runtime repo root discovery
-        var repoRoot = TryDiscoverRepoRoot();
-        if (repoRoot != null)
-            return GenerateRepoRootMappings(repoRoot);
-
         return [];
     }
 
@@ -57,32 +68,14 @@ static class DeterministicBuildHelpers
     {
         try
         {
-            var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
-            if (entryAssembly == null)
-                return null;
-
-            var assemblyName = entryAssembly.GetName().Name;
-            var fileName = $"ShouldlyPathMaps_{assemblyName}";
-
-            // Try AppContext.BaseDirectory first
-            var baseDir = AppContext.BaseDirectory;
-            var pathMapsFile = Path.Combine(baseDir, fileName);
-            if (File.Exists(pathMapsFile))
-                return File.ReadAllText(pathMapsFile).Trim();
-
-            // Fallback: try the directory containing the entry assembly.
-            // Under coverage tool hosts, AppContext.BaseDirectory may point elsewhere
-            // but Assembly.Location still points to the original output directory.
-            var assemblyLocation = entryAssembly.Location;
-            if (!string.IsNullOrEmpty(assemblyLocation))
+            // Scan candidate directories for any ShouldlyPathMaps_* file.
+            // We can't rely on the entry assembly name because under VSTest the entry
+            // assembly is "testhost", not the test project that the sidecar was written for.
+            foreach (var dir in GetCandidateDirectories())
             {
-                var assemblyDir = Path.GetDirectoryName(assemblyLocation);
-                if (assemblyDir != null && assemblyDir != baseDir)
-                {
-                    pathMapsFile = Path.Combine(assemblyDir, fileName);
-                    if (File.Exists(pathMapsFile))
-                        return File.ReadAllText(pathMapsFile).Trim();
-                }
+                var match = Directory.GetFiles(dir, "ShouldlyPathMaps_*").FirstOrDefault();
+                if (match != null)
+                    return File.ReadAllText(match).Trim();
             }
         }
         catch
@@ -93,6 +86,28 @@ static class DeterministicBuildHelpers
         return null;
     }
 
+    private static IEnumerable<string> GetCandidateDirectories()
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // Try AppContext.BaseDirectory first
+        var baseDir = AppContext.BaseDirectory;
+        if (seen.Add(baseDir))
+            yield return baseDir;
+
+        // Fallback: try the directory containing the entry assembly.
+        // Under coverage tool hosts, AppContext.BaseDirectory may point elsewhere
+        // but Assembly.Location still points to the original output directory.
+        var entryAssembly = System.Reflection.Assembly.GetEntryAssembly();
+        var assemblyLocation = entryAssembly?.Location;
+        if (!string.IsNullOrEmpty(assemblyLocation))
+        {
+            var assemblyDir = Path.GetDirectoryName(assemblyLocation);
+            if (assemblyDir != null && seen.Add(assemblyDir))
+                yield return assemblyDir;
+        }
+    }
+
     private static string? TryDiscoverRepoRoot()
     {
         try
@@ -100,7 +115,9 @@ static class DeterministicBuildHelpers
             var dir = new DirectoryInfo(AppContext.BaseDirectory);
             while (dir != null)
             {
-                if (Directory.Exists(Path.Combine(dir.FullName, ".git")) ||
+                var gitPath = Path.Combine(dir.FullName, ".git");
+                if (Directory.Exists(gitPath) ||
+                    File.Exists(gitPath) || // .git can be a file in worktrees/submodules
                     File.Exists(Path.Combine(dir.FullName, "global.json")))
                 {
                     return EnsureTrailingSlash(dir.FullName);
@@ -115,14 +132,6 @@ static class DeterministicBuildHelpers
         }
 
         return null;
-    }
-
-    private static IEnumerable<(string, string)> GenerateRepoRootMappings(string repoRoot)
-    {
-        // Generate mappings for /_/ through /_9/ to cover numbered deterministic prefixes
-        yield return (repoRoot, "/_/");
-        for (var i = 0; i <= 9; i++)
-            yield return (repoRoot, $"/_{i}/");
     }
 
     private static string EnsureTrailingSlash(string path)

--- a/src/Shouldly/Internals/DeterministicBuildHelpers.cs
+++ b/src/Shouldly/Internals/DeterministicBuildHelpers.cs
@@ -128,18 +128,24 @@ static class DeterministicBuildHelpers
     {
         try
         {
-            var dir = new DirectoryInfo(AppContext.BaseDirectory);
-            while (dir != null)
+            // Walk up from each candidate directory (AppContext.BaseDirectory, then Assembly.Location).
+            // Under coverage/tooling hosts that redirect AppContext.BaseDirectory, the assembly
+            // location may be the only path that leads to the actual repo root.
+            foreach (var candidate in GetCandidateDirectories())
             {
-                var gitPath = Path.Combine(dir.FullName, ".git");
-                if (Directory.Exists(gitPath) ||
-                    File.Exists(gitPath) || // .git can be a file in worktrees/submodules
-                    File.Exists(Path.Combine(dir.FullName, "global.json")))
+                var dir = new DirectoryInfo(candidate);
+                while (dir != null)
                 {
-                    return EnsureTrailingSlash(dir.FullName);
-                }
+                    var gitPath = Path.Combine(dir.FullName, ".git");
+                    if (Directory.Exists(gitPath) ||
+                        File.Exists(gitPath) || // .git can be a file in worktrees/submodules
+                        File.Exists(Path.Combine(dir.FullName, "global.json")))
+                    {
+                        return EnsureTrailingSlash(dir.FullName);
+                    }
 
-                dir = dir.Parent;
+                    dir = dir.Parent;
+                }
             }
         }
         catch

--- a/src/Shouldly/ShouldMatchApprovedTestExtensions.cs
+++ b/src/Shouldly/ShouldMatchApprovedTestExtensions.cs
@@ -46,9 +46,10 @@ public static class ShouldMatchApprovedTestExtensions
         var approvedFile = Path.Combine(outputFolder, config.FilenameGenerator(testMethodInfo, discriminator, "approved", config.FileExtension));
         var receivedFile = Path.Combine(outputFolder, config.FilenameGenerator(testMethodInfo, discriminator, "received", config.FileExtension));
 
-        // Check the resolved file path, not the raw source directory — a custom FilenameGenerator
+        // Check the resolved file paths, not the raw source directory — a custom FilenameGenerator
         // may produce an absolute path that resolves the deterministic prefix itself.
-        if (DeterministicBuildHelpers.PathAppearsToBeDeterministic(approvedFile))
+        if (DeterministicBuildHelpers.PathAppearsToBeDeterministic(approvedFile) ||
+            DeterministicBuildHelpers.PathAppearsToBeDeterministic(receivedFile))
             throw new($"Unable to resolve source file from deterministic build source path. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
 
         if (!string.IsNullOrEmpty(config.ApprovalFileSubFolder))

--- a/src/Shouldly/ShouldMatchApprovedTestExtensions.cs
+++ b/src/Shouldly/ShouldMatchApprovedTestExtensions.cs
@@ -53,7 +53,11 @@ public static class ShouldMatchApprovedTestExtensions
             throw new($"Unable to resolve source file from deterministic build source path. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
 
         if (!string.IsNullOrEmpty(config.ApprovalFileSubFolder))
-            Directory.CreateDirectory(outputFolder);
+        {
+            var directoryToCreate = Path.GetDirectoryName(receivedFile);
+            if (!string.IsNullOrEmpty(directoryToCreate))
+                Directory.CreateDirectory(directoryToCreate);
+        }
 
         File.WriteAllText(receivedFile, actual);
 

--- a/src/Shouldly/ShouldMatchApprovedTestExtensions.cs
+++ b/src/Shouldly/ShouldMatchApprovedTestExtensions.cs
@@ -33,20 +33,24 @@ public static class ShouldMatchApprovedTestExtensions
 
         var testMethodInfo = config.TestMethodFinder.GetTestMethodInfo(stackTrace, codeGetter.ShouldlyFrameOffset);
         var discriminator = config.FilenameDiscriminator == null ? null : "." + config.FilenameDiscriminator;
-        var outputFolder = testMethodInfo.SourceFileDirectory;
-        if (string.IsNullOrEmpty(outputFolder))
-            throw new($"Source information not available, make sure you are compiling with full debug information. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
-        if (DeterministicBuildHelpers.PathAppearsToBeDeterministic(outputFolder))
-            throw new($"Unable to resolve source file from deterministic build source path. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
+        var outputFolder = testMethodInfo.SourceFileDirectory ?? "";
 
-        if (!string.IsNullOrEmpty(config.ApprovalFileSubFolder))
+        if (!string.IsNullOrEmpty(config.ApprovalFileSubFolder) && !string.IsNullOrEmpty(outputFolder))
         {
             outputFolder = Path.Combine(outputFolder, config.ApprovalFileSubFolder);
-            Directory.CreateDirectory(outputFolder);
         }
 
         var approvedFile = Path.Combine(outputFolder, config.FilenameGenerator(testMethodInfo, discriminator, "approved", config.FileExtension));
         var receivedFile = Path.Combine(outputFolder, config.FilenameGenerator(testMethodInfo, discriminator, "received", config.FileExtension));
+
+        if (string.IsNullOrEmpty(testMethodInfo.SourceFileDirectory))
+            throw new($"Source information not available, make sure you are compiling with full debug information. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
+        if (DeterministicBuildHelpers.PathAppearsToBeDeterministic(approvedFile))
+            throw new($"Unable to resolve source file from deterministic build source path. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
+
+        if (!string.IsNullOrEmpty(config.ApprovalFileSubFolder))
+            Directory.CreateDirectory(outputFolder);
+
         File.WriteAllText(receivedFile, actual);
 
         if (!File.Exists(approvedFile))

--- a/src/Shouldly/ShouldMatchApprovedTestExtensions.cs
+++ b/src/Shouldly/ShouldMatchApprovedTestExtensions.cs
@@ -33,9 +33,12 @@ public static class ShouldMatchApprovedTestExtensions
 
         var testMethodInfo = config.TestMethodFinder.GetTestMethodInfo(stackTrace, codeGetter.ShouldlyFrameOffset);
         var discriminator = config.FilenameDiscriminator == null ? null : "." + config.FilenameDiscriminator;
-        var outputFolder = testMethodInfo.SourceFileDirectory ?? "";
+        var outputFolder = testMethodInfo.SourceFileDirectory;
 
-        if (!string.IsNullOrEmpty(config.ApprovalFileSubFolder) && !string.IsNullOrEmpty(outputFolder))
+        if (string.IsNullOrEmpty(outputFolder))
+            throw new($"Source information not available, make sure you are compiling with full debug information. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
+
+        if (!string.IsNullOrEmpty(config.ApprovalFileSubFolder))
         {
             outputFolder = Path.Combine(outputFolder, config.ApprovalFileSubFolder);
         }
@@ -43,8 +46,8 @@ public static class ShouldMatchApprovedTestExtensions
         var approvedFile = Path.Combine(outputFolder, config.FilenameGenerator(testMethodInfo, discriminator, "approved", config.FileExtension));
         var receivedFile = Path.Combine(outputFolder, config.FilenameGenerator(testMethodInfo, discriminator, "received", config.FileExtension));
 
-        if (string.IsNullOrEmpty(testMethodInfo.SourceFileDirectory))
-            throw new($"Source information not available, make sure you are compiling with full debug information. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
+        // Check the resolved file path, not the raw source directory — a custom FilenameGenerator
+        // may produce an absolute path that resolves the deterministic prefix itself.
         if (DeterministicBuildHelpers.PathAppearsToBeDeterministic(approvedFile))
             throw new($"Unable to resolve source file from deterministic build source path. Frame: {testMethodInfo.DeclaringTypeName}.{testMethodInfo.MethodName}");
 

--- a/src/Shouldly/buildTransitive/Shouldly.targets
+++ b/src/Shouldly/buildTransitive/Shouldly.targets
@@ -1,22 +1,8 @@
 <Project>
-    <UsingTask TaskName="SetEnvVar" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)/Microsoft.Build.Tasks.Core.dll" >
-        <ParameterGroup>
-            <EnvName ParameterType="System.String" Required="true" />
-            <EnvValue ParameterType="System.String" Required="true" />
-        </ParameterGroup>
-        <Task>
-            <Using Namespace="System" />
-            <Code Type="Fragment" Language="cs"><![CDATA[
-                System.Environment.SetEnvironmentVariable(EnvName, EnvValue);
-            ]]></Code>
-        </Task>
-    </UsingTask>
-    
     <!--
-        This target is used to capture the PathMap value when building the project. The PathMap is used by Shouldly to map paths
-        in stack traces to the source files. The PathMap is written to a file and read by the SetShouldlyPathMaps target.
-        When VSTestNoBuild is not true, then VSTest has inititiated the build so the SetShouldlyPathMaps target has already started,
-        so we need to set the SHOULDLY_SOURCE_PATH_MAP environment variable here.
+        This target captures the PathMap value when building the project and writes it to a sidecar file
+        in the output directory. At runtime, DeterministicBuildHelpers reads this file to map deterministic
+        paths in stack traces back to real source file paths.
     -->
     <Target Name="CapturePathMapsForShouldly" BeforeTargets="CoreCompile" DependsOnTargets="_SetPathMapFromSourceRoots" Condition=" '$(DisableShouldlyPathMaps)' != 'true' AND '$(DeterministicSourcePaths)' == 'true' " >
         <PropertyGroup>
@@ -26,45 +12,5 @@
         <ItemGroup>
             <FileWrites Include="$(_ShouldlyPathMapsFilePath)" Condition=" '$(PathMap)' != '' " />
         </ItemGroup>
-        <SetEnvVar EnvName="SHOULDLY_SOURCE_PATH_MAP" EnvValue="$(PathMap)" Condition=" '$(VSTestNoBuild)' != 'true' " />
-    </Target>
-    
-    <!--
-        This target is used to set the SHOULDLY_SOURCE_PATH_MAP environment variable when running tests with VSTestNoBuild=true.
-        This is necessary because the VSTest task does not run the CoreCompile target, so the PathMap is not set.
-    -->
-    <Target Name="SetShouldlyPathMaps" BeforeTargets="VSTest" Condition=" '$(DisableShouldlyPathMaps)' != 'true' AND '$(VSTestNoBuild)' == 'true' ">
-        <PropertyGroup>
-            <_ShouldlyPathMapsFilePath>$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))ShouldlyPathMaps_$(AssemblyName)</_ShouldlyPathMapsFilePath>
-        </PropertyGroup>
-        <ReadLinesFromFile File="$(_ShouldlyPathMapsFilePath)">
-            <Output TaskParameter="Lines" ItemName="_ShouldlyPathMaps" />
-        </ReadLinesFromFile>
-        <PropertyGroup>
-            <ShouldlyPathMaps>%(_ShouldlyPathMaps.Identity)</ShouldlyPathMaps>
-        </PropertyGroup>
-        <SetEnvVar EnvName="SHOULDLY_SOURCE_PATH_MAP" EnvValue="$(ShouldlyPathMaps)" Condition=" '$(ShouldlyPathMaps)' != '' " />
-    </Target>
-
-    <!--
-        This target is the equivalent of SetShouldlyPathMaps for Microsoft Testing Platform (MTP).
-        MTP test projects (e.g. TUnit, MSTest with runner mode) use InvokeTestingPlatform instead of VSTest.
-        This hooks in before InvokeTestingPlatform launches the test executable, ensuring the environment
-        variable is inherited by the test process.
-        Note: This covers the `dotnet msbuild -t:Test` path. For the `dotnet test` MTP experience (which
-        launches the test exe directly without MSBuild), Shouldly falls back to reading the PathMap file
-        at runtime from the output directory.
-    -->
-    <Target Name="SetShouldlyPathMapsForMTP" BeforeTargets="InvokeTestingPlatform" Condition=" '$(DisableShouldlyPathMaps)' != 'true' ">
-        <PropertyGroup>
-            <_ShouldlyPathMapsFilePath>$([MSBuild]::EnsureTrailingSlash('$(OutputPath)'))ShouldlyPathMaps_$(AssemblyName)</_ShouldlyPathMapsFilePath>
-        </PropertyGroup>
-        <ReadLinesFromFile File="$(_ShouldlyPathMapsFilePath)" Condition=" Exists('$(_ShouldlyPathMapsFilePath)') ">
-            <Output TaskParameter="Lines" ItemName="_ShouldlyMTPPathMaps" />
-        </ReadLinesFromFile>
-        <PropertyGroup>
-            <_ShouldlyMTPPathMaps>%(_ShouldlyMTPPathMaps.Identity)</_ShouldlyMTPPathMaps>
-        </PropertyGroup>
-        <SetEnvVar EnvName="SHOULDLY_SOURCE_PATH_MAP" EnvValue="$(_ShouldlyMTPPathMaps)" Condition=" '$(_ShouldlyMTPPathMaps)' != '' " />
     </Target>
 </Project>


### PR DESCRIPTION
## Summary

Fixes #1173. Improves deterministic path resolution so `ShouldMatchApproved` and source expressions work reliably under coverage tools (MS CodeCoverage, Coverlet) and all test runners (VSTest, MTP).

- **Sidecar file is now the sole build-time mechanism** — removed the `SetEnvVar` inline task and the `SetShouldlyPathMaps`/`SetShouldlyPathMapsForMTP` targets from `Shouldly.targets`. The env var `SHOULDLY_SOURCE_PATH_MAP` is still read at runtime as a manual override if users set it explicitly.
- **Hardened sidecar file discovery** — if the file isn't found at `AppContext.BaseDirectory` (which coverage hosts can redirect), falls back to `Assembly.Location` directory.
- **Added runtime repo root discovery** — walks up from base directory looking for `.git`/`global.json` as a zero-config last resort when no sidecar file or env var is available.
- **Moved deterministic path throw after `FilenameGenerator`** — users with a custom `FilenameGenerator` can now handle deterministic paths themselves instead of being blocked by an early throw.

## Test plan

- [x] `dotnet build src/Shouldly` compiles
- [x] `dotnet test src/Shouldly.Tests` — existing tests pass (2 pre-existing failures unrelated to this change)
- [x] `dotnet build src/TUnitTests -p:ContinuousIntegrationBuild=true && TUnitTests` — deterministic builds + MTP pass
- [x] `dotnet test src/DeterministicTests` — deterministic build tests pass
- [ ] Verify under out-of-process MS CodeCoverage host on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)