### PR TITLE
Fix ShouldBeEquivalentTo throwing when comparing System.Type values

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.ShouldFailWhenTypesDiffer.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.ShouldFailWhenTypesDiffer.approved.txt
@@ -1,0 +1,10 @@
+Comparing object equivalence, at path:
+typeof(int) [System.RuntimeType]
+
+    Expected value to be
+System.String
+    but was
+System.Int32
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.cs
@@ -9,4 +9,42 @@ public class TypeScenario
         Verify.ShouldFail(() =>
             subject.ShouldBeEquivalentTo(5, "Some additional context"));
     }
+
+    // Regression tests for https://github.com/shouldly/shouldly/issues/1050
+    // Comparing System.Type values used to walk every Type property and trip on
+    // Type.DeclaringMethod ("Method may only be called on a Type for which
+    // Type.IsGenericParameter is true"), surfaced as a TargetInvocationException.
+    [Fact]
+    public void ShouldPassWhenTypesAreEqual()
+    {
+        typeof(int).ShouldBeEquivalentTo(typeof(int));
+    }
+
+    [Fact]
+    public void ShouldPassWhenTypeIsPropertyOfContainingObject()
+    {
+        var subject = new Holder { Type = typeof(int) };
+        var expected = new Holder { Type = typeof(int) };
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldPassForListOfTypes()
+    {
+        new List<Type> { typeof(int), typeof(string) }
+            .ShouldBeEquivalentTo(new List<Type> { typeof(int), typeof(string) });
+    }
+
+    [Fact]
+    public void ShouldFailWhenTypesDiffer()
+    {
+        Verify.ShouldFail(() =>
+            typeof(int).ShouldBeEquivalentTo(typeof(string), "Some additional context"));
+    }
+
+    private sealed class Holder
+    {
+        public Type Type { get; set; } = null!;
+    }
 }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.cs
@@ -10,10 +10,6 @@ public class TypeScenario
             subject.ShouldBeEquivalentTo(5, "Some additional context"));
     }
 
-    // Regression tests for https://github.com/shouldly/shouldly/issues/1050
-    // Comparing System.Type values used to walk every Type property and trip on
-    // Type.DeclaringMethod ("Method may only be called on a Type for which
-    // Type.IsGenericParameter is true"), surfaced as a TargetInvocationException.
     [Fact]
     public void ShouldPassWhenTypesAreEqual()
     {

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -48,6 +48,14 @@ public static partial class ObjectGraphTestExtensions
         {
             CompareUris((Uri)actual, (Uri)expected, path, customMessage, shouldlyMethod, actualExpression);
         }
+        else if (typeof(Type).IsAssignableFrom(type))
+        {
+            // A Type's runtime type is the internal RuntimeType, so guard with
+            // IsAssignableFrom rather than `type == typeof(Type)`. Reflecting over a
+            // Type's own properties trips on Type.DeclaringMethod (#1050); compare by
+            // identity instead, matching how Uri/string are treated as leaf values.
+            CompareTypes((Type)actual, (Type)expected, path, customMessage, shouldlyMethod, actualExpression);
+        }
         else if (typeof(IEnumerable).IsAssignableFrom(type))
         {
             CompareEnumerables((IEnumerable)actual, (IEnumerable)expected, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
@@ -140,6 +148,14 @@ public static partial class ObjectGraphTestExtensions
     }
 
     private static void CompareUris(Uri actual, Uri expected, IEnumerable<string> path,
+        string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
+        string? actualExpression = null)
+    {
+        if (!actual.Equals(expected))
+            ThrowException(actual, expected, path, customMessage, shouldlyMethod, actualExpression);
+    }
+
+    private static void CompareTypes(Type actual, Type expected, IEnumerable<string> path,
         string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
         string? actualExpression = null)
     {

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -50,10 +50,6 @@ public static partial class ObjectGraphTestExtensions
         }
         else if (typeof(Type).IsAssignableFrom(type))
         {
-            // A Type's runtime type is the internal RuntimeType, so guard with
-            // IsAssignableFrom rather than `type == typeof(Type)`. Reflecting over a
-            // Type's own properties trips on Type.DeclaringMethod (#1050); compare by
-            // identity instead, matching how Uri/string are treated as leaf values.
             CompareTypes((Type)actual, (Type)expected, path, customMessage, shouldlyMethod, actualExpression);
         }
         else if (typeof(IEnumerable).IsAssignableFrom(type))


### PR DESCRIPTION
`ShouldBeEquivalentTo` throws a `TargetInvocationException` when comparing two different `System.Type` values (or objects/collections that contain them), instead of producing a normal assertion failure.

**Cause:** equivalence walks every property of the runtime type, and `Type.DeclaringMethod` throws for any non–generic-parameter type.

**Fix:** treat `Type` as a leaf value and compare with `Type.Equals` — the approach FluentAssertions uses, and consistent with the existing `Uri` handling from #1215.

> The guard is `typeof(Type).IsAssignableFrom(type)`, not `type == typeof(Type)`: a `Type`'s runtime type is `RuntimeType`, so `==` would never match.

Fixes #1050

_Disclaimer: Generated with Claude._
