### PR TITLE
Add NuGet trusted publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish to NuGet
+
+on:
+  push:
+    tags:
+      - '[0-9]+\.[0-9]+\.[0-9]+'
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release       # secret scoping + optional approval gate
+    permissions:
+      id-token: write          # Required for OIDC token (NuGet trusted publishing)
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+
+      - name: Validate tag matches project version
+        shell: bash
+        run: |
+          PROJECT_VERSION=$(sed -n 's:.*<Version>\(.*\)</Version>.*:\1:p' src/Directory.Build.props)
+          if [ "$PROJECT_VERSION" != "${GITHUB_REF_NAME}" ]; then
+            echo "::error::Tag (${GITHUB_REF_NAME}) doesn't match <Version> ($PROJECT_VERSION) in src/Directory.Build.props"
+            exit 1
+          fi
+
+      # Reuses the same script CI runs: build + pack (src/Shouldly -> artifacts/Packages) + test.
+      - name: Build, pack and test
+        run: ./build.ps1
+        shell: pwsh
+
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}   # nuget.org profile name, NOT email
+
+      - name: Push to NuGet
+        run: >
+          dotnet nuget push ./artifacts/Packages/*.nupkg
+          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
+          --source https://api.nuget.org/v3/index.json
+          --skip-duplicate

--- a/build.ps1
+++ b/build.ps1
@@ -30,10 +30,13 @@ Write-Host "Packing..." -ForegroundColor Cyan
 if (Test-Path $packagesDir) {
     Remove-Item -Recurse -Force $packagesDir
 }
-dotnet pack src\Shouldly --no-build --output $packagesDir @dotnetArgs /bl:"$logsDir/pack.binlog"
-if ($LASTEXITCODE -ne 0) { 
-    Write-Error "Pack failed with exit code $LASTEXITCODE"
-    exit 1 
+$packProjects = @("src\Shouldly", "src\Shouldly.DiffEngine")
+foreach ($project in $packProjects) {
+    dotnet pack $project --no-build --output $packagesDir @dotnetArgs /bl:"$logsDir/pack-$(Split-Path $project -Leaf).binlog"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Pack for $project failed with exit code $LASTEXITCODE"
+        exit 1
+    }
 }
 
 # Test


### PR DESCRIPTION
Adds keyless NuGet publishing via OIDC trusted publishing, replacing long-lived API keys. A new tag-triggered `publish.yml` (matching the existing `[0-9]+.[0-9]+.[0-9]+` tag convention) uses `NuGet/login@v1` with `id-token: write` and a scoped `release` environment, then pushes to nuget.org. It reuses `build.ps1` so publishing is gated on the same build + test run as CI, and `build.ps1` now packs `Shouldly.DiffEngine` alongside `Shouldly` so both packages are validated in CI and shipped on release. Before the first publish, a trusted publishing policy must be created on nuget.org (owner `shouldly`, repo `shouldly`, workflow `publish.yml`, environment `release`) and a `NUGET_USER` secret added to the `release` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)