### PR TITLE
Fix ShouldContain throwing NullReferenceException on a null string

### DIFF
--- a/src/Shouldly.Tests/ShouldContain/NullStringScenario.NullStringScenarioShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldContain/NullStringScenario.NullStringScenarioShouldFail.approved.txt
@@ -1,0 +1,5 @@
+actual
+    should contain (case insensitive comparison)
+"legendary"
+    but was actually
+null

--- a/src/Shouldly.Tests/ShouldContain/NullStringScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/NullStringScenario.cs
@@ -10,4 +10,12 @@ public class NullStringScenario
         Verify.ShouldFail(() =>
             actual.ShouldContain("legendary"));
     }
+
+    [Fact]
+    public void NullStringShouldNotContainShouldPass()
+    {
+        string actual = null!;
+
+        actual.ShouldNotContain("legendary");
+    }
 }

--- a/src/Shouldly.Tests/ShouldContain/NullStringScenario.cs
+++ b/src/Shouldly.Tests/ShouldContain/NullStringScenario.cs
@@ -1,0 +1,13 @@
+namespace Shouldly.Tests.ShouldContain;
+
+public class NullStringScenario
+{
+    [Fact]
+    public void NullStringScenarioShouldFail()
+    {
+        string actual = null!;
+
+        Verify.ShouldFail(() =>
+            actual.ShouldContain("legendary"));
+    }
+}

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringContainsTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/StringContainsTestExtensions.cs
@@ -27,7 +27,7 @@ public static partial class ShouldBeStringTestExtensions
     {
         actual.AssertAwesomely(
             v => caseSensitivity == Case.Sensitive ? Is.StringContainingUsingCaseSensitivity(v, expected) : Is.StringContainingIgnoreCase(v, expected),
-            actual.Clip(100, "..."),
+            actual?.Clip(100, "..."),
             expected,
             caseSensitivity,
             customMessage, actualExpression: actualExpression);
@@ -43,7 +43,7 @@ public static partial class ShouldBeStringTestExtensions
         {
             var b = caseSensitivity == Case.Sensitive ? !Is.StringContainingUsingCaseSensitivity(v, expected) : !Is.StringContainingIgnoreCase(v, expected);
             return b;
-        }, actual.Clip(100, "..."), expected, caseSensitivity, customMessage, actualExpression: actualExpression);
+        }, actual?.Clip(100, "..."), expected, caseSensitivity, customMessage, actualExpression: actualExpression);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #821 - `ShouldContain`/`ShouldNotContain` throwing a raw `NullReferenceException` on a null string.

Use the null-conditional `actual?.Clip(...)` so a null actual flows through the normal message pipeline.