### PR TITLE
Include copyright information in NuGet metadata

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,6 +21,7 @@
     <ShouldlyPublicKey>0024000004800000940000000602000000240000525341310004000001000100e3aa2a20de74f360af7742a2b21b409d570722b14ec3d14283a0d89e8147855d1097fbf084d7b3a8bbd1bfe50a589254ce50ee70bf530f23e280e13eeeff3813a6863a8dffa604f6a749628fc82f449e8a5717a4a70787a3f55547f1a2ad8fffafe8945f327dc7a66887b81c7bb5b8f06651f51a7e640e150a7c4cf1049041ca</ShouldlyPublicKey>
     <Description>Shouldly - Assertion framework for .NET. The way asserting *Should* be</Description>
     <Authors>Jake Ginnivan, Joseph Woodward, Simon Cropp</Authors>
+    <Copyright>Copyright © $(Authors) and Shouldly contributors</Copyright>
     <PackageTags>test;unit;testing;TDD;AAA;should;testunit;rspec;assert;assertion;framework</PackageTags>
     <PackageIcon>assets/logo_128x128.png</PackageIcon>
     <PackageProjectUrl>https://docs.shouldly.org</PackageProjectUrl>


### PR DESCRIPTION
Adds a `Copyright` property to the package metadata in `src/Directory.Build.props`. Uses `$(Authors)` so it stays in sync.

Verified by packing both packages and reading the generated `.nuspec`:

    <copyright>Copyright © Jake Ginnivan, Joseph Woodward, Simon Cropp and Shouldly contributors</copyright>

Could also be shortened to just:

    <copyright>Copyright © Jake Ginnivan, Joseph Woodward, Simon Cropp</copyright>

It could also be added to `LICENSE.txt`.

Closes #1164