### PR TITLE
Fix RemoveBlock greedily stripping non-wrapping outer brackets

### DIFF
--- a/src/Shouldly.Tests/DynamicShould/ThrowFromObjectMethodScenario.NotThrowFromDynamicMethodScenarioShouldFail.approved.txt
+++ b/src/Shouldly.Tests/DynamicShould/ThrowFromObjectMethodScenario.NotThrowFromDynamicMethodScenarioShouldFail.approved.txt
@@ -1,4 +1,4 @@
-`(dynamic)new Foo()).NoExceptionMethod(`
+`((dynamic)new Foo()).NoExceptionMethod()`
     should throw
 System.InvalidOperationException
     but did not

--- a/src/Shouldly.Tests/DynamicShould/ThrowFromObjectMethodScenario.ThrowOtherExceptionFromDynamicMethodScenarioShouldFail.approved.txt
+++ b/src/Shouldly.Tests/DynamicShould/ThrowFromObjectMethodScenario.ThrowOtherExceptionFromDynamicMethodScenarioShouldFail.approved.txt
@@ -1,4 +1,4 @@
-`(dynamic)new Foo()).NoExceptionMethod(`
+`((dynamic)new Foo()).NoExceptionMethod()`
     should throw
 System.ArgumentException
     but did not

--- a/src/Shouldly.Tests/DynamicShould/ThrowFromVoidMethodScenario.NotThrowFromDynamicMethodScenarioShouldFail.approved.txt
+++ b/src/Shouldly.Tests/DynamicShould/ThrowFromVoidMethodScenario.NotThrowFromDynamicMethodScenarioShouldFail.approved.txt
@@ -1,4 +1,4 @@
-`(dynamic)new Foo()).NoExceptionMethod(`
+`((dynamic)new Foo()).NoExceptionMethod()`
     should throw
 System.InvalidOperationException
     but did not

--- a/src/Shouldly.Tests/DynamicShould/ThrowFromVoidMethodScenario.ThrowOtherExceptionFromDynamicMethodScenarioShouldFail.approved.txt
+++ b/src/Shouldly.Tests/DynamicShould/ThrowFromVoidMethodScenario.ThrowOtherExceptionFromDynamicMethodScenarioShouldFail.approved.txt
@@ -1,4 +1,4 @@
-`(dynamic)new Foo()).NoExceptionMethod(`
+`((dynamic)new Foo()).NoExceptionMethod()`
     should throw
 System.ArgumentException
     but did not

--- a/src/Shouldly/Internals/StringHelpers.cs
+++ b/src/Shouldly/Internals/StringHelpers.cs
@@ -117,8 +117,51 @@ static class StringHelpers
         return collapseWhitespace;
     }
 
-    internal static string RemoveBlock(this string input) =>
-        Regex.Replace(input, @"^\s*({|\()\s*(?<inner>.*)\s*(}|\))$", "${inner}");
+    // Strips a single outer `{ ... }` or `( ... )` block, but only when the
+    // brackets genuinely wrap the whole expression. A naive regex would greedily
+    // match the first opening and last closing bracket even when they aren't a
+    // pair (e.g. `((dynamic)new Foo()).NoExceptionMethod()` would lose its real
+    // outer parens), so we balance the brackets to confirm the match.
+    internal static string RemoveBlock(this string input)
+    {
+        var trimmed = input.Trim();
+        if (trimmed.Length < 2)
+            return input;
+
+        var open = trimmed[0];
+        var close = open switch
+        {
+            '{' => '}',
+            '(' => ')',
+            _ => '\0'
+        };
+
+        if (close == '\0' || trimmed[^1] != close)
+            return input;
+
+        var depth = 0;
+        for (var i = 0; i < trimmed.Length; i++)
+        {
+            if (trimmed[i] == open)
+            {
+                depth++;
+            }
+            else if (trimmed[i] == close)
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    // The opening bracket only wraps the whole expression when
+                    // its match is the final character; otherwise leave as-is.
+                    return i == trimmed.Length - 1
+                        ? trimmed[1..^1].Trim()
+                        : input;
+                }
+            }
+        }
+
+        return input;
+    }
 
     // Normalizes a CallerArgumentExpression-captured delegate expression (Action/Func)
     // so failure messages render the inner body the same way the legacy stack-trace


### PR DESCRIPTION
The regex-based `RemoveBlock` matched the first opening bracket and last closing bracket even when they were not a matching pair, corrupting captured expressions such as `((dynamic)new Foo()).NoExceptionMethod()` into `` `(dynamic)new Foo()).NoExceptionMethod(` `` in failure messages. This replaces it with a bracket-balancing implementation that strips a single outer `{ ... }` or `( ... )` block only when those brackets genuinely wrap the whole expression. The four affected `.approved.txt` outputs for the dynamic-method throw scenarios are updated to reflect the corrected expressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)