### PR TITLE
Use Uri.Equals for ShouldBeEquivalentTo Uri comparisons (#1205)

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/UriScenario.ShouldFailWhenUrisAreNotEqual.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/UriScenario.ShouldFailWhenUrisAreNotEqual.approved.txt
@@ -1,0 +1,10 @@
+Comparing object equivalence, at path:
+subject [System.Uri]
+
+    Expected value to be
+http://def/
+    but was
+http://abc/
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/UriScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/UriScenario.cs
@@ -1,0 +1,62 @@
+namespace Shouldly.Tests.ShouldBeEquivalentTo;
+
+public class UriScenario
+{
+    [Fact]
+    public void ShouldPassWhenUrisAreEqual()
+    {
+        var subject = new Uri("http://abc/");
+        var expected = new Uri("http://abc/");
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldPassWhenUrisDifferOnlyByTrailingSlashNormalisation()
+    {
+        var original = new Uri("http://abc");
+        var roundTripped = new Uri(original.ToString());
+
+        original.ShouldBeEquivalentTo(roundTripped);
+        roundTripped.ShouldBeEquivalentTo(original);
+    }
+
+    [Fact]
+    public void ShouldPassWhenUriIsPropertyOfContainingObject()
+    {
+        var original = new Uri("http://abc");
+        var roundTripped = new Uri(original.ToString());
+
+        var subject = new Holder { Endpoint = roundTripped };
+        var expected = new Holder { Endpoint = original };
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    // Regression test for https://github.com/shouldly/shouldly/issues/1205
+    // A Uri round-tripped through its string form (e.g. bound from config, serialised,
+    // then re-parsed) gains a trailing slash via ToString() normalisation, so its
+    // OriginalString differs even though the Uris are equal. Before the Uri special
+    // case, equivalence walked every Uri property and tripped on OriginalString.
+    [Fact]
+    public void ShouldPassWhenUriIsRoundTrippedThroughString()
+    {
+        var original = new Uri("https://abc.def");
+        var roundTripped = new Uri(original.ToString());
+
+        original.OriginalString.ShouldNotBe(roundTripped.OriginalString);
+        original.ShouldBeEquivalentTo(roundTripped);
+    }
+
+    [Fact]
+    public void ShouldFailWhenUrisAreNotEqual()
+    {
+        var subject = new Uri("http://abc/");
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(new Uri("http://def/"), "Some additional context"));
+    }
+
+    private sealed class Holder
+    {
+        public Uri Endpoint { get; set; } = null!;
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -124,26 +124,11 @@ public static partial class ObjectGraphTestExtensions
 
         previousComparisons.Record(actual, expected);
 
-        if (type == typeof(string))
-        {
-            CompareStrings((string)actual, (string)expected, path, customMessage, shouldlyMethod, actualExpression);
-        }
-        else if (type == typeof(Uri))
-        {
-            CompareUris((Uri)actual, (Uri)expected, path, customMessage, shouldlyMethod, actualExpression);
-        }
-        else if (typeof(IEnumerable).IsAssignableFrom(type))
-        {
-            CompareEnumerables((IEnumerable)actual, (IEnumerable)expected, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
-        }
-        else
-        {
-            var fields = type.GetFields(DefaultBindingFlags);
-            CompareFields(actual, expected, fields, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
+        var fields = type.GetFields(DefaultBindingFlags);
+        CompareFields(actual, expected, fields, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
 
-            var properties = type.GetProperties(DefaultBindingFlags);
-            CompareProperties(actual, expected, properties, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
-        }
+        var properties = type.GetProperties(DefaultBindingFlags);
+        CompareProperties(actual, expected, properties, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
     }
 
     private static void CompareStrings(string actual, string expected, IEnumerable<string> path,

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -44,6 +44,10 @@ public static partial class ObjectGraphTestExtensions
         {
             CompareStrings((string)actual, (string)expected, path, customMessage, shouldlyMethod, actualExpression);
         }
+        else if (type == typeof(Uri))
+        {
+            CompareUris((Uri)actual, (Uri)expected, path, customMessage, shouldlyMethod, actualExpression);
+        }
         else if (typeof(IEnumerable).IsAssignableFrom(type))
         {
             CompareEnumerables((IEnumerable)actual, (IEnumerable)expected, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
@@ -124,6 +128,10 @@ public static partial class ObjectGraphTestExtensions
         {
             CompareStrings((string)actual, (string)expected, path, customMessage, shouldlyMethod, actualExpression);
         }
+        else if (type == typeof(Uri))
+        {
+            CompareUris((Uri)actual, (Uri)expected, path, customMessage, shouldlyMethod, actualExpression);
+        }
         else if (typeof(IEnumerable).IsAssignableFrom(type))
         {
             CompareEnumerables((IEnumerable)actual, (IEnumerable)expected, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
@@ -143,6 +151,14 @@ public static partial class ObjectGraphTestExtensions
         string? actualExpression = null)
     {
         if (!actual.Equals(expected, StringComparison.Ordinal))
+            ThrowException(actual, expected, path, customMessage, shouldlyMethod, actualExpression);
+    }
+
+    private static void CompareUris(Uri actual, Uri expected, IEnumerable<string> path,
+        string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
+        string? actualExpression = null)
+    {
+        if (!actual.Equals(expected))
             ThrowException(actual, expected, path, customMessage, shouldlyMethod, actualExpression);
     }
 


### PR DESCRIPTION
Fixes #1205. `ShouldBeEquivalentTo` deep-walked every public property of `Uri`, so two Uris that are equal under `Uri.Equals` but differ in `OriginalString` were incorrectly reported as not equivalent — most commonly a `Uri` round-tripped through `ToString()`, which appends a normalising trailing slash. This adds a `Uri` special case in `ObjectGraphTestExtensions` that defers to `Uri.Equals`, mirroring the existing `string` case, so canonical Uri equality is honoured. New `UriScenario` tests cover equal Uris, the trailing-slash round-trip in both directions, a Uri nested as an object property (the exact issue repro), a documented `#1205` regression test, and the negative case. All `ShouldBeEquivalentTo` tests pass; the regression tests were verified to fail against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)