### PR TITLE
Update authors to current maintainers

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -78,14 +78,16 @@ What is meant by "full" is that when you set up your "release" configuration in 
 
 ## Currently maintained by
 
-* [Jake Ginnivan](https://github.com/JakeGinnivan)
-* [Joseph Woodward](https://github.com/JosephWoodward)
+* [Stuart Lang](https://github.com/slang25)
+* [Simon Cropp](https://github.com/SimonCropp)
+* [Joseph Musser](https://github.com/jnm2)
 
 If you are interested in helping out, jump on [Gitter](https://gitter.im/shouldly/shouldly) and have a chat.
 
 
 ## Brought to you by
 
+* Joseph Woodward
 * Dave Newman
 * Xerxes Battiwalla
 * Anthony Egerton

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)sn.snk</AssemblyOriginatorKeyFile>
     <ShouldlyPublicKey>0024000004800000940000000602000000240000525341310004000001000100e3aa2a20de74f360af7742a2b21b409d570722b14ec3d14283a0d89e8147855d1097fbf084d7b3a8bbd1bfe50a589254ce50ee70bf530f23e280e13eeeff3813a6863a8dffa604f6a749628fc82f449e8a5717a4a70787a3f55547f1a2ad8fffafe8945f327dc7a66887b81c7bb5b8f06651f51a7e640e150a7c4cf1049041ca</ShouldlyPublicKey>
     <Description>Shouldly - Assertion framework for .NET. The way asserting *Should* be</Description>
-    <Authors>Jake Ginnivan, Joseph Woodward, Simon Cropp</Authors>
+    <Authors>Stuart Lang, Simon Cropp, Joseph Musser</Authors>
     <Copyright>Copyright © $(Authors) and Shouldly contributors</Copyright>
     <PackageTags>test;unit;testing;TDD;AAA;should;testunit;rspec;assert;assertion;framework</PackageTags>
     <PackageIcon>assets/logo_128x128.png</PackageIcon>


### PR DESCRIPTION
Updates the package `Authors` metadata and the README "Currently maintained by" list to the current maintainers: Stuart Lang, Simon Cropp, and Joseph Musser. Joseph Woodward is moved into the "Brought to you by" credits, and the `Copyright` field automatically follows the updated `Authors` value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)