### PR TITLE
Add ShouldSatisfy and make ShouldSatisfyAllConditions an obsolete alias

### DIFF
--- a/documentation/documentation/satisfyAllConditions.md
+++ b/documentation/documentation/satisfyAllConditions.md
@@ -1,10 +1,14 @@
-# ShouldSatisfyAllConditions
+# ShouldSatisfy
+
+Asserts that a value satisfies every one of the supplied conditions, reporting *all* the failures at once rather than stopping at the first.
+
+> `ShouldSatisfyAllConditions` is the original name for this assertion. It still works but is now obsolete: it cannot capture the asserted expression via `CallerArgumentExpression` and falls back to stack-trace parsing, which is not trim- or AOT-safe. Prefer `ShouldSatisfy`.
 
 <!-- snippet: ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditions.codeSample.approved.cs -->
 <a id='snippet-ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditions.codeSample.approved.cs'></a>
 ```cs
 var mrBurns = new Person { Name = null };
-mrBurns.ShouldSatisfyAllConditions(
+mrBurns.ShouldSatisfy(
                 [
                     () => mrBurns.Name.ShouldNotBeNullOrEmpty(),
                     () => mrBurns.Name.ShouldBe("Mr.Burns")
@@ -21,11 +25,11 @@ mrBurns.ShouldSatisfyAllConditions(
 mrBurns
     should satisfy all the conditions specified, but does not.
 The following errors were found ...
---------------- Error 1 ---------------
+---------------- Error 1 ----------------
     mrBurns.Name (null)
         should not be null or empty
 
---------------- Error 2 ---------------
+---------------- Error 2 ----------------
     mrBurns.Name
         should be
     "Mr.Burns"
@@ -43,7 +47,7 @@ The following errors were found ...
 <a id='snippet-ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditionsGeneric.codeSample.approved.cs'></a>
 ```cs
 var mrBurns = new Person { Name = null };
-mrBurns.ShouldSatisfyAllConditions(
+mrBurns.ShouldSatisfy(
                 [
                     p => p.Name.ShouldNotBeNullOrEmpty(),
                     p => p.Name.ShouldBe("Mr.Burns")
@@ -60,11 +64,11 @@ mrBurns.ShouldSatisfyAllConditions(
 mrBurns
     should satisfy all the conditions specified, but does not.
 The following errors were found ...
---------------- Error 1 ---------------
+---------------- Error 1 ----------------
     p.Name (null)
         should not be null or empty
 
---------------- Error 2 ---------------
+---------------- Error 2 ----------------
     p.Name
         should be
     "Mr.Burns"

--- a/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditions.codeSample.approved.cs
+++ b/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditions.codeSample.approved.cs
@@ -1,5 +1,5 @@
 var mrBurns = new Person { Name = null };
-mrBurns.ShouldSatisfyAllConditions(
+mrBurns.ShouldSatisfy(
                 [
                     () => mrBurns.Name.ShouldNotBeNullOrEmpty(),
                     () => mrBurns.Name.ShouldBe("Mr.Burns")

--- a/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditions.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditions.exceptionText.approved.txt
@@ -2,11 +2,11 @@
 mrBurns
     should satisfy all the conditions specified, but does not.
 The following errors were found ...
---------------- Error 1 ---------------
+---------------- Error 1 ----------------
     mrBurns.Name (null)
         should not be null or empty
 
---------------- Error 2 ---------------
+---------------- Error 2 ----------------
     mrBurns.Name
         should be
     "Mr.Burns"

--- a/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditionsGeneric.codeSample.approved.cs
+++ b/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditionsGeneric.codeSample.approved.cs
@@ -1,5 +1,5 @@
 var mrBurns = new Person { Name = null };
-mrBurns.ShouldSatisfyAllConditions(
+mrBurns.ShouldSatisfy(
                 [
                     p => p.Name.ShouldNotBeNullOrEmpty(),
                     p => p.Name.ShouldBe("Mr.Burns")

--- a/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditionsGeneric.exceptionText.approved.txt
+++ b/src/DocumentationExamples/CodeExamples/ShouldSatisfyAllConditionsExamples.ShouldSatisfyAllConditionsGeneric.exceptionText.approved.txt
@@ -2,11 +2,11 @@
 mrBurns
     should satisfy all the conditions specified, but does not.
 The following errors were found ...
---------------- Error 1 ---------------
+---------------- Error 1 ----------------
     p.Name (null)
         should not be null or empty
 
---------------- Error 2 ---------------
+---------------- Error 2 ----------------
     p.Name
         should be
     "Mr.Burns"

--- a/src/DocumentationExamples/ShouldSatisfyAllConditionsExamples.cs
+++ b/src/DocumentationExamples/ShouldSatisfyAllConditionsExamples.cs
@@ -12,7 +12,7 @@ public class ShouldSatisfyAllConditionsExamples
             () =>
             {
                 var mrBurns = new Person { Name = null };
-                mrBurns.ShouldSatisfyAllConditions(
+                mrBurns.ShouldSatisfy(
                 [
                     () => mrBurns.Name.ShouldNotBeNullOrEmpty(),
                     () => mrBurns.Name.ShouldBe("Mr.Burns")
@@ -28,7 +28,7 @@ public class ShouldSatisfyAllConditionsExamples
             () =>
             {
                 var mrBurns = new Person { Name = null };
-                mrBurns.ShouldSatisfyAllConditions(
+                mrBurns.ShouldSatisfy(
                 [
                     p => p.Name.ShouldNotBeNullOrEmpty(),
                     p => p.Name.ShouldBe("Mr.Burns")

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -427,8 +427,36 @@ namespace Shouldly
     [Shouldly.ShouldlyMethods]
     public static class ShouldSatisfyAllConditionsTestExtensions
     {
-        public static void ShouldSatisfyAllConditions(this object? actual, System.Action[] conditions, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
-        public static void ShouldSatisfyAllConditions<T>(this T actual, System.Action<T>[] conditions, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
+        public static void ShouldSatisfy(this object? actual, System.Action[] conditions, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
+        public static void ShouldSatisfy<T>(this T actual, System.Action<T>[] conditions, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Without a CallerArgumentExpression the asserted expression is recovered by walkin" +
+            "g the stack trace and reading source, which the trimmer cannot preserve. Use Sho" +
+            "uldSatisfy instead.")]
+        [System.Obsolete("Use ShouldSatisfy instead. This overload cannot capture the asserted expression v" +
+            "ia CallerArgumentExpression and falls back to stack-trace parsing, which is not " +
+            "trim- or AOT-safe.")]
+        public static void ShouldSatisfyAllConditions(this object? actual, params System.Action[] conditions) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Without a CallerArgumentExpression the asserted expression is recovered by walkin" +
+            "g the stack trace and reading source, which the trimmer cannot preserve. Use Sho" +
+            "uldSatisfy instead.")]
+        [System.Obsolete("Use ShouldSatisfy instead. This overload cannot capture the asserted expression v" +
+            "ia CallerArgumentExpression and falls back to stack-trace parsing, which is not " +
+            "trim- or AOT-safe.")]
+        public static void ShouldSatisfyAllConditions(this object? actual, string? customMessage, params System.Action[] conditions) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Without a CallerArgumentExpression the asserted expression is recovered by walkin" +
+            "g the stack trace and reading source, which the trimmer cannot preserve. Use Sho" +
+            "uldSatisfy instead.")]
+        [System.Obsolete("Use ShouldSatisfy instead. This overload cannot capture the asserted expression v" +
+            "ia CallerArgumentExpression and falls back to stack-trace parsing, which is not " +
+            "trim- or AOT-safe.")]
+        public static void ShouldSatisfyAllConditions<T>(this T actual, params System.Action<T>[] conditions) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Without a CallerArgumentExpression the asserted expression is recovered by walkin" +
+            "g the stack trace and reading source, which the trimmer cannot preserve. Use Sho" +
+            "uldSatisfy instead.")]
+        [System.Obsolete("Use ShouldSatisfy instead. This overload cannot capture the asserted expression v" +
+            "ia CallerArgumentExpression and falls back to stack-trace parsing, which is not " +
+            "trim- or AOT-safe.")]
+        public static void ShouldSatisfyAllConditions<T>(this T actual, string? customMessage, params System.Action<T>[] conditions) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class ShouldThrowAsyncExtensions

--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/NonRetraversableEnumerable.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/NonRetraversableEnumerable.cs
@@ -46,7 +46,7 @@ public class NonRetraversableEnumerable
     {
         var fooEnum = CreateTestEnumerable();
 
-        fooEnum.ShouldSatisfyAllConditions(
+        fooEnum.ShouldSatisfy(
         [
             () => fooEnum.ShouldBe([1, 2, 3]),
             () => fooEnum.First().ShouldBe(4),

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario.GenericMultipleConditionsScenarioShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario.GenericMultipleConditionsScenarioShouldFail.approved.txt
@@ -1,7 +1,7 @@
 result
     should satisfy all the conditions specified, but does not.
 The following errors were found ...
---------------- Error 1 ---------------
+---------------- Error 1 ----------------
     r
         should be of type
     System.Single
@@ -11,7 +11,7 @@ The following errors were found ...
     Additional Info:
         Some additional context
 
---------------- Error 2 ---------------
+---------------- Error 2 ----------------
     r
         should be greater than
     5

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario.cs
@@ -7,7 +7,7 @@ public class GenericMultipleConditionsScenario
     {
         var result = 4;
         Verify.ShouldFail(() =>
-            result.ShouldSatisfyAllConditions(
+            result.ShouldSatisfy(
                 [
                     r => r.ShouldBeOfType<float>("Some additional context"),
                     r => r.ShouldBeGreaterThan(5, "Some additional context")
@@ -19,7 +19,7 @@ public class GenericMultipleConditionsScenario
     public void ShouldPass()
     {
         var result = 4;
-        result.ShouldSatisfyAllConditions(
+        result.ShouldSatisfy(
         [
             _ => result.ShouldBeOfType<int>(),
             _ => result.ShouldBeGreaterThan(3)

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine.GenericMultipleConditionsScenario_MultiLineShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine.GenericMultipleConditionsScenario_MultiLineShouldFail.approved.txt
@@ -1,7 +1,7 @@
 result
     should satisfy all the conditions specified, but does not.
 The following errors were found ...
---------------- Error 1 ---------------
+---------------- Error 1 ----------------
     r
         should be of type
     System.Single
@@ -11,7 +11,7 @@ The following errors were found ...
     Additional Info:
         Some additional context
 
---------------- Error 2 ---------------
+---------------- Error 2 ----------------
     r
         should be greater than
     5

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine.cs
@@ -7,7 +7,7 @@ public class GenericMultipleConditionsScenario_MultiLine
     {
         var result = 4;
         Verify.ShouldFail(() =>
-            result.ShouldSatisfyAllConditions(
+            result.ShouldSatisfy(
             [
                 r => r.ShouldBeOfType<float>("Some additional context"),
                 r => r.ShouldBeGreaterThan(5, "Some additional context")
@@ -18,7 +18,7 @@ public class GenericMultipleConditionsScenario_MultiLine
     public void ShouldPass()
     {
         var result = 4;
-        result.ShouldSatisfyAllConditions(
+        result.ShouldSatisfy(
         [
             r
                 => r.ShouldBeOfType<int>(),

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine2.GenericMultipleConditionsScenario_MultiLine2ShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine2.GenericMultipleConditionsScenario_MultiLine2ShouldFail.approved.txt
@@ -1,7 +1,7 @@
 result
     should satisfy all the conditions specified, but does not.
 The following errors were found ...
---------------- Error 1 ---------------
+---------------- Error 1 ----------------
     r
         should be of type
     System.Single
@@ -11,7 +11,7 @@ The following errors were found ...
     Additional Info:
         Some additional context
 
---------------- Error 2 ---------------
+---------------- Error 2 ----------------
     r
         should be greater than
     5

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine2.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/GenericMultipleConditionsScenario_MultiLine2.cs
@@ -7,7 +7,7 @@ public class GenericMultipleConditionsScenario_MultiLine2
     {
         var result = 4;
         Verify.ShouldFail(() =>
-            result.ShouldSatisfyAllConditions(
+            result.ShouldSatisfy(
             [
                 r => r.ShouldBeOfType<float>("Some additional context"),
                 r => r.ShouldBeGreaterThan(5, "Some additional context")
@@ -18,7 +18,7 @@ public class GenericMultipleConditionsScenario_MultiLine2
     public void ShouldPass()
     {
         var result = 4;
-        result.ShouldSatisfyAllConditions(
+        result.ShouldSatisfy(
         [
             r
                 => r

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario.MultipleConditionsScenarioShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario.MultipleConditionsScenarioShouldFail.approved.txt
@@ -1,7 +1,7 @@
 result
     should satisfy all the conditions specified, but does not.
 The following errors were found ...
---------------- Error 1 ---------------
+---------------- Error 1 ----------------
     result
         should be of type
     System.Single
@@ -11,7 +11,7 @@ The following errors were found ...
     Additional Info:
         Some additional context
 
---------------- Error 2 ---------------
+---------------- Error 2 ----------------
     result
         should be greater than
     5

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario.cs
@@ -7,7 +7,7 @@ public class MultipleConditionsScenario
     {
         var result = 4;
         Verify.ShouldFail(() =>
-            result.ShouldSatisfyAllConditions(
+            result.ShouldSatisfy(
                 [
                     () => result.ShouldBeOfType<float>("Some additional context"),
                     () => result.ShouldBeGreaterThan(5, "Some additional context")
@@ -19,7 +19,7 @@ public class MultipleConditionsScenario
     public void ShouldPass()
     {
         var result = 4;
-        result.ShouldSatisfyAllConditions(
+        result.ShouldSatisfy(
         [
             () => result.ShouldBeOfType<int>(),
             () => result.ShouldBeGreaterThan(3)

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario_MultiLine.MultipleConditionsScenario_MultiLineShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario_MultiLine.MultipleConditionsScenario_MultiLineShouldFail.approved.txt
@@ -1,7 +1,7 @@
 result
     should satisfy all the conditions specified, but does not.
 The following errors were found ...
---------------- Error 1 ---------------
+---------------- Error 1 ----------------
     result
         should be of type
     System.Single
@@ -11,7 +11,7 @@ The following errors were found ...
     Additional Info:
         Some additional context
 
---------------- Error 2 ---------------
+---------------- Error 2 ----------------
     result
         should be greater than
     5

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario_MultiLine.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario_MultiLine.cs
@@ -7,7 +7,7 @@ public class MultipleConditionsScenario_MultiLine
     {
         var result = 4;
         Verify.ShouldFail(() =>
-            result.ShouldSatisfyAllConditions(
+            result.ShouldSatisfy(
             [
                 () => result.ShouldBeOfType<float>("Some additional context"),
                 () => result.ShouldBeGreaterThan(5, "Some additional context")
@@ -18,7 +18,7 @@ public class MultipleConditionsScenario_MultiLine
     public void ShouldPass()
     {
         var result = 4;
-        result.ShouldSatisfyAllConditions(
+        result.ShouldSatisfy(
         [
             ()
                 => result.ShouldBeOfType<int>(),

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario_MultiLine2.MultipleConditionsScenario_MultiLine2ShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario_MultiLine2.MultipleConditionsScenario_MultiLine2ShouldFail.approved.txt
@@ -1,7 +1,7 @@
 result
     should satisfy all the conditions specified, but does not.
 The following errors were found ...
---------------- Error 1 ---------------
+---------------- Error 1 ----------------
     result
         should be of type
     System.Single
@@ -11,7 +11,7 @@ The following errors were found ...
     Additional Info:
         Some additional context
 
---------------- Error 2 ---------------
+---------------- Error 2 ----------------
     result
         should be greater than
     5

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario_MultiLine2.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/MultipleConditionsScenario_MultiLine2.cs
@@ -7,7 +7,7 @@ public class MultipleConditionsScenario_MultiLine2
     {
         var result = 4;
         Verify.ShouldFail(() =>
-            result.ShouldSatisfyAllConditions(
+            result.ShouldSatisfy(
             [
                 () => result.ShouldBeOfType<float>("Some additional context"),
                 () => result.ShouldBeGreaterThan(5, "Some additional context")
@@ -18,7 +18,7 @@ public class MultipleConditionsScenario_MultiLine2
     public void ShouldPass()
     {
         var result = 4;
-        result.ShouldSatisfyAllConditions(
+        result.ShouldSatisfy(
         [
             ()
                 => result

--- a/src/Shouldly.Tests/ShouldSatisfyAllConditions/ObsoleteShouldSatisfyAllConditionsScenario.cs
+++ b/src/Shouldly.Tests/ShouldSatisfyAllConditions/ObsoleteShouldSatisfyAllConditionsScenario.cs
@@ -1,0 +1,82 @@
+namespace Shouldly.Tests.ShouldSatisfyAllConditions;
+
+// ShouldSatisfyAllConditions is the obsolete 4.3.0-shaped alias for ShouldSatisfy. These tests
+// deliberately exercise the obsolete params overloads to prove they still collect every failure
+// and honour the custom message. They assert on message fragments rather than a full approved
+// file because, without a CallerArgumentExpression, the rendered code part differs by target
+// framework (stack-walked source on netstandard2.0/net48 versus the value elsewhere).
+#pragma warning disable CS0618 // Type or member is obsolete
+
+public class ObsoleteShouldSatisfyAllConditionsScenario
+{
+    [Fact]
+    public void ParamsOverloadCollectsAllFailures()
+    {
+        var result = 4;
+        var ex = Should.Throw<ShouldAssertException>(() =>
+            result.ShouldSatisfyAllConditions(
+                () => result.ShouldBeOfType<float>(),
+                () => result.ShouldBeGreaterThan(5)));
+
+        ex.Message.ShouldContain("should satisfy all the conditions specified, but does not");
+        ex.Message.ShouldContain("Error 1");
+        ex.Message.ShouldContain("Error 2");
+    }
+
+    [Fact]
+    public void CustomMessageOverloadIncludesCustomMessage()
+    {
+        var result = 4;
+        var ex = Should.Throw<ShouldAssertException>(() =>
+            result.ShouldSatisfyAllConditions(
+                "Some additional context",
+                () => result.ShouldBeGreaterThan(5)));
+
+        ex.Message.ShouldContain("Some additional context");
+    }
+
+    [Fact]
+    public void GenericParamsOverloadCollectsAllFailures()
+    {
+        var result = 4;
+        var ex = Should.Throw<ShouldAssertException>(() =>
+            result.ShouldSatisfyAllConditions(
+                r => r.ShouldBeOfType<float>(),
+                r => r.ShouldBeGreaterThan(5)));
+
+        ex.Message.ShouldContain("Error 1");
+        ex.Message.ShouldContain("Error 2");
+    }
+
+    [Fact]
+    public void GenericCustomMessageOverloadIncludesCustomMessage()
+    {
+        var result = 4;
+        var ex = Should.Throw<ShouldAssertException>(() =>
+            result.ShouldSatisfyAllConditions(
+                "Some additional context",
+                r => r.ShouldBeGreaterThan(5)));
+
+        ex.Message.ShouldContain("Some additional context");
+    }
+
+    [Fact]
+    public void AllConditionsPassDoesNotThrow()
+    {
+        var result = 4;
+        result.ShouldSatisfyAllConditions(
+            () => result.ShouldBeOfType<int>(),
+            () => result.ShouldBeGreaterThan(3));
+    }
+
+    [Fact]
+    public void GenericAllConditionsPassDoesNotThrow()
+    {
+        var result = 4;
+        result.ShouldSatisfyAllConditions(
+            r => r.ShouldBeOfType<int>(),
+            r => r.ShouldBeGreaterThan(3));
+    }
+}
+
+#pragma warning restore CS0618

--- a/src/Shouldly/Internals/AssertionErrorFormatter.cs
+++ b/src/Shouldly/Internals/AssertionErrorFormatter.cs
@@ -2,9 +2,10 @@ namespace Shouldly;
 
 /// <summary>
 /// Formats a set of assertion failure messages into the numbered "Error N" block layout
-/// used by ShouldSatisfyAllConditions. Each error is followed by a blank line and the block
-/// is terminated with a closing divider; dividers are a fixed width so they align in
-/// monospaced output regardless of the error number.
+/// used by ShouldSatisfy (and its obsolete ShouldSatisfyAllConditions alias, which delegates
+/// into it). Each error is followed by a blank line and the block is terminated with a closing
+/// divider; dividers are a fixed width so they align in monospaced output regardless of the
+/// error number.
 /// </summary>
 internal static class AssertionErrorFormatter
 {

--- a/src/Shouldly/Internals/AssertionErrorFormatter.cs
+++ b/src/Shouldly/Internals/AssertionErrorFormatter.cs
@@ -1,0 +1,49 @@
+namespace Shouldly;
+
+/// <summary>
+/// Formats a set of assertion failure messages into the numbered "Error N" block layout
+/// used by ShouldSatisfyAllConditions. Each error is followed by a blank line and the block
+/// is terminated with a closing divider; dividers are a fixed width so they align in
+/// monospaced output regardless of the error number.
+/// </summary>
+internal static class AssertionErrorFormatter
+{
+    private const int DividerWidth = 41;
+
+    /// <summary>
+    /// Builds the "Error N" blocks for the supplied failure messages.
+    /// </summary>
+    internal static string FormatErrors(IEnumerable<string?> errorMessages)
+    {
+        var sb = new StringBuilder();
+        var errorCount = 1;
+        foreach (var message in errorMessages)
+        {
+            sb.AppendLine(Divider($"Error {errorCount}"));
+            var lines = (message ?? string.Empty).Replace("\r\n", "\n").Split('\n');
+            var paddedLines = lines.Select(l => string.IsNullOrEmpty(l) ? l : "    " + l);
+            sb.AppendLine(string.Join(Environment.NewLine, paddedLines.ToArray()));
+            sb.AppendLine();
+            errorCount++;
+        }
+
+        sb.AppendLine(Divider());
+
+        return sb.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Builds a divider line of a fixed width so the error headers and the closing divider
+    /// always align in monospaced output, regardless of the error number.
+    /// </summary>
+    private static string Divider(string? label = null)
+    {
+        if (string.IsNullOrEmpty(label))
+            return new string('-', DividerWidth);
+
+        var text = $" {label} ";
+        var dashes = Math.Max(DividerWidth - text.Length, 2);
+        var left = dashes / 2;
+        return new string('-', left) + text + new string('-', dashes - left);
+    }
+}

--- a/src/Shouldly/MessageGenerators/ShouldSatisfyAllConditionsMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldSatisfyAllConditionsMessageGenerator.cs
@@ -2,7 +2,9 @@ namespace Shouldly.MessageGenerators;
 
 class ShouldSatisfyAllConditionsMessageGenerator : ShouldlyMessageGenerator
 {
-    private static readonly Regex Validator = new("ShouldSatisfyAllConditions");
+    // Matches both the primary ShouldSatisfy and the obsolete ShouldSatisfyAllConditions overloads
+    // (the latter delegates into ShouldSatisfy, so the captured ShouldMethod is "ShouldSatisfy").
+    private static readonly Regex Validator = new("ShouldSatisfy");
 
     public override bool CanProcess(IShouldlyAssertionContext context) =>
         Validator.IsMatch(context.ShouldMethod);

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAllConditionsTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldSatisfyAllConditionsTestExtensions.cs
@@ -10,19 +10,27 @@ namespace Shouldly;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class ShouldSatisfyAllConditionsTestExtensions
 {
+    private const string ObsoleteMessage =
+        "Use ShouldSatisfy instead. This overload cannot capture the asserted expression via " +
+        "CallerArgumentExpression and falls back to stack-trace parsing, which is not trim- or AOT-safe.";
+
+    private const string NotAotSafeMessage =
+        "Without a CallerArgumentExpression the asserted expression is recovered by walking the stack " +
+        "trace and reading source, which the trimmer cannot preserve. Use ShouldSatisfy instead.";
+
     /// <summary>
     /// Asserts that the actual value satisfies all specified conditions.
     /// </summary>
-    public static void ShouldSatisfyAllConditions<T>(this T actual, [InstantHandle] Action<T>[] conditions, string? customMessage = null,
+    public static void ShouldSatisfy<T>(this T actual, [InstantHandle] Action<T>[] conditions, string? customMessage = null,
         [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
-        ShouldSatisfyAllConditions(actual, CreateParameterlessActions(actual, conditions), customMessage, actualExpression);
+        ShouldSatisfy(actual, CreateParameterlessActions(actual, conditions), customMessage, actualExpression);
     }
 
     /// <summary>
-    /// Asserts that the actual object satisfies all specified conditions with a custom message
+    /// Asserts that the actual object satisfies all specified conditions.
     /// </summary>
-    public static void ShouldSatisfyAllConditions(this object? actual, [InstantHandle] Action[] conditions, string? customMessage = null,
+    public static void ShouldSatisfy(this object? actual, [InstantHandle] Action[] conditions, string? customMessage = null,
         [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
         var errorMessages = new List<Exception>();
@@ -45,27 +53,66 @@ public static partial class ShouldSatisfyAllConditionsTestExtensions
         }
     }
 
+    /// <summary>
+    /// Asserts that the actual value satisfies all specified conditions.
+    /// </summary>
+    [Obsolete(ObsoleteMessage)]
+    [RequiresUnreferencedCode(NotAotSafeMessage)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ShouldSatisfyAllConditions<T>(this T actual, [InstantHandle] params Action<T>[] conditions)
+    {
+        SatisfyAllConditionsViaStackWalking(actual, null, CreateParameterlessActions(actual, conditions));
+    }
+
+    /// <summary>
+    /// Asserts that the actual value satisfies all specified conditions with a custom message.
+    /// </summary>
+    [Obsolete(ObsoleteMessage)]
+    [RequiresUnreferencedCode(NotAotSafeMessage)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ShouldSatisfyAllConditions<T>(this T actual, string? customMessage, [InstantHandle] params Action<T>[] conditions)
+    {
+        SatisfyAllConditionsViaStackWalking(actual, customMessage, CreateParameterlessActions(actual, conditions));
+    }
+
+    /// <summary>
+    /// Asserts that the actual object satisfies all specified conditions.
+    /// </summary>
+    [Obsolete(ObsoleteMessage)]
+    [RequiresUnreferencedCode(NotAotSafeMessage)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ShouldSatisfyAllConditions(this object? actual, [InstantHandle] params Action[] conditions)
+    {
+        SatisfyAllConditionsViaStackWalking(actual, null, conditions);
+    }
+
+    /// <summary>
+    /// Asserts that the actual object satisfies all specified conditions with a custom message.
+    /// </summary>
+    [Obsolete(ObsoleteMessage)]
+    [RequiresUnreferencedCode(NotAotSafeMessage)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ShouldSatisfyAllConditions(this object? actual, string? customMessage, [InstantHandle] params Action[] conditions)
+    {
+        SatisfyAllConditionsViaStackWalking(actual, customMessage, conditions);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void SatisfyAllConditionsViaStackWalking(object? actual, string? customMessage, Action[] conditions)
+    {
+        // The obsolete params overloads have no CallerArgumentExpression, so the asserted
+        // expression is recovered by stack-walking. Opt out of the trip-wire that otherwise
+        // forbids that fallback (see ShouldlyConfiguration.AllowStackWalking).
+        using (ShouldlyConfiguration.AllowStackWalking())
+        {
+            ShouldSatisfy(actual, conditions, customMessage, actualExpression: null);
+        }
+    }
+
     private static Action[] CreateParameterlessActions<T>(T parameter, params Action<T>[] actions) {
         return actions.Select(a => new Action(() => a(parameter))).ToArray();
     }
 
-    private static string BuildErrorMessageString(IEnumerable<Exception> errorMessages)
-    {
-        var errorCount = 1;
-        var sb = new StringBuilder();
-        foreach (var errorMessage in errorMessages)
-        {
-            sb.AppendLine($"--------------- Error {errorCount} ---------------");
-            var lines = errorMessage.Message.Replace("\r\n", "\n").Split('\n');
-            var paddedLines = lines.Select(l => string.IsNullOrEmpty(l) ? l : "    " + l);
-            var value = string.Join("\r\n", paddedLines.ToArray());
-            sb.AppendLine(value);
-            sb.AppendLine();
-            errorCount++;
-        }
-
-        sb.AppendLine("-----------------------------------------");
-
-        return sb.ToString().TrimEnd();
-    }
+    private static string BuildErrorMessageString(IEnumerable<Exception> errorMessages) =>
+        AssertionErrorFormatter.FormatErrors(errorMessages.Select(e => e.Message));
 }


### PR DESCRIPTION
Adds `ShouldSatisfy` as the primary multi-condition assertion — an array signature with `CallerArgumentExpression` so the asserted expression is captured at compile time (trim/AOT-safe). `ShouldSatisfyAllConditions` now mirrors the 4.3.0 `params` overloads, marked `[Obsolete]` and `[RequiresUnreferencedCode]`, delegating into `ShouldSatisfy` via `AllowStackWalking`. Both now share a single `AssertionErrorFormatter` so the numbered "Error N" blocks use fixed-width centred dividers that align with the closing divider. Internal call sites (tests and docs) move to `ShouldSatisfy`, with a dedicated characterisation test covering the obsolete overloads. The public API approval and the documentation page are updated accordingly.