### PR TITLE
Add FluentAssertions migration guide

### DIFF
--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -7,6 +7,7 @@
 ## Documentation
 
 * [Getting Started](documentation/getting-started.md)
+* [Migrating from FluentAssertions](documentation/migrating-from-fluentassertions.md)
 * [Configuration](documentation/configuration.md)
 * [Equality](documentation/equality/README.md)
   * [ShouldBe](documentation/equality/shouldBe.md)

--- a/documentation/documentation/migrating-from-fluentassertions.md
+++ b/documentation/documentation/migrating-from-fluentassertions.md
@@ -40,7 +40,8 @@ result.ShouldBe(5);
 
 ## Quick reference
 
-Direct name mappings. Rows marked with a warning sign are not a plain rename, so check the note.
+Direct name mappings. Where a mapping is not a plain rename, a note in parentheses says what
+changed.
 
 ### Equality and identity
 
@@ -57,6 +58,7 @@ Direct name mappings. Rows marked with a warning sign are not a plain rename, so
 | `x.Should().BeOfType<T>()` | `x.ShouldBeOfType<T>()` |
 | `x.Should().NotBeOfType<T>()` | `x.ShouldNotBeOfType<T>()` |
 | `x.Should().BeAssignableTo<T>()` | `x.ShouldBeAssignableTo<T>()` |
+| `x.Should().BeOneOf(a, b)` | `x.ShouldBeOneOf([a, b])` (takes an array, not `params`) |
 | `x.Should().BeEquivalentTo(y)` | `x.ShouldBeEquivalentTo(y)` (see [caveats](#object-equivalence-shouldbeequivalentto)) |
 
 ### Comparisons and ranges
@@ -85,14 +87,14 @@ Direct name mappings. Rows marked with a warning sign are not a plain rename, so
 | `c.Should().Contain(x => …)` | `c.ShouldContain(x => …)` |
 | `c.Should().BeEmpty()` | `c.ShouldBeEmpty()` |
 | `c.Should().NotBeEmpty()` | `c.ShouldNotBeEmpty()` |
-| `c.Should().HaveCount(n)` | `c.Count.ShouldBe(n)` ⚠️ (no `ShouldHaveCount`) |
+| `c.Should().HaveCount(n)` | `c.Count.ShouldBe(n)` (no `ShouldHaveCount`) |
 | `c.Should().HaveCountGreaterThan(n)` | `c.Count.ShouldBeGreaterThan(n)` |
 | `c.Should().Equal(a, b, c)` | `c.ShouldBe([a, b, c])` (order-sensitive) |
-| `c.Should().BeEquivalentTo(other)` | `c.ShouldBe(other, ignoreOrder: true)` ⚠️ (not `ShouldBeEquivalentTo`; [see below](#collections-order-and-element-equality)) |
-| `c.Should().OnlyHaveUniqueItems()` | `c.ShouldBeUnique()` ⚠️ (not `ShouldAllBeUnique`) |
+| `c.Should().BeEquivalentTo(other)` | `c.ShouldBe(other, ignoreOrder: true)` (not `ShouldBeEquivalentTo`; [see below](#collections-order-and-element-equality)) |
+| `c.Should().OnlyHaveUniqueItems()` | `c.ShouldBeUnique()` (not `ShouldAllBeUnique`) |
 | `c.Should().OnlyContain(x => …)` | `c.ShouldAllBe(x => …)` |
-| `c.Should().AllBeAssignableTo<T>()` | `c.ShouldAllBe(x => x is T)` ⚠️ (no `ShouldAllBeAssignableTo`) |
-| `c.Should().AllSatisfy(x => x.Should()…)` | `foreach (var x in c) { … }` ⚠️ (assertion per element; [see below](#per-element-assertions-allsatisfy)) |
+| `c.Should().AllBeAssignableTo<T>()` | `c.ShouldAllBe(x => x is T)` (no `ShouldAllBeAssignableTo`) |
+| `c.Should().AllSatisfy(x => x.Should()…)` | `foreach (var x in c) { … }` (assertion per element; [see below](#per-element-assertions-allsatisfy)) |
 | `c.Should().ContainSingle()` | `c.ShouldHaveSingleItem()` |
 | `c.Should().ContainSingle().Which.Should().Be(v)` | `c.ShouldHaveSingleItem().ShouldBe(v)` |
 | `c.Should().BeSubsetOf(other)` | `c.ShouldBeSubsetOf(other)` |
@@ -108,18 +110,18 @@ Direct name mappings. Rows marked with a warning sign are not a plain rename, so
 | `d.Should().ContainKey(k)` | `d.ShouldContainKey(k)` |
 | `d.Should().NotContainKey(k)` | `d.ShouldNotContainKey(k)` |
 | `d.Should().Contain(k, v)` | `d.ShouldContainKeyAndValue(k, v)` |
-| `d.Should().ContainValue(v)` | `d.Values.ShouldContain(v)` ⚠️ (no `ShouldContainValue`) |
-| `d.Should().NotContainValue(v)` | `d.Values.ShouldNotContain(v)` ⚠️ (no `ShouldNotContainValue`) |
+| `d.Should().ContainValue(v)` | `d.Values.ShouldContain(v)` (no `ShouldContainValue`) |
+| `d.Should().NotContainValue(v)` | `d.Values.ShouldNotContain(v)` (no `ShouldNotContainValue`) |
 
 ### Strings
 
 | FluentAssertions | Shouldly |
 |---|---|
 | `s.Should().Be("x")` | `s.ShouldBe("x")` (exact, case-sensitive) |
-| `s.Should().Contain("x")` | `s.ShouldContain("x")` ⚠️ ([case-insensitive by default](#strings-are-case-insensitive-by-default)) |
+| `s.Should().Contain("x")` | `s.ShouldContain("x")` ([case-insensitive by default](#strings-are-case-insensitive-by-default)) |
 | `s.Should().ContainEquivalentOf("x")` | `s.ShouldContain("x")` (both ignore case, a rare case where the default matches) |
-| `s.Should().StartWith("x")` | `s.ShouldStartWith("x")` ⚠️ (case-insensitive by default) |
-| `s.Should().EndWith("x")` | `s.ShouldEndWith("x")` ⚠️ (case-insensitive by default) |
+| `s.Should().StartWith("x")` | `s.ShouldStartWith("x")` (case-insensitive by default) |
+| `s.Should().EndWith("x")` | `s.ShouldEndWith("x")` (case-insensitive by default) |
 | `s.Should().Match("re*ex")` | `s.ShouldMatch(regex)` (Shouldly takes a regex, FA `Match` takes a wildcard) |
 | `s.Should().MatchRegex("re.ex")` | `s.ShouldMatch("re.ex")` |
 | `s.Should().BeNullOrEmpty()` | `s.ShouldBeNullOrEmpty()` |
@@ -130,10 +132,11 @@ Direct name mappings. Rows marked with a warning sign are not a plain rename, so
 | FluentAssertions | Shouldly |
 |---|---|
 | `act.Should().Throw<T>()` | `act.ShouldThrow<T>()` |
-| `act.Should().ThrowExactly<T>()` | `act.ShouldThrow<T>()` then `ex.ShouldBeOfType<T>()` ⚠️ (no `ShouldThrowExactly`) |
+| `act.Should().ThrowExactly<T>()` | `act.ShouldThrow<T>()` then `ex.ShouldBeOfType<T>()` (no `ShouldThrowExactly`) |
 | `act.Should().NotThrow()` | `act.ShouldNotThrow()` |
+| `await act.Should().NotThrowAsync()` | `await act.ShouldNotThrowAsync()` |
 | `(await act.Should().ThrowAsync<T>())` | `await act.ShouldThrowAsync<T>()` |
-| `act.Should().Throw<T>().WithMessage("x*")` | `act.ShouldThrow<T>().Message.ShouldContain("x")` ⚠️ (no `WithMessage`) |
+| `act.Should().Throw<T>().WithMessage("x*")` | `act.ShouldThrow<T>().Message.ShouldContain("x")` (no `WithMessage`) |
 
 
 ## Behavioral differences to watch for
@@ -156,6 +159,13 @@ weakens these assertions. Pass `Case.Sensitive` to keep the old behavior:
 
 ```csharp
 "Hello".ShouldContain("hello", Case.Sensitive);   // fails, as FA would
+```
+
+```text
+"Hello"
+    should contain
+"hello"
+    but did not
 ```
 
 Note the asymmetry: string `ShouldBe` is exact and case-sensitive (`"Hello".ShouldBe("hello")`
@@ -226,6 +236,33 @@ result.ShouldHaveSingleItem().ShouldBe(5);
 (`ShouldContain` on a string is case-insensitive, see the warning above, so add `Case.Sensitive`
 if the original `.Contain` relied on case.)
 
+### Custom messages (`because`)
+
+Every FluentAssertions assertion accepts a reason with format arguments, which FA weaves into the
+failure sentence. The Shouldly counterpart is the `customMessage` parameter, a plain string with
+no format arguments, so use interpolation:
+
+```csharp
+// FA
+count.Should().Be(3, "the cache warms {0} entries on startup", entries);
+
+// Shouldly
+count.ShouldBe(3, $"the cache warms {entries} entries on startup");
+```
+
+The message is appended to the failure output under "Additional Info":
+
+```text
+count
+    should be
+3
+    but was
+2
+
+Additional Info:
+    the cache warms 42 entries on startup
+```
+
 ### Per-element assertions (`AllSatisfy`)
 
 FA's `AllSatisfy` runs an assertion action against every element. It is not the same as
@@ -277,7 +314,16 @@ var dto  = new Dto            { Name = "Bob", Age = 30 };
 var full = new PersonExtended { Name = "Bob", Age = 30, Extra = "x" };
 
 dto.ShouldBeEquivalentTo(full);
-// -> Expected value to be PersonExtended but was Dto
+```
+
+```text
+Comparing object equivalence, at path:
+dto
+
+    Expected value to be
+PersonExtended
+    but was
+Dto
 ```
 
 FluentAssertions is deliberately looser here. Its `BeEquivalentTo` is direction-sensitive and

--- a/documentation/documentation/migrating-from-fluentassertions.md
+++ b/documentation/documentation/migrating-from-fluentassertions.md
@@ -87,10 +87,10 @@ changed.
 | `c.Should().Contain(x => …)` | `c.ShouldContain(x => …)` |
 | `c.Should().BeEmpty()` | `c.ShouldBeEmpty()` |
 | `c.Should().NotBeEmpty()` | `c.ShouldNotBeEmpty()` |
-| `c.Should().HaveCount(n)` | `c.Count.ShouldBe(n)` (no `ShouldHaveCount`) |
-| `c.Should().HaveCountGreaterThan(n)` | `c.Count.ShouldBeGreaterThan(n)` |
+| `c.Should().HaveCount(n)` | `c.ShouldHaveCount(n)` |
+| `c.Should().HaveCountGreaterThan(n)` | `c.Count.ShouldBeGreaterThan(n)` (no `ShouldHaveCountGreaterThan`) |
 | `c.Should().Equal(a, b, c)` | `c.ShouldBe([a, b, c])` (order-sensitive) |
-| `c.Should().BeEquivalentTo(other)` | `c.ShouldBe(other, ignoreOrder: true)` (not `ShouldBeEquivalentTo`; [see below](#collections-order-and-element-equality)) |
+| `c.Should().BeEquivalentTo(other)` | `c.ShouldBeEquivalentTo(other, new EquivalencyOptions { IgnoreOrder = true })` (structural + unordered; [see below](#collections-order-and-element-equality)) |
 | `c.Should().OnlyHaveUniqueItems()` | `c.ShouldBeUnique()` (not `ShouldAllBeUnique`) |
 | `c.Should().OnlyContain(x => …)` | `c.ShouldAllBe(x => …)` |
 | `c.Should().AllBeAssignableTo<T>()` | `c.ShouldAllBe(x => x is T)` (no `ShouldAllBeAssignableTo`) |
@@ -199,13 +199,17 @@ new[] { 1, 2, 3 }.ShouldBe([3, 2, 1]);                    // fails: order differ
 new[] { 1, 2, 3 }.ShouldBe([3, 2, 1], ignoreOrder: true); // passes
 ```
 
-So the two FluentAssertions collection methods map differently:
+So the FluentAssertions collection methods map like this:
 
-- `Should().Equal(…)` (ordered) becomes `ShouldBe(…)`
-- `Should().BeEquivalentTo(…)` (unordered) becomes `ShouldBe(…, ignoreOrder: true)`
+- `Should().Equal(…)` (ordered, element equality) becomes `ShouldBe(…)`
+- `Should().BeEquivalentTo(…)` (unordered, structural) becomes
+  `ShouldBeEquivalentTo(…, new EquivalencyOptions { IgnoreOrder = true })`
 
-Do not reach for `ShouldBeEquivalentTo` here. That is a deep object-graph comparison (next
-section), not an unordered collection check.
+`ShouldBe(…, ignoreOrder: true)` also compares order-insensitively, but it matches elements by their
+`Equals`, so it only lines up with FA's collection `BeEquivalentTo` when the elements are values (or
+override equality). For collections of reference types that should be compared *structurally*, use
+`ShouldBeEquivalentTo` with `IgnoreOrder` (see the
+[object equivalence](#object-equivalence-shouldbeequivalentto) section).
 
 Because `ShouldBe` uses each element's `Equals`, a collection of reference types that don't override
 equality is compared by reference:
@@ -305,53 +309,84 @@ Two collection assertions have no Shouldly counterpart:
 
 ## Object equivalence: `ShouldBeEquivalentTo`
 
-`ShouldBeEquivalentTo` walks the object graph and compares public fields and properties
-recursively, but it is strict about type. Both sides must be the same runtime type; two
-structurally identical objects of different types fail immediately:
+`ShouldBeEquivalentTo` walks the object graph and compares public fields and properties recursively.
+Like FA's `BeEquivalentTo`, it is **direction-sensitive**: comparison is driven by the *expected*
+value's members, and any extra members the actual value carries are ignored. It does **not** require
+the two sides to be the same type, so two structurally identical objects of different types are
+equivalent:
+
+```csharp
+var actual   = new Dto      { Name = "Bob", Age = 30 };
+var expected = new Customer { Name = "Bob", Age = 30 };
+
+actual.ShouldBeEquivalentTo(expected);   // passes: same members, same values
+```
+
+Because the expectation drives member selection, you assert a **subset** by passing an anonymous
+type (or any type) that carries only the members you care about. This is the direct replacement for
+FA's "project to a shape and compare" pattern:
+
+```csharp
+var person = new Person { Name = "Bob", Age = 30, Internal = "secret" };
+
+person.ShouldBeEquivalentTo(new { Name = "Bob", Age = 30 });   // passes: Internal is not checked
+```
+
+A member present on the expected value but missing on the actual value is a failure, and every
+difference is collected rather than stopping at the first:
 
 ```csharp
 var dto  = new Dto            { Name = "Bob", Age = 30 };
 var full = new PersonExtended { Name = "Bob", Age = 30, Extra = "x" };
 
-dto.ShouldBeEquivalentTo(full);
+full.ShouldBeEquivalentTo(dto);   // passes: dto's members all match; full's Extra is ignored
+dto.ShouldBeEquivalentTo(full);   // fails: full expects an Extra member dto doesn't have
 ```
 
 ```text
 Comparing object equivalence, at path:
-dto
+dto [PersonExtended]
+    Extra
 
-    Expected value to be
-PersonExtended
-    but was
+    Expected a public member named
+"Extra"
+    but was not found on
 Dto
 ```
 
-FluentAssertions is deliberately looser here. Its `BeEquivalentTo` is direction-sensitive and
-tolerant of extra members: it checks that every member of the expectation exists and matches on the
-subject, ignoring any extra members the subject carries. That is what makes FA's
-"map `List<A>` to `IEnumerable<B>` and compare shapes" tests work, and it is exactly what Shouldly
-does not replicate today.
+### Options
 
-Shouldly's version also has no fluent options. There is no `.Excluding(...)`, `.WithAutoConversion()`,
-custom member selection, or comparison rules. It is all-or-nothing structural equality of the same
-type.
+A second overload takes an `EquivalencyOptions`:
 
-If your FA equivalence test relied on any of that, there is no drop-in replacement yet. Practical
-options:
+```csharp
+actual.ShouldBeEquivalentTo(expected, new EquivalencyOptions
+{
+    IgnoreOrder = true,                          // compare collections order-insensitively
+    MembersToIgnore = { "CreatedAt", "Id" },     // skip these members anywhere in the graph
+});
+```
 
-- Project both sides to a common shape, an anonymous type, tuple, or record with just the members
-  you care about, then compare:
-  ```csharp
-  (dto.Name, dto.Age).ShouldBe((full.Name, full.Age));
-  ```
-- Assert the members individually with [`ShouldSatisfy`](satisfyAllConditions.md) so you still get
-  all failures at once.
-- Keep a dedicated equivalence library for the handful of tests that genuinely need FA-style
-  flexibility.
+- `MembersToIgnore` is the counterpart to FA's `.Excluding(...)`, matched by member name anywhere in
+  the graph.
+- `IgnoreOrder` makes sequences compare order-insensitively; sets and dictionaries are always
+  compared unordered/by key.
 
-Richer equivalency options are being added for v5
-([#1094](https://github.com/shouldly/shouldly/pull/1094),
-[#1101](https://github.com/shouldly/shouldly/pull/1101)).
+### What still differs from FA
+
+- **Sequences are ordered by default.** Opt into `IgnoreOrder` for FA's unordered collection
+  behavior.
+- **`Equals` overrides on complex types are ignored** — comparison is always member-wise, so a type
+  with a custom `Equals` is still compared property-by-property. (Well-known value-semantic types
+  such as `string`, `Guid`, `DateTime`, and `Uri` are treated as leaves and compared with `Equals`.)
+- **Comparers and tolerances** — a fluent `.WithAutoConversion()` switch, `.Using<T>(...)` custom
+  comparers, or approximate numeric/`DateTime` matching — are not exposed as options yet. Numeric
+  *leaves* are auto-converted across kinds, so `int` `5` is equivalent to `long` `5` or `double`
+  `5.0`.
+
+For the rare test that needs an FA feature with no counterpart today (custom comparison rules,
+member selection by predicate), assert the members individually with
+[`ShouldSatisfy`](satisfyAllConditions.md) so you still get every failure at once, or keep a
+dedicated equivalence library for those cases.
 
 
 ## Exceptions and messages
@@ -418,7 +453,8 @@ expression and isn't trimming/AOT-safe. Prefer `ShouldSatisfy` or `Should.Satisf
 
 | FluentAssertions | Shouldly today |
 |---|---|
-| `BeEquivalentTo(…)` with options (`.Excluding`, `.WithAutoConversion`, member selection) | Project to a common shape, or assert members with `ShouldSatisfy` |
+| `BeEquivalentTo(…).Excluding(…)` | `ShouldBeEquivalentTo(…, new EquivalencyOptions { MembersToIgnore = { … } })` |
+| `BeEquivalentTo(…)` with custom comparers / `.WithAutoConversion` | No fluent equivalent yet; assert members with `ShouldSatisfy`, or use an anonymous-type subset ([see above](#object-equivalence-shouldbeequivalentto)) |
 | `ThrowExactly<T>()` | `ShouldThrow<T>()` + `ex.ShouldBeOfType<T>()` |
 | `.WithMessage("x*")` | `ex.Message.ShouldContain("x")` or `ShouldMatch(regex)` |
 | `AssertionScope` | `ShouldSatisfy` or `Should.Satisfy` |

--- a/documentation/documentation/migrating-from-fluentassertions.md
+++ b/documentation/documentation/migrating-from-fluentassertions.md
@@ -381,13 +381,3 @@ expression and isn't trimming/AOT-safe. Prefer `ShouldSatisfy` or `Should.Satisf
 | `AllSatisfy(x => x.Should()…)` | `foreach` loop of assertions ([see above](#per-element-assertions-allsatisfy); `ShouldAllBe` is only for boolean predicates) |
 | `ContainInOrder(…)` / `ContainEquivalentOf(…)` | [see above](#no-drop-in-for-containinorder-or-containequivalentof) |
 | `Implement<TInterface>()` | `typeof(IFoo).IsAssignableFrom(typeof(MyType)).ShouldBeTrue()` |
-
-
-## Further reading
-
-- [Getting Started](getting-started.md)
-- [Equality assertions](equality/README.md)
-- [Enumerable assertions](enumerable/README.md)
-- [String assertions](string/README.md)
-- [Exception assertions](exceptions/README.md)
-- [ShouldSatisfy](satisfyAllConditions.md)

--- a/documentation/documentation/migrating-from-fluentassertions.md
+++ b/documentation/documentation/migrating-from-fluentassertions.md
@@ -94,7 +94,7 @@ changed.
 | `c.Should().OnlyHaveUniqueItems()` | `c.ShouldBeUnique()` (not `ShouldAllBeUnique`) |
 | `c.Should().OnlyContain(x => …)` | `c.ShouldAllBe(x => …)` |
 | `c.Should().AllBeAssignableTo<T>()` | `c.ShouldAllBe(x => x is T)` (no `ShouldAllBeAssignableTo`) |
-| `c.Should().AllSatisfy(x => x.Should()…)` | `foreach (var x in c) { … }` (assertion per element; [see below](#per-element-assertions-allsatisfy)) |
+| `c.Should().AllSatisfy(x => x.Should()…)` | `Should.Satisfy([.. c.Select(x => new Action(() => …))])` (assertion per element, all failures aggregated; [see below](#per-element-assertions-allsatisfy)) |
 | `c.Should().ContainSingle()` | `c.ShouldHaveSingleItem()` |
 | `c.Should().ContainSingle().Which.Should().Be(v)` | `c.ShouldHaveSingleItem().ShouldBe(v)` |
 | `c.Should().BeSubsetOf(other)` | `c.ShouldBeSubsetOf(other)` |
@@ -118,10 +118,10 @@ changed.
 | FluentAssertions | Shouldly |
 |---|---|
 | `s.Should().Be("x")` | `s.ShouldBe("x")` (exact, case-sensitive) |
-| `s.Should().Contain("x")` | `s.ShouldContain("x")` ([case-insensitive by default](#strings-are-case-insensitive-by-default)) |
-| `s.Should().ContainEquivalentOf("x")` | `s.ShouldContain("x")` (both ignore case, a rare case where the default matches) |
-| `s.Should().StartWith("x")` | `s.ShouldStartWith("x")` (case-insensitive by default) |
-| `s.Should().EndWith("x")` | `s.ShouldEndWith("x")` (case-insensitive by default) |
+| `s.Should().Contain("x")` | `s.ShouldContain("x")` ([case-sensitive by default](#strings-are-case-sensitive-by-default), matches FA) |
+| `s.Should().ContainEquivalentOf("x")` | `s.ShouldContain("x", Case.Insensitive)` (FA ignores case, so pass `Case.Insensitive`) |
+| `s.Should().StartWith("x")` | `s.ShouldStartWith("x")` (case-sensitive by default, matches FA) |
+| `s.Should().EndWith("x")` | `s.ShouldEndWith("x")` (case-sensitive by default, matches FA) |
 | `s.Should().Match("re*ex")` | `s.ShouldMatch(regex)` (Shouldly takes a regex, FA `Match` takes a wildcard) |
 | `s.Should().MatchRegex("re.ex")` | `s.ShouldMatch("re.ex")` |
 | `s.Should().BeNullOrEmpty()` | `s.ShouldBeNullOrEmpty()` |
@@ -143,22 +143,15 @@ changed.
 
 These are the traps. Read them before you trust a bulk find-and-replace.
 
-### Strings are case-insensitive by default
+### Strings are case-sensitive by default
 
-This is the single most surprising difference, because it can make a test pass when it should fail.
 Shouldly's string `ShouldContain`, `ShouldStartWith`, `ShouldEndWith` (and their `Not…` forms)
-ignore case by default:
+are case-sensitive by default, matching FluentAssertions' `Contain`, `StartWith`, and `EndWith`,
+so a straight rename preserves the behavior:
 
 ```csharp
-"Hello".ShouldContain("hello");     // PASSES, case is ignored
-"Hello".ShouldStartWith("HELLO");   // PASSES, case is ignored
-```
-
-FluentAssertions' `Contain` and `StartWith` are case-sensitive, so a straight rename quietly
-weakens these assertions. Pass `Case.Sensitive` to keep the old behavior:
-
-```csharp
-"Hello".ShouldContain("hello", Case.Sensitive);   // fails, as FA would
+"Hello".ShouldContain("hello");     // fails, case matters
+"Hello".ShouldStartWith("HELLO");   // fails, case matters
 ```
 
 ```text
@@ -168,8 +161,13 @@ weakens these assertions. Pass `Case.Sensitive` to keep the old behavior:
     but did not
 ```
 
-Note the asymmetry: string `ShouldBe` is exact and case-sensitive (`"Hello".ShouldBe("hello")`
-fails), so only the substring, prefix, and suffix assertions are affected.
+When you do want a case-insensitive comparison — for example FA's `ContainEquivalentOf`, which
+ignores case — pass `Case.Insensitive`:
+
+```csharp
+"Hello".Should().ContainEquivalentOf("hello");    // FA, ignores case
+"Hello".ShouldContain("hello", Case.Insensitive); // Shouldly equivalent
+```
 
 ### `ShouldBe` is strongly typed
 
@@ -237,8 +235,8 @@ markup.ShouldContain("mud-elevation-1");
 result.ShouldHaveSingleItem().ShouldBe(5);
 ```
 
-(`ShouldContain` on a string is case-insensitive, see the warning above, so add `Case.Sensitive`
-if the original `.Contain` relied on case.)
+(`ShouldContain` on a string is case-sensitive, matching FA's `.Contain`; add `Case.Insensitive`
+if you want to ignore case.)
 
 ### Custom messages (`because`)
 
@@ -269,16 +267,25 @@ Additional Info:
 
 ### Per-element assertions (`AllSatisfy`)
 
-FA's `AllSatisfy` runs an assertion action against every element. It is not the same as
-`ShouldAllBe`, which takes a boolean predicate. Map each one to the right tool:
+FA's `AllSatisfy` runs an assertion action against every element and reports every failing
+element at once. It is not the same as `ShouldAllBe`, which takes a boolean predicate. Map each
+one to the right tool:
 
 ```csharp
 // FA, a boolean predicate: use ShouldAllBe
 items.Should().OnlyContain(x => x.IsActive);
 items.ShouldAllBe(x => x.IsActive);
 
-// FA, an assertion action per element: use a foreach (Shouldly has no AllSatisfy)
+// FA, an assertion action per element: project each element into a condition and pass them to
+// Should.Satisfy, which runs them all and aggregates every failure just like AllSatisfy.
 inputs.Should().AllSatisfy(i => i.GetAttribute("type").Should().Be("checkbox"));
+Should.Satisfy([.. inputs.Select(i => new Action(() => i.GetAttribute("type").ShouldBe("checkbox")))]);
+```
+
+If you do not need the aggregated report, a plain `foreach` of assertions also works, but it stops
+at the first failing element rather than listing them all:
+
+```csharp
 foreach (var i in inputs)
     i.GetAttribute("type").ShouldBe("checkbox");
 ```
@@ -304,7 +311,7 @@ Two collection assertions have no Shouldly counterpart:
   ```
 - `ContainEquivalentOf(item)` on a collection (structural match of an element) has no equivalent.
   Assert with `ShouldContain(x => …)` on the members you care about, or loop. On a string it just
-  means a case-insensitive substring, which is exactly what `ShouldContain` already does.
+  means a case-insensitive substring, which is `ShouldContain(x, Case.Insensitive)`.
 
 
 ## Object equivalence: `ShouldBeEquivalentTo`
@@ -460,6 +467,5 @@ expression and isn't trimming/AOT-safe. Prefer `ShouldSatisfy` or `Should.Satisf
 | `AssertionScope` | `ShouldSatisfy` or `Should.Satisfy` |
 | `.And` / `.Which` chaining | Separate statements, or use the value a `Should…` returns |
 | `SatisfyRespectively(…)` | `ShouldSatisfy` with one condition per element (indexed manually) |
-| `AllSatisfy(x => x.Should()…)` | `foreach` loop of assertions ([see above](#per-element-assertions-allsatisfy); `ShouldAllBe` is only for boolean predicates) |
 | `ContainInOrder(…)` / `ContainEquivalentOf(…)` | [see above](#no-drop-in-for-containinorder-or-containequivalentof) |
 | `Implement<TInterface>()` | `typeof(IFoo).IsAssignableFrom(typeof(MyType)).ShouldBeTrue()` |

--- a/documentation/documentation/migrating-from-fluentassertions.md
+++ b/documentation/documentation/migrating-from-fluentassertions.md
@@ -1,0 +1,418 @@
+# Migrating from FluentAssertions
+
+This guide is for teams moving from [FluentAssertions](https://fluentassertions.com/) to Shouldly,
+and targets **Shouldly 5.x**.
+
+Most of a migration is mechanical: `value.Should().Be(x)` becomes `value.ShouldBe(x)`. The value
+is in the handful of places where the two libraries behave *differently* — the cases that make a
+green FA test fail, or silently pass, after a rename. This guide focuses on those.
+
+
+## The mental model
+
+| | FluentAssertions | Shouldly |
+|---|---|---|
+| Import | `using FluentAssertions;` | `using Shouldly;` |
+| Entry point | `value.Should().Be(x)` | `value.ShouldBe(x)` |
+| Failure type | the host test framework's assert exception (or `AssertionFailedException`) | always `ShouldAssertException` |
+| Chaining | `.And` / `.Which` fluent chain | separate statements (some assertions return a value) |
+
+There is **no `.Should()` gateway** — every assertion is an extension method directly on the
+value, named `Should…`. Most return `void`. A few return something useful for a follow-up
+assertion:
+
+```csharp
+InvalidOperationException ex = action.ShouldThrow<InvalidOperationException>();
+Cat cat = animal.ShouldBeOfType<Cat>();          // also ShouldBeAssignableTo<T>
+string name = maybeNull.ShouldNotBeNull();       // returns the non-null value
+Order only = orders.ShouldHaveSingleItem();      // returns the single element
+```
+
+Shouldly puts the **code you asserted on** into the failure message. In v5 that expression is
+captured by the compiler (`CallerArgumentExpression`), so you get the source text in the message
+without any runtime source lookup:
+
+```csharp
+var result = Add(2, 2);
+result.ShouldBe(5);
+// -> result should be 5 but was 4
+```
+
+
+## Quick reference
+
+Direct name mappings. Rows marked ⚠️ are **not** a plain rename — check the note.
+
+### Equality and identity
+
+| FluentAssertions | Shouldly |
+|---|---|
+| `x.Should().Be(y)` | `x.ShouldBe(y)` |
+| `x.Should().NotBe(y)` | `x.ShouldNotBe(y)` |
+| `x.Should().BeNull()` | `x.ShouldBeNull()` |
+| `x.Should().NotBeNull()` | `x.ShouldNotBeNull()` |
+| `x.Should().BeTrue()` | `x.ShouldBeTrue()` |
+| `x.Should().BeFalse()` | `x.ShouldBeFalse()` |
+| `x.Should().BeSameAs(y)` | `x.ShouldBeSameAs(y)` |
+| `x.Should().NotBeSameAs(y)` | `x.ShouldNotBeSameAs(y)` |
+| `x.Should().BeOfType<T>()` | `x.ShouldBeOfType<T>()` |
+| `x.Should().NotBeOfType<T>()` | `x.ShouldNotBeOfType<T>()` |
+| `x.Should().BeAssignableTo<T>()` | `x.ShouldBeAssignableTo<T>()` |
+| `x.Should().BeEquivalentTo(y)` | `x.ShouldBeEquivalentTo(y)` — **see [caveats](#object-equivalence-shouldbeequivalentto)** |
+
+### Comparisons and ranges
+
+| FluentAssertions | Shouldly |
+|---|---|
+| `x.Should().BeGreaterThan(y)` | `x.ShouldBeGreaterThan(y)` |
+| `x.Should().BeGreaterThanOrEqualTo(y)` | `x.ShouldBeGreaterThanOrEqualTo(y)` |
+| `x.Should().BeLessThan(y)` | `x.ShouldBeLessThan(y)` |
+| `x.Should().BeLessThanOrEqualTo(y)` | `x.ShouldBeLessThanOrEqualTo(y)` |
+| `x.Should().BePositive()` | `x.ShouldBePositive()` |
+| `x.Should().BeNegative()` | `x.ShouldBeNegative()` |
+| `x.Should().BeInRange(lo, hi)` | `x.ShouldBeInRange(lo, hi)` |
+| `x.Should().NotBeInRange(lo, hi)` | `x.ShouldNotBeInRange(lo, hi)` |
+| `date.Should().BeCloseTo(y, precision)` | `date.ShouldBe(y, tolerance)` |
+| `date.Should().BeAfter(y)` | `date.ShouldBeGreaterThan(y)` |
+| `date.Should().BeBefore(y)` | `date.ShouldBeLessThan(y)` |
+| `num.Should().BeApproximately(y, tol)` | `num.ShouldBe(y, tol)` |
+
+### Collections
+
+| FluentAssertions | Shouldly |
+|---|---|
+| `c.Should().Contain(item)` | `c.ShouldContain(item)` |
+| `c.Should().NotContain(item)` | `c.ShouldNotContain(item)` |
+| `c.Should().Contain(x => …)` | `c.ShouldContain(x => …)` |
+| `c.Should().BeEmpty()` | `c.ShouldBeEmpty()` |
+| `c.Should().NotBeEmpty()` | `c.ShouldNotBeEmpty()` |
+| `c.Should().HaveCount(n)` | `c.Count.ShouldBe(n)` ⚠️ *(no `ShouldHaveCount`)* |
+| `c.Should().HaveCountGreaterThan(n)` | `c.Count.ShouldBeGreaterThan(n)` |
+| `c.Should().Equal(a, b, c)` | `c.ShouldBe([a, b, c])` *(order-sensitive)* |
+| `c.Should().BeEquivalentTo(other)` | `c.ShouldBe(other, ignoreOrder: true)` ⚠️ *(not `ShouldBeEquivalentTo` — [see below](#collections-order-and-element-equality))* |
+| `c.Should().OnlyHaveUniqueItems()` | `c.ShouldBeUnique()` ⚠️ *(not `ShouldAllBeUnique`)* |
+| `c.Should().OnlyContain(x => …)` | `c.ShouldAllBe(x => …)` |
+| `c.Should().AllBeAssignableTo<T>()` | `c.ShouldAllBe(x => x is T)` ⚠️ *(no `ShouldAllBeAssignableTo`)* |
+| `c.Should().AllSatisfy(x => x.Should()…)` | `foreach (var x in c) { … }` ⚠️ *(assertion per element — [see below](#per-element-assertions-allsatisfy))* |
+| `c.Should().ContainSingle()` | `c.ShouldHaveSingleItem()` |
+| `c.Should().ContainSingle().Which.Should().Be(v)` | `c.ShouldHaveSingleItem().ShouldBe(v)` |
+| `c.Should().BeSubsetOf(other)` | `c.ShouldBeSubsetOf(other)` |
+| `c.Should().BeInAscendingOrder()` | `c.ShouldBeInOrder()` |
+| `c.Should().BeInDescendingOrder()` | `c.ShouldBeInOrder(SortDirection.Descending)` |
+| `c.Should().ContainInOrder(a, b)` | *no equivalent — [see below](#no-drop-in-for-containinorder-or-containequivalentof)* |
+| `c.Should().ContainEquivalentOf(item)` | *no equivalent for collections — [see below](#no-drop-in-for-containinorder-or-containequivalentof)* |
+
+### Dictionaries
+
+| FluentAssertions | Shouldly |
+|---|---|
+| `d.Should().ContainKey(k)` | `d.ShouldContainKey(k)` |
+| `d.Should().NotContainKey(k)` | `d.ShouldNotContainKey(k)` |
+| `d.Should().Contain(k, v)` | `d.ShouldContainKeyAndValue(k, v)` |
+| `d.Should().ContainValue(v)` | `d.Values.ShouldContain(v)` ⚠️ *(no `ShouldContainValue`)* |
+| `d.Should().NotContainValue(v)` | `d.Values.ShouldNotContain(v)` ⚠️ *(no `ShouldNotContainValue`)* |
+
+### Strings
+
+| FluentAssertions | Shouldly |
+|---|---|
+| `s.Should().Be("x")` | `s.ShouldBe("x")` *(exact, case-sensitive)* |
+| `s.Should().Contain("x")` | `s.ShouldContain("x")` ⚠️ *([case-**insensitive** by default](#strings-are-case-insensitive-by-default))* |
+| `s.Should().ContainEquivalentOf("x")` | `s.ShouldContain("x")` *(both ignore case — a rare case where the default matches)* |
+| `s.Should().StartWith("x")` | `s.ShouldStartWith("x")` ⚠️ *(case-insensitive by default)* |
+| `s.Should().EndWith("x")` | `s.ShouldEndWith("x")` ⚠️ *(case-insensitive by default)* |
+| `s.Should().Match("re*ex")` | `s.ShouldMatch(regex)` *(Shouldly takes a **regex**, FA `Match` takes a wildcard)* |
+| `s.Should().MatchRegex("re.ex")` | `s.ShouldMatch("re.ex")` |
+| `s.Should().BeNullOrEmpty()` | `s.ShouldBeNullOrEmpty()` |
+| `s.Should().BeNullOrWhiteSpace()` | `s.ShouldBeNullOrWhiteSpace()` |
+
+### Exceptions
+
+| FluentAssertions | Shouldly |
+|---|---|
+| `act.Should().Throw<T>()` | `act.ShouldThrow<T>()` |
+| `act.Should().ThrowExactly<T>()` | `act.ShouldThrow<T>()` then `ex.ShouldBeOfType<T>()` ⚠️ *(no `ShouldThrowExactly`)* |
+| `act.Should().NotThrow()` | `act.ShouldNotThrow()` |
+| `(await act.Should().ThrowAsync<T>())` | `await act.ShouldThrowAsync<T>()` |
+| `act.Should().Throw<T>().WithMessage("x*")` | `act.ShouldThrow<T>().Message.ShouldContain("x")` ⚠️ *(no `WithMessage`)* |
+
+
+## Behavioral differences to watch for
+
+These are the traps. Read them before you trust a bulk find-and-replace.
+
+### Strings are case-insensitive by default
+
+This is the single most surprising difference, because it can make a test **pass when it should
+fail**. Shouldly's string `ShouldContain`, `ShouldStartWith`, `ShouldEndWith` (and their `Not…`
+forms) ignore case by default:
+
+```csharp
+"Hello".ShouldContain("hello");     // PASSES — case is ignored
+"Hello".ShouldStartWith("HELLO");   // PASSES — case is ignored
+```
+
+FluentAssertions' `Contain` / `StartWith` are case-*sensitive*, so a straight rename quietly
+weakens these assertions. Pass `Case.Sensitive` to keep the old behavior:
+
+```csharp
+"Hello".ShouldContain("hello", Case.Sensitive);   // fails, as FA would
+```
+
+Note the asymmetry: string **`ShouldBe` is exact and case-sensitive** (`"Hello".ShouldBe("hello")`
+fails), so only the substring/prefix/suffix assertions are affected.
+
+### `ShouldBe` is strongly typed
+
+FluentAssertions compares through `object`, so it happily accepts mismatched types and converts
+them. Shouldly's `ShouldBe<T>` requires the actual and expected values to be the **same type** —
+mismatches are caught by the compiler, not at runtime:
+
+```csharp
+int i = 1;
+i.ShouldBe(1L);            // does NOT compile: int vs long
+
+decimal d = 1m;
+decimal? n = 1m;
+d.ShouldBe(n);             // does NOT compile: decimal vs decimal?
+```
+
+This is usually a *good* thing — it turns sloppy tests into compile errors — but it means some
+FA assertions that compiled will not. Fix the types (cast, or make both sides `T?`) rather than
+fighting it.
+
+### Collections: order and element equality
+
+`ShouldBe` on a collection is **order-sensitive** and compares elements with their normal
+equality:
+
+```csharp
+new[] { 1, 2, 3 }.ShouldBe([3, 2, 1]);                    // fails: order differs
+new[] { 1, 2, 3 }.ShouldBe([3, 2, 1], ignoreOrder: true); // passes
+```
+
+So the two FluentAssertions collection methods map differently:
+
+- `Should().Equal(…)` (ordered) → `ShouldBe(…)`
+- `Should().BeEquivalentTo(…)` (unordered) → `ShouldBe(…, ignoreOrder: true)`
+
+Do **not** reach for `ShouldBeEquivalentTo` here — that is a deep object-graph comparison (next
+section), not an unordered collection check.
+
+Because `ShouldBe` uses each element's `Equals`, a collection of reference types that don't
+override equality is compared **by reference**:
+
+```csharp
+var a = new List<Dog> { new Dog { Name = "Rex" } };
+var b = new List<Dog> { new Dog { Name = "Rex" } };
+a.ShouldBe(b);              // fails — different instances
+a.ShouldBeEquivalentTo(b); // passes — compares member by member
+```
+
+### Chaining: `.And` and `.Which`
+
+FluentAssertions chains with `.And` and drills in with `.Which`. Shouldly has neither — split a
+`.And` chain into separate statements, and for `.Which` use the value that some assertions return.
+
+```csharp
+// FA
+markup.Should().Contain("mud-card").And.Contain("mud-elevation-1");
+result.Should().ContainSingle().Which.Should().Be(5);
+
+// Shouldly
+markup.ShouldContain("mud-card");
+markup.ShouldContain("mud-elevation-1");
+result.ShouldHaveSingleItem().ShouldBe(5);
+```
+
+(`ShouldContain` on a string is case-insensitive — see the warning above — so add `Case.Sensitive`
+if the original `.Contain` relied on case.)
+
+### Per-element assertions (`AllSatisfy`)
+
+FA's `AllSatisfy` runs an **assertion action** against every element. It is *not* the same as
+`ShouldAllBe`, which takes a boolean **predicate**. Map each one to the right tool:
+
+```csharp
+// FA — a boolean predicate: use ShouldAllBe
+items.Should().OnlyContain(x => x.IsActive);
+items.ShouldAllBe(x => x.IsActive);
+
+// FA — an assertion action per element: use a foreach (Shouldly has no AllSatisfy)
+inputs.Should().AllSatisfy(i => i.GetAttribute("type").Should().Be("checkbox"));
+foreach (var i in inputs)
+    i.GetAttribute("type").ShouldBe("checkbox");
+```
+
+### No drop-in for `ContainInOrder` or `ContainEquivalentOf`
+
+Two collection assertions have no Shouldly counterpart:
+
+- **`ContainInOrder(a, b, c)`** — asserts the items appear in that *relative* order (gaps allowed).
+  There is no built-in; a small local helper covers it:
+  ```csharp
+  static void ShouldContainInOrder<T>(IEnumerable<T> actual, params T[] expected)
+  {
+      var list = actual.ToList();
+      var idx = -1;
+      foreach (var e in expected)
+      {
+          var next = list.FindIndex(idx + 1, x => EqualityComparer<T>.Default.Equals(x, e));
+          next.ShouldBeGreaterThan(idx, $"expected '{e}' after index {idx}, in order");
+          idx = next;
+      }
+  }
+  ```
+- **`ContainEquivalentOf(item)`** on a *collection* (structural match of an element) has no
+  equivalent — assert with `ShouldContain(x => …)` on the members you care about, or loop.
+  On a *string* it just means a case-insensitive substring, which is exactly what `ShouldContain`
+  already does.
+
+
+## Object equivalence: `ShouldBeEquivalentTo`
+
+`ShouldBeEquivalentTo` walks the object graph and compares public fields and properties
+recursively — but it is **strict about type**. Both sides must be the same runtime type; two
+structurally identical objects of different types fail immediately:
+
+```csharp
+var dto  = new Dto            { Name = "Bob", Age = 30 };
+var full = new PersonExtended { Name = "Bob", Age = 30, Extra = "x" };
+
+dto.ShouldBeEquivalentTo(full);
+// -> Expected value to be PersonExtended but was Dto
+```
+
+FluentAssertions is deliberately looser here. Its `BeEquivalentTo` is **direction-sensitive** and
+tolerant of extra members: it checks that every member of the *expectation* exists and matches on
+the *subject*, ignoring any extra members the subject carries. That is what makes FA's
+"map `List<A>` to `IEnumerable<B>` and compare shapes" tests work — and it is exactly what
+Shouldly does not replicate today.
+
+Shouldly's version also has **no fluent options** — there is no `.Excluding(...)`,
+`.WithAutoConversion()`, custom member selection, or comparison rules. It is all-or-nothing
+structural equality of the same type.
+
+**If your FA equivalence test relied on any of that, there is no drop-in replacement yet.**
+Practical options:
+
+- **Project both sides to a common shape** — an anonymous type, tuple, or record with just the
+  members you care about — then compare:
+  ```csharp
+  (dto.Name, dto.Age).ShouldBe((full.Name, full.Age));
+  ```
+- **Assert the members individually** with [`ShouldSatisfy`](satisfyAllConditions.md) so you still
+  get all failures at once.
+- **Keep a dedicated equivalence library** for the handful of tests that genuinely need FA-style
+  flexibility.
+
+Richer equivalency options are being added for v5
+([#1094](https://github.com/shouldly/shouldly/pull/1094),
+[#1101](https://github.com/shouldly/shouldly/pull/1101)).
+
+
+## Exceptions and messages
+
+`ShouldThrow<T>()` returns the caught exception, so assert on its message directly — there is no
+`WithMessage`:
+
+```csharp
+var ex = Should.Throw<InvalidOperationException>(() => Widget.Spin());
+ex.Message.ShouldContain("jammed");     // substring, like FA's WithMessage("*jammed*")
+ex.Message.ShouldBe("Widget jammed");   // exact match
+```
+
+Async is the same shape — `ShouldThrowAsync<T>` returns a `Task<T>`, so `await` it:
+
+```csharp
+var ex = await Should.ThrowAsync<InvalidOperationException>(() => widget.SpinAsync());
+ex.Message.ShouldContain("jammed");
+```
+
+Like FA's `Throw<T>`, `ShouldThrow<T>` **matches derived exception types** — asserting
+`ShouldThrow<ArgumentException>()` is satisfied by an `ArgumentNullException`. There is no
+`ThrowExactly`; if you need an exact type, check it explicitly:
+
+```csharp
+var ex = act.ShouldThrow<ArgumentException>();
+ex.ShouldBeOfType<ArgumentException>();   // fails for the derived ArgumentNullException
+```
+
+
+## Grouping assertions (FA's `AssertionScope`)
+
+FluentAssertions uses `using (new AssertionScope())` to report several failures together. Shouldly
+does not have assertion scopes; use [`ShouldSatisfy`](satisfyAllConditions.md) (or the static
+`Should.Satisfy` for unrelated conditions), which runs every condition and reports all failures at
+once:
+
+```csharp
+person.ShouldSatisfy(
+[
+    p => p.Name.ShouldBe("Alice"),
+    p => p.Age.ShouldBeGreaterThan(0),
+]);
+```
+
+```text
+person
+    should satisfy all the conditions specified, but does not.
+The following errors were found ...
+---------------- Error 1 ----------------
+    p.Name
+        should be
+    "Alice"
+        but was
+    "Bob"
+...
+```
+
+> `ShouldSatisfyAllConditions` still exists but is **obsolete** in v5 — it can't capture the
+> asserted expression and isn't trimming/AOT-safe. Prefer `ShouldSatisfy` / `Should.Satisfy`.
+
+
+## Features without a direct equivalent
+
+| FluentAssertions | Shouldly today |
+|---|---|
+| `BeEquivalentTo(…)` with options (`.Excluding`, `.WithAutoConversion`, member selection) | Project to a common shape, or assert members with `ShouldSatisfy` |
+| `ThrowExactly<T>()` | `ShouldThrow<T>()` + `ex.ShouldBeOfType<T>()` |
+| `.WithMessage("x*")` | `ex.Message.ShouldContain("x")` / `ShouldMatch(regex)` |
+| `AssertionScope` | `ShouldSatisfy` / `Should.Satisfy` |
+| `.And` / `.Which` chaining | Separate statements, or use the value a `Should…` returns |
+| `SatisfyRespectively(…)` | `ShouldSatisfy` with one condition per element (indexed manually) |
+| `AllSatisfy(x => x.Should()…)` | `foreach` loop of assertions — [see above](#per-element-assertions-allsatisfy) *(`ShouldAllBe` is only for boolean predicates)* |
+| `ContainInOrder(…)` / `ContainEquivalentOf(…)` | [see above](#no-drop-in-for-containinorder-or-containequivalentof) |
+| `Implement<TInterface>()` | `typeof(IFoo).IsAssignableFrom(typeof(MyType)).ShouldBeTrue()` |
+
+
+## Automating the rename
+
+The bulk of a migration — turning `value.Should().X(…)` into `value.ShouldX(…)` — can be
+scripted. A community tool exists for exactly this (not officially maintained by Shouldly):
+
+- [galadril/Shouldly.FromFluentAssertions](https://github.com/galadril/Shouldly.FromFluentAssertions)
+  — a best-effort PowerShell script that rewrites FluentAssertions calls, strips `AssertionScope`
+  blocks, and swaps the package reference. Its authors note the result "might not be 100%
+  buildable," so treat it as a first pass: rebuild and run your tests afterward.
+
+If your project also still has classic NUnit `Assert.*` calls,
+[agoda-com/Shouldly.FromAssert](https://github.com/agoda-com/Shouldly.FromAssert) is a Roslyn
+analyzer/code-fix that converts *those* (not FluentAssertions) to Shouldly.
+
+Whatever you use, **review the result against the gotchas above** — especially case sensitivity,
+`BeEquivalentTo`, and `ThrowExactly` — because those need a human decision, not a rename.
+
+If your goal is simply to get off the commercial FluentAssertions license *without* changing test
+code, note that [AwesomeAssertions](https://awesomeassertions.org/) is a free, drop-in fork of the
+FluentAssertions API. That is a different choice from adopting Shouldly, but worth knowing about.
+
+
+## Further reading
+
+- [Getting Started](getting-started.md)
+- [Equality assertions](equality/README.md)
+- [Enumerable assertions](enumerable/README.md)
+- [String assertions](string/README.md)
+- [Exception assertions](exceptions/README.md)
+- [ShouldSatisfy](satisfyAllConditions.md)

--- a/documentation/documentation/migrating-from-fluentassertions.md
+++ b/documentation/documentation/migrating-from-fluentassertions.md
@@ -1,11 +1,11 @@
 # Migrating from FluentAssertions
 
 This guide is for teams moving from [FluentAssertions](https://fluentassertions.com/) to Shouldly,
-and targets **Shouldly 5.x**.
+and targets Shouldly 5.x.
 
 Most of a migration is mechanical: `value.Should().Be(x)` becomes `value.ShouldBe(x)`. The value
-is in the handful of places where the two libraries behave *differently* — the cases that make a
-green FA test fail, or silently pass, after a rename. This guide focuses on those.
+is in the handful of places where the two libraries behave differently. Those are the cases that
+make a green FA test fail, or silently pass, after a rename. This guide focuses on them.
 
 
 ## The mental model
@@ -17,9 +17,8 @@ green FA test fail, or silently pass, after a rename. This guide focuses on thos
 | Failure type | the host test framework's assert exception (or `AssertionFailedException`) | always `ShouldAssertException` |
 | Chaining | `.And` / `.Which` fluent chain | separate statements (some assertions return a value) |
 
-There is **no `.Should()` gateway** — every assertion is an extension method directly on the
-value, named `Should…`. Most return `void`. A few return something useful for a follow-up
-assertion:
+There is no `.Should()` gateway. Every assertion is an extension method directly on the value,
+named `Should…`. Most return `void`. A few return something useful for a follow-up assertion:
 
 ```csharp
 InvalidOperationException ex = action.ShouldThrow<InvalidOperationException>();
@@ -28,9 +27,9 @@ string name = maybeNull.ShouldNotBeNull();       // returns the non-null value
 Order only = orders.ShouldHaveSingleItem();      // returns the single element
 ```
 
-Shouldly puts the **code you asserted on** into the failure message. In v5 that expression is
-captured by the compiler (`CallerArgumentExpression`), so you get the source text in the message
-without any runtime source lookup:
+Shouldly puts the code you asserted on into the failure message. In v5 that expression is captured
+by the compiler (`CallerArgumentExpression`), so you get the source text in the message without any
+runtime source lookup:
 
 ```csharp
 var result = Add(2, 2);
@@ -41,7 +40,7 @@ result.ShouldBe(5);
 
 ## Quick reference
 
-Direct name mappings. Rows marked ⚠️ are **not** a plain rename — check the note.
+Direct name mappings. Rows marked with a warning sign are not a plain rename, so check the note.
 
 ### Equality and identity
 
@@ -58,7 +57,7 @@ Direct name mappings. Rows marked ⚠️ are **not** a plain rename — check th
 | `x.Should().BeOfType<T>()` | `x.ShouldBeOfType<T>()` |
 | `x.Should().NotBeOfType<T>()` | `x.ShouldNotBeOfType<T>()` |
 | `x.Should().BeAssignableTo<T>()` | `x.ShouldBeAssignableTo<T>()` |
-| `x.Should().BeEquivalentTo(y)` | `x.ShouldBeEquivalentTo(y)` — **see [caveats](#object-equivalence-shouldbeequivalentto)** |
+| `x.Should().BeEquivalentTo(y)` | `x.ShouldBeEquivalentTo(y)` (see [caveats](#object-equivalence-shouldbeequivalentto)) |
 
 ### Comparisons and ranges
 
@@ -86,21 +85,21 @@ Direct name mappings. Rows marked ⚠️ are **not** a plain rename — check th
 | `c.Should().Contain(x => …)` | `c.ShouldContain(x => …)` |
 | `c.Should().BeEmpty()` | `c.ShouldBeEmpty()` |
 | `c.Should().NotBeEmpty()` | `c.ShouldNotBeEmpty()` |
-| `c.Should().HaveCount(n)` | `c.Count.ShouldBe(n)` ⚠️ *(no `ShouldHaveCount`)* |
+| `c.Should().HaveCount(n)` | `c.Count.ShouldBe(n)` ⚠️ (no `ShouldHaveCount`) |
 | `c.Should().HaveCountGreaterThan(n)` | `c.Count.ShouldBeGreaterThan(n)` |
-| `c.Should().Equal(a, b, c)` | `c.ShouldBe([a, b, c])` *(order-sensitive)* |
-| `c.Should().BeEquivalentTo(other)` | `c.ShouldBe(other, ignoreOrder: true)` ⚠️ *(not `ShouldBeEquivalentTo` — [see below](#collections-order-and-element-equality))* |
-| `c.Should().OnlyHaveUniqueItems()` | `c.ShouldBeUnique()` ⚠️ *(not `ShouldAllBeUnique`)* |
+| `c.Should().Equal(a, b, c)` | `c.ShouldBe([a, b, c])` (order-sensitive) |
+| `c.Should().BeEquivalentTo(other)` | `c.ShouldBe(other, ignoreOrder: true)` ⚠️ (not `ShouldBeEquivalentTo`; [see below](#collections-order-and-element-equality)) |
+| `c.Should().OnlyHaveUniqueItems()` | `c.ShouldBeUnique()` ⚠️ (not `ShouldAllBeUnique`) |
 | `c.Should().OnlyContain(x => …)` | `c.ShouldAllBe(x => …)` |
-| `c.Should().AllBeAssignableTo<T>()` | `c.ShouldAllBe(x => x is T)` ⚠️ *(no `ShouldAllBeAssignableTo`)* |
-| `c.Should().AllSatisfy(x => x.Should()…)` | `foreach (var x in c) { … }` ⚠️ *(assertion per element — [see below](#per-element-assertions-allsatisfy))* |
+| `c.Should().AllBeAssignableTo<T>()` | `c.ShouldAllBe(x => x is T)` ⚠️ (no `ShouldAllBeAssignableTo`) |
+| `c.Should().AllSatisfy(x => x.Should()…)` | `foreach (var x in c) { … }` ⚠️ (assertion per element; [see below](#per-element-assertions-allsatisfy)) |
 | `c.Should().ContainSingle()` | `c.ShouldHaveSingleItem()` |
 | `c.Should().ContainSingle().Which.Should().Be(v)` | `c.ShouldHaveSingleItem().ShouldBe(v)` |
 | `c.Should().BeSubsetOf(other)` | `c.ShouldBeSubsetOf(other)` |
 | `c.Should().BeInAscendingOrder()` | `c.ShouldBeInOrder()` |
 | `c.Should().BeInDescendingOrder()` | `c.ShouldBeInOrder(SortDirection.Descending)` |
-| `c.Should().ContainInOrder(a, b)` | *no equivalent — [see below](#no-drop-in-for-containinorder-or-containequivalentof)* |
-| `c.Should().ContainEquivalentOf(item)` | *no equivalent for collections — [see below](#no-drop-in-for-containinorder-or-containequivalentof)* |
+| `c.Should().ContainInOrder(a, b)` | no equivalent; [see below](#no-drop-in-for-containinorder-or-containequivalentof) |
+| `c.Should().ContainEquivalentOf(item)` | no equivalent for collections; [see below](#no-drop-in-for-containinorder-or-containequivalentof) |
 
 ### Dictionaries
 
@@ -109,19 +108,19 @@ Direct name mappings. Rows marked ⚠️ are **not** a plain rename — check th
 | `d.Should().ContainKey(k)` | `d.ShouldContainKey(k)` |
 | `d.Should().NotContainKey(k)` | `d.ShouldNotContainKey(k)` |
 | `d.Should().Contain(k, v)` | `d.ShouldContainKeyAndValue(k, v)` |
-| `d.Should().ContainValue(v)` | `d.Values.ShouldContain(v)` ⚠️ *(no `ShouldContainValue`)* |
-| `d.Should().NotContainValue(v)` | `d.Values.ShouldNotContain(v)` ⚠️ *(no `ShouldNotContainValue`)* |
+| `d.Should().ContainValue(v)` | `d.Values.ShouldContain(v)` ⚠️ (no `ShouldContainValue`) |
+| `d.Should().NotContainValue(v)` | `d.Values.ShouldNotContain(v)` ⚠️ (no `ShouldNotContainValue`) |
 
 ### Strings
 
 | FluentAssertions | Shouldly |
 |---|---|
-| `s.Should().Be("x")` | `s.ShouldBe("x")` *(exact, case-sensitive)* |
-| `s.Should().Contain("x")` | `s.ShouldContain("x")` ⚠️ *([case-**insensitive** by default](#strings-are-case-insensitive-by-default))* |
-| `s.Should().ContainEquivalentOf("x")` | `s.ShouldContain("x")` *(both ignore case — a rare case where the default matches)* |
-| `s.Should().StartWith("x")` | `s.ShouldStartWith("x")` ⚠️ *(case-insensitive by default)* |
-| `s.Should().EndWith("x")` | `s.ShouldEndWith("x")` ⚠️ *(case-insensitive by default)* |
-| `s.Should().Match("re*ex")` | `s.ShouldMatch(regex)` *(Shouldly takes a **regex**, FA `Match` takes a wildcard)* |
+| `s.Should().Be("x")` | `s.ShouldBe("x")` (exact, case-sensitive) |
+| `s.Should().Contain("x")` | `s.ShouldContain("x")` ⚠️ ([case-insensitive by default](#strings-are-case-insensitive-by-default)) |
+| `s.Should().ContainEquivalentOf("x")` | `s.ShouldContain("x")` (both ignore case, a rare case where the default matches) |
+| `s.Should().StartWith("x")` | `s.ShouldStartWith("x")` ⚠️ (case-insensitive by default) |
+| `s.Should().EndWith("x")` | `s.ShouldEndWith("x")` ⚠️ (case-insensitive by default) |
+| `s.Should().Match("re*ex")` | `s.ShouldMatch(regex)` (Shouldly takes a regex, FA `Match` takes a wildcard) |
 | `s.Should().MatchRegex("re.ex")` | `s.ShouldMatch("re.ex")` |
 | `s.Should().BeNullOrEmpty()` | `s.ShouldBeNullOrEmpty()` |
 | `s.Should().BeNullOrWhiteSpace()` | `s.ShouldBeNullOrWhiteSpace()` |
@@ -131,10 +130,10 @@ Direct name mappings. Rows marked ⚠️ are **not** a plain rename — check th
 | FluentAssertions | Shouldly |
 |---|---|
 | `act.Should().Throw<T>()` | `act.ShouldThrow<T>()` |
-| `act.Should().ThrowExactly<T>()` | `act.ShouldThrow<T>()` then `ex.ShouldBeOfType<T>()` ⚠️ *(no `ShouldThrowExactly`)* |
+| `act.Should().ThrowExactly<T>()` | `act.ShouldThrow<T>()` then `ex.ShouldBeOfType<T>()` ⚠️ (no `ShouldThrowExactly`) |
 | `act.Should().NotThrow()` | `act.ShouldNotThrow()` |
 | `(await act.Should().ThrowAsync<T>())` | `await act.ShouldThrowAsync<T>()` |
-| `act.Should().Throw<T>().WithMessage("x*")` | `act.ShouldThrow<T>().Message.ShouldContain("x")` ⚠️ *(no `WithMessage`)* |
+| `act.Should().Throw<T>().WithMessage("x*")` | `act.ShouldThrow<T>().Message.ShouldContain("x")` ⚠️ (no `WithMessage`) |
 
 
 ## Behavioral differences to watch for
@@ -143,29 +142,29 @@ These are the traps. Read them before you trust a bulk find-and-replace.
 
 ### Strings are case-insensitive by default
 
-This is the single most surprising difference, because it can make a test **pass when it should
-fail**. Shouldly's string `ShouldContain`, `ShouldStartWith`, `ShouldEndWith` (and their `Not…`
-forms) ignore case by default:
+This is the single most surprising difference, because it can make a test pass when it should fail.
+Shouldly's string `ShouldContain`, `ShouldStartWith`, `ShouldEndWith` (and their `Not…` forms)
+ignore case by default:
 
 ```csharp
-"Hello".ShouldContain("hello");     // PASSES — case is ignored
-"Hello".ShouldStartWith("HELLO");   // PASSES — case is ignored
+"Hello".ShouldContain("hello");     // PASSES, case is ignored
+"Hello".ShouldStartWith("HELLO");   // PASSES, case is ignored
 ```
 
-FluentAssertions' `Contain` / `StartWith` are case-*sensitive*, so a straight rename quietly
+FluentAssertions' `Contain` and `StartWith` are case-sensitive, so a straight rename quietly
 weakens these assertions. Pass `Case.Sensitive` to keep the old behavior:
 
 ```csharp
 "Hello".ShouldContain("hello", Case.Sensitive);   // fails, as FA would
 ```
 
-Note the asymmetry: string **`ShouldBe` is exact and case-sensitive** (`"Hello".ShouldBe("hello")`
-fails), so only the substring/prefix/suffix assertions are affected.
+Note the asymmetry: string `ShouldBe` is exact and case-sensitive (`"Hello".ShouldBe("hello")`
+fails), so only the substring, prefix, and suffix assertions are affected.
 
 ### `ShouldBe` is strongly typed
 
 FluentAssertions compares through `object`, so it happily accepts mismatched types and converts
-them. Shouldly's `ShouldBe<T>` requires the actual and expected values to be the **same type** —
+them. Shouldly's `ShouldBe<T>` requires the actual and expected values to be the same type, so
 mismatches are caught by the compiler, not at runtime:
 
 ```csharp
@@ -177,14 +176,13 @@ decimal? n = 1m;
 d.ShouldBe(n);             // does NOT compile: decimal vs decimal?
 ```
 
-This is usually a *good* thing — it turns sloppy tests into compile errors — but it means some
-FA assertions that compiled will not. Fix the types (cast, or make both sides `T?`) rather than
+This is usually a good thing, since it turns sloppy tests into compile errors, but it means some FA
+assertions that compiled will not. Fix the types (cast, or make both sides `T?`) rather than
 fighting it.
 
 ### Collections: order and element equality
 
-`ShouldBe` on a collection is **order-sensitive** and compares elements with their normal
-equality:
+`ShouldBe` on a collection is order-sensitive and compares elements with their normal equality:
 
 ```csharp
 new[] { 1, 2, 3 }.ShouldBe([3, 2, 1]);                    // fails: order differs
@@ -193,25 +191,25 @@ new[] { 1, 2, 3 }.ShouldBe([3, 2, 1], ignoreOrder: true); // passes
 
 So the two FluentAssertions collection methods map differently:
 
-- `Should().Equal(…)` (ordered) → `ShouldBe(…)`
-- `Should().BeEquivalentTo(…)` (unordered) → `ShouldBe(…, ignoreOrder: true)`
+- `Should().Equal(…)` (ordered) becomes `ShouldBe(…)`
+- `Should().BeEquivalentTo(…)` (unordered) becomes `ShouldBe(…, ignoreOrder: true)`
 
-Do **not** reach for `ShouldBeEquivalentTo` here — that is a deep object-graph comparison (next
+Do not reach for `ShouldBeEquivalentTo` here. That is a deep object-graph comparison (next
 section), not an unordered collection check.
 
-Because `ShouldBe` uses each element's `Equals`, a collection of reference types that don't
-override equality is compared **by reference**:
+Because `ShouldBe` uses each element's `Equals`, a collection of reference types that don't override
+equality is compared by reference:
 
 ```csharp
 var a = new List<Dog> { new Dog { Name = "Rex" } };
 var b = new List<Dog> { new Dog { Name = "Rex" } };
-a.ShouldBe(b);              // fails — different instances
-a.ShouldBeEquivalentTo(b); // passes — compares member by member
+a.ShouldBe(b);              // fails: different instances
+a.ShouldBeEquivalentTo(b); // passes: compares member by member
 ```
 
 ### Chaining: `.And` and `.Which`
 
-FluentAssertions chains with `.And` and drills in with `.Which`. Shouldly has neither — split a
+FluentAssertions chains with `.And` and drills in with `.Which`. Shouldly has neither. Split a
 `.And` chain into separate statements, and for `.Which` use the value that some assertions return.
 
 ```csharp
@@ -225,20 +223,20 @@ markup.ShouldContain("mud-elevation-1");
 result.ShouldHaveSingleItem().ShouldBe(5);
 ```
 
-(`ShouldContain` on a string is case-insensitive — see the warning above — so add `Case.Sensitive`
+(`ShouldContain` on a string is case-insensitive, see the warning above, so add `Case.Sensitive`
 if the original `.Contain` relied on case.)
 
 ### Per-element assertions (`AllSatisfy`)
 
-FA's `AllSatisfy` runs an **assertion action** against every element. It is *not* the same as
-`ShouldAllBe`, which takes a boolean **predicate**. Map each one to the right tool:
+FA's `AllSatisfy` runs an assertion action against every element. It is not the same as
+`ShouldAllBe`, which takes a boolean predicate. Map each one to the right tool:
 
 ```csharp
-// FA — a boolean predicate: use ShouldAllBe
+// FA, a boolean predicate: use ShouldAllBe
 items.Should().OnlyContain(x => x.IsActive);
 items.ShouldAllBe(x => x.IsActive);
 
-// FA — an assertion action per element: use a foreach (Shouldly has no AllSatisfy)
+// FA, an assertion action per element: use a foreach (Shouldly has no AllSatisfy)
 inputs.Should().AllSatisfy(i => i.GetAttribute("type").Should().Be("checkbox"));
 foreach (var i in inputs)
     i.GetAttribute("type").ShouldBe("checkbox");
@@ -248,8 +246,8 @@ foreach (var i in inputs)
 
 Two collection assertions have no Shouldly counterpart:
 
-- **`ContainInOrder(a, b, c)`** — asserts the items appear in that *relative* order (gaps allowed).
-  There is no built-in; a small local helper covers it:
+- `ContainInOrder(a, b, c)` asserts the items appear in that relative order (gaps allowed). There
+  is no built-in; a small local helper covers it:
   ```csharp
   static void ShouldContainInOrder<T>(IEnumerable<T> actual, params T[] expected)
   {
@@ -263,16 +261,15 @@ Two collection assertions have no Shouldly counterpart:
       }
   }
   ```
-- **`ContainEquivalentOf(item)`** on a *collection* (structural match of an element) has no
-  equivalent — assert with `ShouldContain(x => …)` on the members you care about, or loop.
-  On a *string* it just means a case-insensitive substring, which is exactly what `ShouldContain`
-  already does.
+- `ContainEquivalentOf(item)` on a collection (structural match of an element) has no equivalent.
+  Assert with `ShouldContain(x => …)` on the members you care about, or loop. On a string it just
+  means a case-insensitive substring, which is exactly what `ShouldContain` already does.
 
 
 ## Object equivalence: `ShouldBeEquivalentTo`
 
 `ShouldBeEquivalentTo` walks the object graph and compares public fields and properties
-recursively — but it is **strict about type**. Both sides must be the same runtime type; two
+recursively, but it is strict about type. Both sides must be the same runtime type; two
 structurally identical objects of different types fail immediately:
 
 ```csharp
@@ -283,27 +280,27 @@ dto.ShouldBeEquivalentTo(full);
 // -> Expected value to be PersonExtended but was Dto
 ```
 
-FluentAssertions is deliberately looser here. Its `BeEquivalentTo` is **direction-sensitive** and
-tolerant of extra members: it checks that every member of the *expectation* exists and matches on
-the *subject*, ignoring any extra members the subject carries. That is what makes FA's
-"map `List<A>` to `IEnumerable<B>` and compare shapes" tests work — and it is exactly what
-Shouldly does not replicate today.
+FluentAssertions is deliberately looser here. Its `BeEquivalentTo` is direction-sensitive and
+tolerant of extra members: it checks that every member of the expectation exists and matches on the
+subject, ignoring any extra members the subject carries. That is what makes FA's
+"map `List<A>` to `IEnumerable<B>` and compare shapes" tests work, and it is exactly what Shouldly
+does not replicate today.
 
-Shouldly's version also has **no fluent options** — there is no `.Excluding(...)`,
-`.WithAutoConversion()`, custom member selection, or comparison rules. It is all-or-nothing
-structural equality of the same type.
+Shouldly's version also has no fluent options. There is no `.Excluding(...)`, `.WithAutoConversion()`,
+custom member selection, or comparison rules. It is all-or-nothing structural equality of the same
+type.
 
-**If your FA equivalence test relied on any of that, there is no drop-in replacement yet.**
-Practical options:
+If your FA equivalence test relied on any of that, there is no drop-in replacement yet. Practical
+options:
 
-- **Project both sides to a common shape** — an anonymous type, tuple, or record with just the
-  members you care about — then compare:
+- Project both sides to a common shape, an anonymous type, tuple, or record with just the members
+  you care about, then compare:
   ```csharp
   (dto.Name, dto.Age).ShouldBe((full.Name, full.Age));
   ```
-- **Assert the members individually** with [`ShouldSatisfy`](satisfyAllConditions.md) so you still
-  get all failures at once.
-- **Keep a dedicated equivalence library** for the handful of tests that genuinely need FA-style
+- Assert the members individually with [`ShouldSatisfy`](satisfyAllConditions.md) so you still get
+  all failures at once.
+- Keep a dedicated equivalence library for the handful of tests that genuinely need FA-style
   flexibility.
 
 Richer equivalency options are being added for v5
@@ -313,7 +310,7 @@ Richer equivalency options are being added for v5
 
 ## Exceptions and messages
 
-`ShouldThrow<T>()` returns the caught exception, so assert on its message directly — there is no
+`ShouldThrow<T>()` returns the caught exception, so assert on its message directly. There is no
 `WithMessage`:
 
 ```csharp
@@ -322,14 +319,14 @@ ex.Message.ShouldContain("jammed");     // substring, like FA's WithMessage("*ja
 ex.Message.ShouldBe("Widget jammed");   // exact match
 ```
 
-Async is the same shape — `ShouldThrowAsync<T>` returns a `Task<T>`, so `await` it:
+Async is the same shape. `ShouldThrowAsync<T>` returns a `Task<T>`, so `await` it:
 
 ```csharp
 var ex = await Should.ThrowAsync<InvalidOperationException>(() => widget.SpinAsync());
 ex.Message.ShouldContain("jammed");
 ```
 
-Like FA's `Throw<T>`, `ShouldThrow<T>` **matches derived exception types** — asserting
+Like FA's `Throw<T>`, `ShouldThrow<T>` matches derived exception types: asserting
 `ShouldThrow<ArgumentException>()` is satisfied by an `ArgumentNullException`. There is no
 `ThrowExactly`; if you need an exact type, check it explicitly:
 
@@ -367,8 +364,8 @@ The following errors were found ...
 ...
 ```
 
-> `ShouldSatisfyAllConditions` still exists but is **obsolete** in v5 — it can't capture the
-> asserted expression and isn't trimming/AOT-safe. Prefer `ShouldSatisfy` / `Should.Satisfy`.
+`ShouldSatisfyAllConditions` still exists but is obsolete in v5: it can't capture the asserted
+expression and isn't trimming/AOT-safe. Prefer `ShouldSatisfy` or `Should.Satisfy`.
 
 
 ## Features without a direct equivalent
@@ -377,11 +374,11 @@ The following errors were found ...
 |---|---|
 | `BeEquivalentTo(…)` with options (`.Excluding`, `.WithAutoConversion`, member selection) | Project to a common shape, or assert members with `ShouldSatisfy` |
 | `ThrowExactly<T>()` | `ShouldThrow<T>()` + `ex.ShouldBeOfType<T>()` |
-| `.WithMessage("x*")` | `ex.Message.ShouldContain("x")` / `ShouldMatch(regex)` |
-| `AssertionScope` | `ShouldSatisfy` / `Should.Satisfy` |
+| `.WithMessage("x*")` | `ex.Message.ShouldContain("x")` or `ShouldMatch(regex)` |
+| `AssertionScope` | `ShouldSatisfy` or `Should.Satisfy` |
 | `.And` / `.Which` chaining | Separate statements, or use the value a `Should…` returns |
 | `SatisfyRespectively(…)` | `ShouldSatisfy` with one condition per element (indexed manually) |
-| `AllSatisfy(x => x.Should()…)` | `foreach` loop of assertions — [see above](#per-element-assertions-allsatisfy) *(`ShouldAllBe` is only for boolean predicates)* |
+| `AllSatisfy(x => x.Should()…)` | `foreach` loop of assertions ([see above](#per-element-assertions-allsatisfy); `ShouldAllBe` is only for boolean predicates) |
 | `ContainInOrder(…)` / `ContainEquivalentOf(…)` | [see above](#no-drop-in-for-containinorder-or-containequivalentof) |
 | `Implement<TInterface>()` | `typeof(IFoo).IsAssignableFrom(typeof(MyType)).ShouldBeTrue()` |
 

--- a/documentation/documentation/migrating-from-fluentassertions.md
+++ b/documentation/documentation/migrating-from-fluentassertions.md
@@ -386,28 +386,6 @@ The following errors were found ...
 | `Implement<TInterface>()` | `typeof(IFoo).IsAssignableFrom(typeof(MyType)).ShouldBeTrue()` |
 
 
-## Automating the rename
-
-The bulk of a migration — turning `value.Should().X(…)` into `value.ShouldX(…)` — can be
-scripted. A community tool exists for exactly this (not officially maintained by Shouldly):
-
-- [galadril/Shouldly.FromFluentAssertions](https://github.com/galadril/Shouldly.FromFluentAssertions)
-  — a best-effort PowerShell script that rewrites FluentAssertions calls, strips `AssertionScope`
-  blocks, and swaps the package reference. Its authors note the result "might not be 100%
-  buildable," so treat it as a first pass: rebuild and run your tests afterward.
-
-If your project also still has classic NUnit `Assert.*` calls,
-[agoda-com/Shouldly.FromAssert](https://github.com/agoda-com/Shouldly.FromAssert) is a Roslyn
-analyzer/code-fix that converts *those* (not FluentAssertions) to Shouldly.
-
-Whatever you use, **review the result against the gotchas above** — especially case sensitivity,
-`BeEquivalentTo`, and `ThrowExactly` — because those need a human decision, not a rename.
-
-If your goal is simply to get off the commercial FluentAssertions license *without* changing test
-code, note that [AwesomeAssertions](https://awesomeassertions.org/) is a free, drop-in fork of the
-FluentAssertions API. That is a different choice from adopting Shouldly, but worth knowing about.
-
-
 ## Further reading
 
 - [Getting Started](getting-started.md)


### PR DESCRIPTION
Adds a Migrating from FluentAssertions guide which targets Shouldly v5 and addresses shouldly/shouldly#1034.

Every mapping and behavioural claim was checked against the v5 public API (`ApprovePublicApi.ShouldlyApi.approved.cs`) and executed against a local Shouldly v5 build alongside FluentAssertions. Dogfooded by migrating 21 real assertion patterns mined from MudBlazor's test suite (16k+ `.Should()` call sites); each migrated assertion matches FluentAssertions' pass/fail outcome on both passing and failing inputs.