### PR TITLE
Add ShouldBe/ShouldNotBe overloads for Span<T> and ReadOnlySpan<T>

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -311,6 +311,10 @@ namespace Shouldly
         public static void ShouldBe(this float actual, float expected, double tolerance, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void ShouldBe<T>(this System.Memory<T> actual, System.Memory<T> expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void ShouldBe<T>(this System.ReadOnlyMemory<T> actual, System.ReadOnlyMemory<T> expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void ShouldBe<T>(this System.ReadOnlySpan<T> actual, System.ReadOnlySpan<T> expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void ShouldBe<T>(this System.Span<T> actual, System.ReadOnlySpan<T> expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this T? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] T? expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
         public static void ShouldBe<T>([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this System.Collections.Generic.IEnumerable<T>? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] System.Collections.Generic.IEnumerable<T>? expected, bool ignoreOrder = false, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
@@ -355,6 +359,10 @@ namespace Shouldly
         public static void ShouldNotBe(this System.TimeSpan actual, System.TimeSpan expected, System.TimeSpan tolerance, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void ShouldNotBe<T>(this System.Memory<T> actual, System.Memory<T> expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void ShouldNotBe<T>(this System.ReadOnlyMemory<T> actual, System.ReadOnlyMemory<T> expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void ShouldNotBe<T>(this System.ReadOnlySpan<T> actual, System.ReadOnlySpan<T> expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
+        [System.Runtime.CompilerServices.OverloadResolutionPriority(-1)]
+        public static void ShouldNotBe<T>(this System.Span<T> actual, System.ReadOnlySpan<T> expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void ShouldNotBe<T>(this T? actual, T? expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void ShouldNotBe<T>(this T? actual, T? expected, System.Collections.Generic.IEqualityComparer<T> comparer, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void ShouldNotBeAssignableTo(this object? actual, System.Type expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }

--- a/src/Shouldly.Tests/ShouldBe/Span/ReadOnlySpanScenario.ReadOnlySpanScenarioShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldBe/Span/ReadOnlySpanScenario.ReadOnlySpanScenarioShouldFail.approved.txt
@@ -1,0 +1,10 @@
+"hello".AsSpan()
+    should be
+[w, o, r, l, d]
+    but was
+[h, e, l, l, o]
+    difference
+[*h*, *e*, *l*, l, *o*]
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBe/Span/ReadOnlySpanScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/Span/ReadOnlySpanScenario.cs
@@ -1,0 +1,17 @@
+namespace Shouldly.Tests.ShouldBe.Span;
+
+public class ReadOnlySpanScenario
+{
+    [Fact]
+    public void ReadOnlySpanScenarioShouldFail()
+    {
+        Verify.ShouldFail(() =>
+            "hello".AsSpan().ShouldBe("world".AsSpan(), "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        "hello".AsSpan().ShouldBe("hello".AsSpan());
+    }
+}

--- a/src/Shouldly.Tests/ShouldBe/Span/SpanScenario.SpanScenarioShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldBe/Span/SpanScenario.SpanScenarioShouldFail.approved.txt
@@ -1,0 +1,10 @@
+new[] { 99, 2, 3, 5 }.AsSpan()
+    should be
+[1, 2, 3, 4]
+    but was
+[99, 2, 3, 5]
+    difference
+[*99*, 2, 3, *5*]
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBe/Span/SpanScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/Span/SpanScenario.cs
@@ -1,0 +1,17 @@
+namespace Shouldly.Tests.ShouldBe.Span;
+
+public class SpanScenario
+{
+    [Fact]
+    public void SpanScenarioShouldFail()
+    {
+        Verify.ShouldFail(() =>
+            new[] { 99, 2, 3, 5 }.AsSpan().ShouldBe([1, 2, 3, 4], "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        new[] { 1, 2, 3, 4 }.AsSpan().ShouldBe([1, 2, 3, 4]);
+    }
+}

--- a/src/Shouldly.Tests/ShouldBe/Span/SpanShouldBeBehaviourTests.cs
+++ b/src/Shouldly.Tests/ShouldBe/Span/SpanShouldBeBehaviourTests.cs
@@ -31,13 +31,11 @@ public class SpanShouldBeBehaviourTests
     }
 
     [Fact]
-    [Fact]
     public void SpanOfComplexTypeUsesElementEquality()
     {
         // double comparison goes through Shouldly's own comparer, not bitwise SequenceEqual
         ReadOnlySpan<double> actual = [1.0, 2.0, 3.0];
         actual.ShouldBe([1.0, 2.0, 3.0]);
-    }
     }
 
     [Fact]

--- a/src/Shouldly.Tests/ShouldBe/Span/SpanShouldBeBehaviourTests.cs
+++ b/src/Shouldly.Tests/ShouldBe/Span/SpanShouldBeBehaviourTests.cs
@@ -1,0 +1,57 @@
+namespace Shouldly.Tests.ShouldBe.Span;
+
+public class SpanShouldBeBehaviourTests
+{
+    [Fact]
+    public void ReadOnlySpanOfIntPasses()
+    {
+        ReadOnlySpan<int> actual = [1, 2, 3];
+        actual.ShouldBe([1, 2, 3]);
+    }
+
+    [Fact]
+    public void StackAllocSpanPasses()
+    {
+        Span<int> actual = stackalloc int[] { 1, 2, 3 };
+        actual.ShouldBe([1, 2, 3]);
+    }
+
+    [Fact]
+    public void ArrayConvertsToExpectedReadOnlySpan()
+    {
+        Span<int> actual = [1, 2, 3];
+        actual.ShouldBe(new[] { 1, 2, 3 });
+    }
+
+    [Fact]
+    public void SpanShouldBeFailsWhenLengthsDiffer()
+    {
+        Should.Throw<ShouldAssertException>(() =>
+            new[] { 1, 2, 3 }.AsSpan().ShouldBe([1, 2]));
+    }
+
+    [Fact]
+    public void SpanOfComplexTypeUsesElementEquality()
+    {
+        // float comparison goes through Shouldly's own comparer, not bitwise SequenceEqual
+        ReadOnlySpan<double> actual = [1.0, 2.0, 3.0];
+        actual.ShouldBe([1.0, 2.0, 3.0]);
+    }
+
+    [Fact]
+    public void ShouldNotBePassesWhenContentsDiffer()
+    {
+        ReadOnlySpan<char> actual = "hello".AsSpan();
+        actual.ShouldNotBe("world".AsSpan());
+    }
+
+    // Regression pin: arrays must continue to bind to the IEnumerable<T> overload,
+    // not the new span overloads. The ignoreOrder parameter only exists on the
+    // IEnumerable<T> overload, so this both compiles and passes only if arrays
+    // still resolve there.
+    [Fact]
+    public void ArrayStillResolvesToEnumerableOverload()
+    {
+        new[] { 3, 2, 1 }.ShouldBe([1, 2, 3], ignoreOrder: true);
+    }
+}

--- a/src/Shouldly.Tests/ShouldBe/Span/SpanShouldBeBehaviourTests.cs
+++ b/src/Shouldly.Tests/ShouldBe/Span/SpanShouldBeBehaviourTests.cs
@@ -31,11 +31,13 @@ public class SpanShouldBeBehaviourTests
     }
 
     [Fact]
+    [Fact]
     public void SpanOfComplexTypeUsesElementEquality()
     {
-        // float comparison goes through Shouldly's own comparer, not bitwise SequenceEqual
+        // double comparison goes through Shouldly's own comparer, not bitwise SequenceEqual
         ReadOnlySpan<double> actual = [1.0, 2.0, 3.0];
         actual.ShouldBe([1.0, 2.0, 3.0]);
+    }
     }
 
     [Fact]

--- a/src/Shouldly.Tests/ShouldBe/Span/SpanShouldNotBeScenario.SpanShouldNotBeScenarioShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldBe/Span/SpanShouldNotBeScenario.SpanShouldNotBeScenarioShouldFail.approved.txt
@@ -1,0 +1,9 @@
+new[] { 1, 2, 3 }.AsSpan()
+    should not be
+[1, 2, 3]
+    but was
+    difference
+[1, 2, 3]
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBe/Span/SpanShouldNotBeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/Span/SpanShouldNotBeScenario.cs
@@ -1,0 +1,17 @@
+namespace Shouldly.Tests.ShouldBe.Span;
+
+public class SpanShouldNotBeScenario
+{
+    [Fact]
+    public void SpanShouldNotBeScenarioShouldFail()
+    {
+        Verify.ShouldFail(() =>
+            new[] { 1, 2, 3 }.AsSpan().ShouldNotBe([1, 2, 3], "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldPass()
+    {
+        new[] { 1, 2, 3 }.AsSpan().ShouldNotBe([1, 2, 4]);
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/SpanShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/SpanShouldBeTestExtensions.cs
@@ -1,0 +1,86 @@
+namespace Shouldly;
+
+public static partial class ShouldBeTestExtensions
+{
+    // These overloads are marked as the lowest overload-resolution priority on
+    // purpose. From C# 14, arrays and strings gain an implicit span conversion
+    // for extension-method receivers, so `someArray.ShouldBe([...])` would
+    // otherwise become ambiguous between the generic T / IEnumerable<T> overloads
+    // and these span ones. Demoting the span overloads means a genuine span
+    // (which the generic T overload can't bind, since ref structs can't be a type
+    // argument) still selects them, while arrays/strings keep their existing
+    // higher-priority overloads and behaviour.
+
+    /// <summary>
+    /// Asserts that a <see cref="ReadOnlySpan{T}"/> has content-equal elements to another <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    [OverloadResolutionPriority(-1)]
+    public static void ShouldBe<T>(
+        this ReadOnlySpan<T> actual,
+        ReadOnlySpan<T> expected,
+        string? customMessage = null,
+        [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
+    {
+        AssertSpansEqual(actual, expected, shouldBeEqual: true, customMessage, actualExpression);
+    }
+
+    /// <summary>
+    /// Asserts that a <see cref="Span{T}"/> has content-equal elements to another <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    [OverloadResolutionPriority(-1)]
+    public static void ShouldBe<T>(
+        this Span<T> actual,
+        ReadOnlySpan<T> expected,
+        string? customMessage = null,
+        [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
+    {
+        AssertSpansEqual(actual, expected, shouldBeEqual: true, customMessage, actualExpression);
+    }
+
+    /// <summary>
+    /// Asserts that a <see cref="ReadOnlySpan{T}"/> does not have content-equal elements to another <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    [OverloadResolutionPriority(-1)]
+    public static void ShouldNotBe<T>(
+        this ReadOnlySpan<T> actual,
+        ReadOnlySpan<T> expected,
+        string? customMessage = null,
+        [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
+    {
+        AssertSpansEqual(actual, expected, shouldBeEqual: false, customMessage, actualExpression);
+    }
+
+    /// <summary>
+    /// Asserts that a <see cref="Span{T}"/> does not have content-equal elements to another <see cref="ReadOnlySpan{T}"/>.
+    /// </summary>
+    [OverloadResolutionPriority(-1)]
+    public static void ShouldNotBe<T>(
+        this Span<T> actual,
+        ReadOnlySpan<T> expected,
+        string? customMessage = null,
+        [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
+    {
+        AssertSpansEqual(actual, expected, shouldBeEqual: false, customMessage, actualExpression);
+    }
+
+    // Spans are ref structs: they cannot be boxed into object?, captured in the
+    // Func<T,bool> AssertAwesomely expects, or stored on the assertion context.
+    // So we compare inline and only materialise (ToArray) on the failure path,
+    // where we're allocating to build the message anyway. CallerMemberName picks
+    // up "ShouldBe"/"ShouldNotBe" from the public overload that called us, so the
+    // message generator negates correctly.
+    private static void AssertSpansEqual<T>(
+        ReadOnlySpan<T> actual,
+        ReadOnlySpan<T> expected,
+        bool shouldBeEqual,
+        string? customMessage,
+        string? actualExpression,
+        [CallerMemberName] string shouldlyMethod = null!)
+    {
+        if (SpanSequenceEqual(actual, expected) == shouldBeEqual)
+            return;
+
+        throw new ShouldAssertException(
+            new ExpectedActualShouldlyMessage(expected.ToArray(), actual.ToArray(), customMessage, shouldlyMethod, actualExpression).ToString());
+    }
+}


### PR DESCRIPTION
Adds `ShouldBe`/`ShouldNotBe` overloads for `Span<T>` and `ReadOnlySpan<T>`, comparing elements element-wise via Shouldly's existing comparer and only materialising arrays on the failure path (ref structs can't be boxed or captured). The overloads are marked `[OverloadResolutionPriority(-1)]` so arrays and strings keep binding to their existing higher-priority overloads under C# 14 first-class span conversions, while genuine spans — which can't bind the generic `T` overload — select these. Includes behaviour tests plus approval-based failure-message scenarios, and the updated public API approval file. Verified the library and test project build warning-clean and all new span tests pass.