### PR TITLE
Bump version to 5.0.0-preview.1 and allow prerelease publish tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,8 @@ name: Publish to NuGet
 on:
   push:
     tags:
-      - '[0-9]+\.[0-9]+\.[0-9]+'
+      - '[0-9]+\.[0-9]+\.[0-9]+'        # stable: 5.0.0
+      - '[0-9]+\.[0-9]+\.[0-9]+-*'      # prerelease: 5.0.0-preview.1
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>4.3.0</Version>
+    <Version>5.0.0-preview.1</Version>
     <AnalysisLevel>5</AnalysisLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Prepares the first trusted-publishing release. Adds a prerelease tag pattern (`[0-9]+.[0-9]+.[0-9]+-*`) to `publish.yml` so tags like `5.0.0-preview.1` trigger a NuGet publish, and bumps `<Version>` in `src/Directory.Build.props` to `5.0.0-preview.1` so the workflow's tag/version validation passes. Once merged, pushing the `5.0.0-preview.1` tag will publish `Shouldly` and `Shouldly.DiffEngine` previews to nuget.org via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)