### PR TITLE
Rewrite ShouldBeEquivalentTo with a per-node strategy engine

### DIFF
--- a/Shouldly.sln
+++ b/Shouldly.sln
@@ -25,6 +25,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TUnitTests", "src\TUnitTests\TUnitTests.csproj", "{2E530398-B93E-4FE9-82D6-E82E4BD9A7AE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EquivalencyComparisonTests", "src\EquivalencyComparisonTests\EquivalencyComparisonTests.csproj", "{7F761E6D-0926-4069-8253-2E6D924C6453}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -107,12 +109,25 @@ Global
 		{2E530398-B93E-4FE9-82D6-E82E4BD9A7AE}.Release|x64.Build.0 = Release|Any CPU
 		{2E530398-B93E-4FE9-82D6-E82E4BD9A7AE}.Release|x86.ActiveCfg = Release|Any CPU
 		{2E530398-B93E-4FE9-82D6-E82E4BD9A7AE}.Release|x86.Build.0 = Release|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Debug|x64.Build.0 = Debug|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Debug|x86.Build.0 = Debug|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Release|x64.ActiveCfg = Release|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Release|x64.Build.0 = Release|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Release|x86.ActiveCfg = Release|Any CPU
+		{7F761E6D-0926-4069-8253-2E6D924C6453}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{2E530398-B93E-4FE9-82D6-E82E4BD9A7AE} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{7F761E6D-0926-4069-8253-2E6D924C6453} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CD9358BB-31E8-41B1-AE9F-FE3678785A14}

--- a/build.ps1
+++ b/build.ps1
@@ -46,7 +46,10 @@ if (Test-Path $testResultsDir) {
 }
 
 # Define test projects
-$testProjects = @("src/Shouldly.Tests/Shouldly.Tests.csproj")
+$testProjects = @(
+    "src/Shouldly.Tests/Shouldly.Tests.csproj"
+    "src/EquivalencyComparisonTests/EquivalencyComparisonTests.csproj"
+)
 
 # Add DocumentationExamples project only on Windows
 if ($IsWindows) {

--- a/documentation/SUMMARY.md
+++ b/documentation/SUMMARY.md
@@ -50,3 +50,4 @@
 * [CompleteIn](documentation/completeIn.md)
 * [DynamicShould](documentation/dynamicShould.md)
 * [Upgrade 3 to 4](documentation/upgrade/3to4.md)
+* [Upgrade 4 to 5](documentation/upgrade/4to5.md)

--- a/documentation/documentation/upgrade/4to5.md
+++ b/documentation/documentation/upgrade/4to5.md
@@ -1,0 +1,64 @@
+# 4 to 5
+
+This is a work in progress. Please send a PR with any amendments.
+
+## String assertions default to case-sensitive comparison
+
+`ShouldContain`, `ShouldNotContain`, `ShouldStartWith`, `ShouldEndWith`, `ShouldNotStartWith`, and `ShouldNotEndWith` defaulted to `Case.Insensitive` in v4, while `ShouldBe` compared case-sensitively. In v5 all string assertions are case-sensitive by default, aligning with `ShouldBe`, C# string semantics, and other assertion libraries. `Case.Insensitive` remains available as an opt-in.
+
+## `ShouldBeEquivalentTo` has been rewritten
+
+The comparison engine behind `ShouldBeEquivalentTo` was rewritten for v5 (see [the roadmap](https://github.com/shouldly/shouldly/issues/1265) for the full rationale). The public API is unchanged, plus a new optional `EquivalencyOptions` parameter.
+
+### The new model
+
+A comparison strategy is selected per node in the object graph:
+
+| Node type | Strategy |
+| --- | --- |
+| Leaf values: primitives, enums, `string` (ordinal), `Guid`, `DateTime`/`DateTimeOffset`/`TimeSpan`, `Uri`, `Type`, delegates, and `System.*` value-semantic types generally | Compared with `Equals`, with lossless cross-numeric equality (`int 1` ≡ `long 1`) |
+| Dictionaries (`IDictionary`, `IDictionary<,>`, `IReadOnlyDictionary<,>`, immutable variants) | Matched **by key**, recursing into values |
+| Sets (`ISet<>`, `IReadOnlySet<>`, immutable variants) | Order-insensitive |
+| Other collections | Order-sensitive, element-by-element, recursing; container type ignored (array ≡ `List<T>`); multidimensional arrays compared by rank and dimensions |
+| Everything else — classes *and* structs | Member-wise and recursive over public properties and fields; indexers skipped |
+
+Member selection uses **the expectation's members, with declared types and subset semantics**: every member on the expectation must exist and match on the actual object; extra members on the actual object are ignored; runtime type identity is no longer required. This enables the most-requested scenario:
+
+```csharp
+person.ShouldBeEquivalentTo(new { Name = "John" });
+```
+
+Failures now collect **every difference** and report them all with their paths, instead of stopping at the first.
+
+### What newly passes
+
+Most changes turn v4 failures (or crashes) into passes: cross-type and anonymous-type expectations, dictionaries compared insertion-order-insensitively with complex values compared structurally, sets compared order-insensitively, array vs `List<T>` with equal elements, structs and tuples holding reference-type members, types with indexers (previously `NotSupportedException`), `Type`- and `Uri`-valued members, and numeric members of different types holding the same value.
+
+### What newly fails
+
+- **`Equals` overrides on complex types are ignored** — members are compared. Values that were `Equals`-equal but structurally different passed in v4 and now fail. (Equivalency is for comparing structure; `ShouldBe` honors `Equals`.)
+- **Structs are compared by public members**, not `ValueType.Equals`, so structs whose equality depended on private state compare only their public surface — and a struct with *no* public members now trips the vacuous-comparison guard below.
+- **Multidimensional arrays check shape**: a 2×3 array no longer equals a 3×2 array with the same flat content.
+- **Vacuous comparisons fail.** If a node selects zero comparable members (e.g. `new object()`, an empty marker interface as the declared type, or ignoring every member via options), the assertion fails with guidance instead of silently passing.
+
+### Audit note: derived members in base-typed slots
+
+v4 walked **runtime** types, so asserting on derived instances held in base-typed members also compared derived-only members. v5 selects members from the **declared** type, so those members are no longer compared — if your tests rely on this, cast the expectation to the concrete type. The vacuous-comparison guard catches the zero-member extreme, but a partial narrowing will not fail loudly.
+
+### Deliberate differences from FluentAssertions
+
+Lists and arrays remain **order-sensitive** by default (opt out with `EquivalencyOptions.IgnoreOrder`), different enum types with equal underlying values are **not** equivalent, cyclic graphs are compared gracefully without configuration, and recursion depth is unbounded. The executable comparison suite at `src/EquivalencyComparisonTests` documents every remaining divergence.
+
+### `EquivalencyOptions`
+
+```csharp
+actual.ShouldBeEquivalentTo(expected, new EquivalencyOptions
+{
+    IgnoreOrder = true,                    // order-insensitive collection comparison
+    MembersToIgnore = { "Id", "Created" }, // skip these members wherever they appear
+});
+```
+
+### Trimming and AOT
+
+`ShouldBeEquivalentTo` no longer carries `[RequiresUnreferencedCode]`. The reflection-based comparison sits behind the `Shouldly.Equivalency.IsReflectionEnabledByDefault` feature switch (the same pattern as `System.Text.Json`); a companion source-generation package that registers AOT-safe type shapes is planned, at which point trimmed publishes can disable the switch and drop the reflection path entirely.

--- a/src/EquivalencyComparisonTests/BasicSpecs.cs
+++ b/src/EquivalencyComparisonTests/BasicSpecs.cs
@@ -1,0 +1,171 @@
+using Xunit;
+
+namespace EquivalencyComparisonTests;
+
+/// <summary>
+/// Core object-graph comparison semantics, mirroring FluentAssertions.Equivalency.Specs/BasicSpecs
+/// and MemberMatchingSpecs.
+/// </summary>
+public class BasicSpecs
+{
+    [Fact]
+    public void Same_type_with_identical_member_values_is_equivalent()
+    {
+        var actual = new Person { Name = "John", Age = 30 };
+        var expected = new Person { Name = "John", Age = 30 };
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Same_type_with_a_differing_member_value_is_not_equivalent()
+    {
+        var actual = new Person { Name = "John", Age = 30 };
+        var expected = new Person { Name = "Jane", Age = 30 };
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Different_types_with_identical_shape_and_values()
+    {
+        var actual = new Person { Name = "John", Age = 30 };
+        var expected = new Customer { Name = "John", Age = 30 };
+
+        Compare.Run<object>(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "Shouldly requires identical runtime types; FluentAssertions compares structurally by the expectation's members");
+    }
+
+    [Fact]
+    public void Anonymous_type_expectation_with_all_members_matching()
+    {
+        var actual = new Person { Name = "John", Age = 30 };
+        var expected = new { Name = "John", Age = 30 };
+
+        Compare.Run<object>(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "FluentAssertions supports anonymous-type expectations (structural typing); Shouldly requires identical runtime types");
+    }
+
+    [Fact]
+    public void Anonymous_type_expectation_selecting_a_subset_of_members()
+    {
+        var actual = new Person { Name = "John", Age = 30 };
+        var expected = new { Name = "John" };
+
+        Compare.Run<object>(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "FluentAssertions only compares members present on the expectation, enabling partial matching; Shouldly has no equivalent capability");
+    }
+
+    [Fact]
+    public void Null_is_equivalent_to_null()
+    {
+        Compare.Run<Person?>(null, null).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Null_actual_is_not_equivalent_to_an_instance()
+    {
+        Compare.Run<Person?>(null, new Person()).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Instance_is_not_equivalent_to_null_expectation()
+    {
+        Compare.Run<Person?>(new Person(), null).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Same_reference_is_equivalent_to_itself()
+    {
+        var person = new Person { Name = "John", Age = 30 };
+
+        Compare.Run(person, person).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Nested_objects_with_identical_values_are_equivalent()
+    {
+        var actual = new PersonWithAddress { Name = "John", Address = new() { Street = "1 Main St", City = "Springfield" } };
+        var expected = new PersonWithAddress { Name = "John", Address = new() { Street = "1 Main St", City = "Springfield" } };
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Nested_objects_with_a_differing_leaf_value_are_not_equivalent()
+    {
+        var actual = new PersonWithAddress { Name = "John", Address = new() { Street = "1 Main St", City = "Springfield" } };
+        var expected = new PersonWithAddress { Name = "John", Address = new() { Street = "2 Main St", City = "Springfield" } };
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Differing_private_fields_are_ignored_by_both()
+    {
+        var actual = new FieldHolder("same", "one");
+        var expected = new FieldHolder("same", "two");
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Differing_private_properties_are_ignored_by_both()
+    {
+        var actual = new PrivatePropertyHolder("same", "one");
+        var expected = new PrivatePropertyHolder("same", "two");
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Differing_public_fields_are_compared_by_both()
+    {
+        var actual = new FieldHolder("one", "same");
+        var expected = new FieldHolder("two", "same");
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Types_with_indexers()
+    {
+        var actual = new IndexerHolder { Name = "same" };
+        var expected = new IndexerHolder { Name = "same" };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Error,
+            fluentAssertions: Outcome.Pass,
+            because: "Shouldly throws NotSupportedException for any type with an indexer; FluentAssertions skips indexers");
+    }
+
+    [Fact]
+    public void Custom_Equals_reporting_equal_when_members_differ()
+    {
+        var actual = new EqualsById { Id = 1, Name = "John" };
+        var expected = new EqualsById { Id = 1, Name = "Jane" };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "FluentAssertions uses a type's Equals override by default (value semantics); Shouldly always walks members of reference types");
+    }
+
+    [Fact]
+    public void Custom_Equals_reporting_not_equal_when_members_are_identical()
+    {
+        var actual = new EqualsNever { Name = "John" };
+        var expected = new EqualsNever { Name = "John" };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Pass,
+            fluentAssertions: Outcome.Fail,
+            because: "FluentAssertions honors the Equals override even when it reports inequality; Shouldly ignores Equals on reference types and compares members");
+    }
+}

--- a/src/EquivalencyComparisonTests/BasicSpecs.cs
+++ b/src/EquivalencyComparisonTests/BasicSpecs.cs
@@ -32,10 +32,8 @@ public class BasicSpecs
         var actual = new Person { Name = "John", Age = 30 };
         var expected = new Customer { Name = "John", Age = 30 };
 
-        Compare.Run<object>(actual, expected).ShouldDiverge(
-            shouldly: Outcome.Fail,
-            fluentAssertions: Outcome.Pass,
-            because: "Shouldly requires identical runtime types; FluentAssertions compares structurally by the expectation's members");
+        // Both compare structurally by the expectation's members; runtime type identity is not required.
+        Compare.Run<object>(actual, expected).ShouldAgree(Outcome.Pass);
     }
 
     [Fact]
@@ -44,10 +42,7 @@ public class BasicSpecs
         var actual = new Person { Name = "John", Age = 30 };
         var expected = new { Name = "John", Age = 30 };
 
-        Compare.Run<object>(actual, expected).ShouldDiverge(
-            shouldly: Outcome.Fail,
-            fluentAssertions: Outcome.Pass,
-            because: "FluentAssertions supports anonymous-type expectations (structural typing); Shouldly requires identical runtime types");
+        Compare.Run<object>(actual, expected).ShouldAgree(Outcome.Pass);
     }
 
     [Fact]
@@ -56,10 +51,8 @@ public class BasicSpecs
         var actual = new Person { Name = "John", Age = 30 };
         var expected = new { Name = "John" };
 
-        Compare.Run<object>(actual, expected).ShouldDiverge(
-            shouldly: Outcome.Fail,
-            fluentAssertions: Outcome.Pass,
-            because: "FluentAssertions only compares members present on the expectation, enabling partial matching; Shouldly has no equivalent capability");
+        // Subset semantics: only members present on the expectation are compared.
+        Compare.Run<object>(actual, expected).ShouldAgree(Outcome.Pass);
     }
 
     [Fact]
@@ -139,10 +132,8 @@ public class BasicSpecs
         var actual = new IndexerHolder { Name = "same" };
         var expected = new IndexerHolder { Name = "same" };
 
-        Compare.Run(actual, expected).ShouldDiverge(
-            shouldly: Outcome.Error,
-            fluentAssertions: Outcome.Pass,
-            because: "Shouldly throws NotSupportedException for any type with an indexer; FluentAssertions skips indexers");
+        // Both skip indexers (there is no general way to enumerate their values).
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
     }
 
     [Fact]

--- a/src/EquivalencyComparisonTests/CollectionSpecs.cs
+++ b/src/EquivalencyComparisonTests/CollectionSpecs.cs
@@ -51,10 +51,8 @@ public class CollectionSpecs
     [Fact]
     public void Array_vs_list_with_identical_elements()
     {
-        Compare.Run<object>(new[] { 1, 2, 3 }, new List<int> { 1, 2, 3 }).ShouldDiverge(
-            shouldly: Outcome.Fail,
-            fluentAssertions: Outcome.Pass,
-            because: "FluentAssertions ignores the container type of collections; Shouldly requires identical runtime types");
+        // Both ignore the container type of collections; only the elements matter.
+        Compare.Run<object>(new[] { 1, 2, 3 }, new List<int> { 1, 2, 3 }).ShouldAgree(Outcome.Pass);
     }
 
     [Fact]
@@ -63,10 +61,8 @@ public class CollectionSpecs
         var actual = new HashSet<int> { 1, 2, 3 };
         var expected = new HashSet<int> { 3, 2, 1 };
 
-        Compare.Run(actual, expected).ShouldDiverge(
-            shouldly: Outcome.Fail,
-            fluentAssertions: Outcome.Pass,
-            because: "sets have no defined order; Shouldly compares them in enumeration order, which reflects insertion history");
+        // Sets have no defined order; both compare them order-insensitively.
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
     }
 
     [Fact]
@@ -88,10 +84,8 @@ public class CollectionSpecs
         var actual = new int[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } };
         var expected = new int[3, 2] { { 1, 2 }, { 3, 4 }, { 5, 6 } };
 
-        Compare.Run<object>(actual, expected).ShouldDiverge(
-            shouldly: Outcome.Pass,
-            fluentAssertions: Outcome.Fail,
-            because: "Shouldly flattens any IEnumerable, losing array shape; FluentAssertions checks rank and per-dimension lengths");
+        // Both check rank and per-dimension lengths.
+        Compare.Run<object>(actual, expected).ShouldAgree(Outcome.Fail);
     }
 
     [Fact]

--- a/src/EquivalencyComparisonTests/CollectionSpecs.cs
+++ b/src/EquivalencyComparisonTests/CollectionSpecs.cs
@@ -1,0 +1,132 @@
+using Xunit;
+
+namespace EquivalencyComparisonTests;
+
+/// <summary>
+/// Collection comparison semantics, mirroring FluentAssertions.Equivalency.Specs/CollectionSpecs.
+/// The headline difference: FluentAssertions matches collections order-insensitively by default
+/// (except byte arrays); Shouldly always compares element-by-element in order.
+/// </summary>
+public class CollectionSpecs
+{
+    [Fact]
+    public void Lists_with_same_elements_in_same_order_are_equivalent()
+    {
+        Compare.Run(new List<int> { 1, 2, 3 }, new List<int> { 1, 2, 3 }).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Lists_with_same_elements_in_different_order()
+    {
+        Compare.Run(new List<int> { 1, 2, 3 }, new List<int> { 3, 2, 1 }).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "FluentAssertions matches collections order-insensitively by default; Shouldly compares element-by-element in order");
+    }
+
+    [Fact]
+    public void Collection_order_inside_an_object_graph()
+    {
+        var actual = new OrderHolder { Values = [1, 2, 3] };
+        var expected = new OrderHolder { Values = [3, 2, 1] };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "order-insensitivity also applies to collections nested inside object graphs in FluentAssertions");
+    }
+
+    [Fact]
+    public void Lists_with_different_counts_are_not_equivalent()
+    {
+        Compare.Run(new List<int> { 1, 2 }, new List<int> { 1, 2, 3 }).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Lists_with_same_counts_but_different_duplicate_multiplicity_are_not_equivalent()
+    {
+        Compare.Run(new List<int> { 1, 1, 2 }, new List<int> { 1, 2, 2 }).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Array_vs_list_with_identical_elements()
+    {
+        Compare.Run<object>(new[] { 1, 2, 3 }, new List<int> { 1, 2, 3 }).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "FluentAssertions ignores the container type of collections; Shouldly requires identical runtime types");
+    }
+
+    [Fact]
+    public void Hash_sets_with_same_elements_inserted_in_different_order()
+    {
+        var actual = new HashSet<int> { 1, 2, 3 };
+        var expected = new HashSet<int> { 3, 2, 1 };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "sets have no defined order; Shouldly compares them in enumeration order, which reflects insertion history");
+    }
+
+    [Fact]
+    public void Empty_collections_are_equivalent()
+    {
+        Compare.Run(new List<int>(), new List<int>()).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Byte_arrays_in_different_order_are_not_equivalent_in_either()
+    {
+        // Byte arrays are the one collection FluentAssertions compares strictly in order by default.
+        Compare.Run(new byte[] { 1, 2, 3 }, new byte[] { 3, 2, 1 }).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Multidimensional_arrays_with_same_flat_content_but_different_shape()
+    {
+        var actual = new int[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } };
+        var expected = new int[3, 2] { { 1, 2 }, { 3, 4 }, { 5, 6 } };
+
+        Compare.Run<object>(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Pass,
+            fluentAssertions: Outcome.Fail,
+            because: "Shouldly flattens any IEnumerable, losing array shape; FluentAssertions checks rank and per-dimension lengths");
+    }
+
+    [Fact]
+    public void Lists_of_complex_objects_with_identical_values_in_order_are_equivalent()
+    {
+        var actual = new List<Person> { new() { Name = "A", Age = 1 }, new() { Name = "B", Age = 2 } };
+        var expected = new List<Person> { new() { Name = "A", Age = 1 }, new() { Name = "B", Age = 2 } };
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Lists_of_complex_objects_with_a_differing_member_are_not_equivalent()
+    {
+        var actual = new List<Person> { new() { Name = "A", Age = 1 } };
+        var expected = new List<Person> { new() { Name = "A", Age = 2 } };
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Lists_of_complex_objects_in_different_order()
+    {
+        var actual = new List<Person> { new() { Name = "A", Age = 1 }, new() { Name = "B", Age = 2 } };
+        var expected = new List<Person> { new() { Name = "B", Age = 2 }, new() { Name = "A", Age = 1 } };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "FluentAssertions matches complex-typed collection items order-insensitively by structural equivalence");
+    }
+
+    [Fact]
+    public void Null_collection_vs_empty_collection_is_not_equivalent_in_either()
+    {
+        Compare.Run<List<int>?>(null, []).ShouldAgree(Outcome.Fail);
+    }
+}

--- a/src/EquivalencyComparisonTests/ComparisonHarness.cs
+++ b/src/EquivalencyComparisonTests/ComparisonHarness.cs
@@ -1,0 +1,114 @@
+using System.Text;
+using FluentAssertions;
+using Shouldly;
+using Xunit.Sdk;
+
+namespace EquivalencyComparisonTests;
+
+public enum Outcome
+{
+    /// <summary>The assertion passed.</summary>
+    Pass,
+
+    /// <summary>The assertion failed with an assertion exception.</summary>
+    Fail,
+
+    /// <summary>The library threw a non-assertion exception (e.g. NotSupportedException).</summary>
+    Error,
+}
+
+public record ComparisonResult(
+    Outcome Shouldly,
+    string? ShouldlyMessage,
+    Outcome FluentAssertions,
+    string? FluentAssertionsMessage)
+{
+    public override string ToString()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Shouldly:         {Shouldly}");
+        if (ShouldlyMessage != null)
+            sb.AppendLine(Indent(ShouldlyMessage));
+        sb.AppendLine($"FluentAssertions: {FluentAssertions}");
+        if (FluentAssertionsMessage != null)
+            sb.AppendLine(Indent(FluentAssertionsMessage));
+        return sb.ToString();
+
+        static string Indent(string message) =>
+            "    " + message.Replace("\n", "\n    ");
+    }
+}
+
+/// <summary>
+/// Runs the same equivalency assertion through Shouldly's ShouldBeEquivalentTo and
+/// FluentAssertions' BeEquivalentTo (v7, default options) and reports both outcomes,
+/// so each test documents where the two libraries agree or diverge.
+/// </summary>
+public static class Compare
+{
+    public static ComparisonResult Run<T>(T? actual, T? expected)
+    {
+        var (shouldlyOutcome, shouldlyMessage) = RunShouldly(actual, expected);
+        var (fluentOutcome, fluentMessage) = RunFluentAssertions(actual, expected);
+        return new(shouldlyOutcome, shouldlyMessage, fluentOutcome, fluentMessage);
+    }
+
+    private static (Outcome, string?) RunShouldly<T>(T? actual, T? expected)
+    {
+        try
+        {
+            actual.ShouldBeEquivalentTo(expected);
+            return (Outcome.Pass, null);
+        }
+        catch (ShouldAssertException ex)
+        {
+            return (Outcome.Fail, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return (Outcome.Error, $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    private static (Outcome, string?) RunFluentAssertions<T>(T? actual, T? expected)
+    {
+        try
+        {
+            actual.Should().BeEquivalentTo(expected);
+            return (Outcome.Pass, null);
+        }
+        catch (Exception ex) when (ex is XunitException || ex.GetType().FullName!.StartsWith("FluentAssertions.Execution", StringComparison.Ordinal))
+        {
+            return (Outcome.Fail, ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return (Outcome.Error, $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}
+
+public static class ComparisonAssertions
+{
+    /// <summary>Asserts that both libraries produce the same outcome for this scenario.</summary>
+    public static void ShouldAgree(this ComparisonResult result, Outcome expected)
+    {
+        if (result.Shouldly != expected || result.FluentAssertions != expected)
+            throw new XunitException(
+                $"Expected both libraries to {expected}, but got:\n{result}");
+    }
+
+    /// <summary>
+    /// Asserts that the libraries diverge in the documented way. The <paramref name="because"/>
+    /// text explains the behavioral difference this test pins down.
+    /// </summary>
+    public static void ShouldDiverge(this ComparisonResult result, Outcome shouldly, Outcome fluentAssertions, string because)
+    {
+        if (shouldly == fluentAssertions)
+            throw new ArgumentException("Divergence requires different outcomes; use ShouldAgree instead.");
+
+        if (result.Shouldly != shouldly || result.FluentAssertions != fluentAssertions)
+            throw new XunitException(
+                $"Expected divergence (Shouldly: {shouldly}, FluentAssertions: {fluentAssertions}) because {because}, but got:\n{result}");
+    }
+}

--- a/src/EquivalencyComparisonTests/DictionarySpecs.cs
+++ b/src/EquivalencyComparisonTests/DictionarySpecs.cs
@@ -4,10 +4,8 @@ namespace EquivalencyComparisonTests;
 
 /// <summary>
 /// Dictionary comparison semantics, mirroring FluentAssertions.Equivalency.Specs/DictionarySpecs.
-/// FluentAssertions matches dictionaries by key; Shouldly enumerates them as sequences of
-/// KeyValuePair structs, which makes it sensitive to insertion order and — because KeyValuePair
-/// is a value type compared via Equals — unable to see into reference-typed values (shouldly#767,
-/// shouldly#1077).
+/// Both libraries match dictionaries by key, insertion-order-insensitively, and recurse into
+/// values (cf. shouldly#767, shouldly#1077 for the historical failures this design fixed).
 /// </summary>
 public class DictionarySpecs
 {
@@ -26,10 +24,8 @@ public class DictionarySpecs
         var actual = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
         var expected = new Dictionary<string, int> { ["b"] = 2, ["a"] = 1 };
 
-        Compare.Run(actual, expected).ShouldDiverge(
-            shouldly: Outcome.Fail,
-            fluentAssertions: Outcome.Pass,
-            because: "FluentAssertions matches dictionaries by key; Shouldly compares them as ordered sequences of pairs");
+        // Both match dictionaries by key, so insertion order is irrelevant.
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
     }
 
     [Fact]
@@ -56,10 +52,8 @@ public class DictionarySpecs
         var actual = new Dictionary<string, Person> { ["a"] = new() { Name = "John", Age = 30 } };
         var expected = new Dictionary<string, Person> { ["a"] = new() { Name = "John", Age = 30 } };
 
-        Compare.Run(actual, expected).ShouldDiverge(
-            shouldly: Outcome.Fail,
-            fluentAssertions: Outcome.Pass,
-            because: "Shouldly compares KeyValuePair structs with Equals, which reference-compares the Person values instead of recursing into them (shouldly#1077)");
+        // Both recurse into dictionary values (shouldly#1077).
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
     }
 
     [Fact]
@@ -68,9 +62,7 @@ public class DictionarySpecs
         var actual = new Dictionary<string, List<int>> { ["a"] = [1, 2] };
         var expected = new Dictionary<string, List<int>> { ["a"] = [1, 2] };
 
-        Compare.Run(actual, expected).ShouldDiverge(
-            shouldly: Outcome.Fail,
-            fluentAssertions: Outcome.Pass,
-            because: "Shouldly compares KeyValuePair structs with Equals, which reference-compares the List values instead of recursing into them (shouldly#767)");
+        // Both recurse into dictionary values, including collection values (shouldly#767).
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
     }
 }

--- a/src/EquivalencyComparisonTests/DictionarySpecs.cs
+++ b/src/EquivalencyComparisonTests/DictionarySpecs.cs
@@ -1,0 +1,76 @@
+using Xunit;
+
+namespace EquivalencyComparisonTests;
+
+/// <summary>
+/// Dictionary comparison semantics, mirroring FluentAssertions.Equivalency.Specs/DictionarySpecs.
+/// FluentAssertions matches dictionaries by key; Shouldly enumerates them as sequences of
+/// KeyValuePair structs, which makes it sensitive to insertion order and — because KeyValuePair
+/// is a value type compared via Equals — unable to see into reference-typed values (shouldly#767,
+/// shouldly#1077).
+/// </summary>
+public class DictionarySpecs
+{
+    [Fact]
+    public void Dictionaries_with_same_pairs_inserted_in_same_order_are_equivalent()
+    {
+        var actual = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var expected = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Dictionaries_with_same_pairs_inserted_in_different_order()
+    {
+        var actual = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var expected = new Dictionary<string, int> { ["b"] = 2, ["a"] = 1 };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "FluentAssertions matches dictionaries by key; Shouldly compares them as ordered sequences of pairs");
+    }
+
+    [Fact]
+    public void Dictionaries_with_a_differing_value_are_not_equivalent()
+    {
+        var actual = new Dictionary<string, int> { ["a"] = 1 };
+        var expected = new Dictionary<string, int> { ["a"] = 2 };
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Dictionaries_with_a_missing_key_are_not_equivalent()
+    {
+        var actual = new Dictionary<string, int> { ["a"] = 1 };
+        var expected = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Dictionaries_with_reference_typed_values_that_are_equal_but_not_the_same_instance()
+    {
+        var actual = new Dictionary<string, Person> { ["a"] = new() { Name = "John", Age = 30 } };
+        var expected = new Dictionary<string, Person> { ["a"] = new() { Name = "John", Age = 30 } };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "Shouldly compares KeyValuePair structs with Equals, which reference-compares the Person values instead of recursing into them (shouldly#1077)");
+    }
+
+    [Fact]
+    public void Dictionaries_with_collection_values_that_are_equal_but_not_the_same_instance()
+    {
+        var actual = new Dictionary<string, List<int>> { ["a"] = [1, 2] };
+        var expected = new Dictionary<string, List<int>> { ["a"] = [1, 2] };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "Shouldly compares KeyValuePair structs with Equals, which reference-compares the List values instead of recursing into them (shouldly#767)");
+    }
+}

--- a/src/EquivalencyComparisonTests/EquivalencyComparisonTests.csproj
+++ b/src/EquivalencyComparisonTests/EquivalencyComparisonTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <NoWarn>CA1861</NoWarn>
+    <!-- This project intentionally references FluentAssertions 7.x (the last Apache-2.0 licensed
+         version) to document behavioral differences between Shouldly's ShouldBeEquivalentTo and
+         FluentAssertions' BeEquivalentTo. It is a comparison/characterization suite, not part of
+         the shipped product. -->
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shouldly\Shouldly.csproj" />
+    <PackageReference Include="FluentAssertions" Version="7.2.0" />
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/src/EquivalencyComparisonTests/InheritanceSpecs.cs
+++ b/src/EquivalencyComparisonTests/InheritanceSpecs.cs
@@ -1,0 +1,44 @@
+using Xunit;
+
+namespace EquivalencyComparisonTests;
+
+/// <summary>
+/// Declared-type vs runtime-type semantics, mirroring FluentAssertions.Equivalency.Specs and
+/// the subject of shouldly#1094: FluentAssertions selects members from the declared
+/// (compile-time) type by default; Shouldly always reflects over the runtime type.
+/// </summary>
+public class InheritanceSpecs
+{
+    [Fact]
+    public void Members_declared_as_base_type_holding_derived_instances_with_differing_derived_members()
+    {
+        var actual = new PetOwner { Pet = new Dog { Name = "Rex", Breed = "Lab" } };
+        var expected = new PetOwner { Pet = new Dog { Name = "Rex", Breed = "Poodle" } };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "the Pet member is declared as Animal, so FluentAssertions only compares Animal's members; Shouldly reflects over the runtime type Dog and sees the differing Breed");
+    }
+
+    [Fact]
+    public void Members_declared_as_base_type_with_differing_base_members_are_not_equivalent_in_either()
+    {
+        var actual = new PetOwner { Pet = new Dog { Name = "Rex", Breed = "Lab" } };
+        var expected = new PetOwner { Pet = new Dog { Name = "Fido", Breed = "Lab" } };
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Root_objects_compared_through_a_base_typed_reference_with_differing_derived_members()
+    {
+        Animal actual = new Dog { Name = "Rex", Breed = "Lab" };
+        Animal expected = new Dog { Name = "Rex", Breed = "Poodle" };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "the static type Animal drives FluentAssertions' member selection at the root; Shouldly reflects over the runtime type Dog");
+    }
+}

--- a/src/EquivalencyComparisonTests/InheritanceSpecs.cs
+++ b/src/EquivalencyComparisonTests/InheritanceSpecs.cs
@@ -4,8 +4,8 @@ namespace EquivalencyComparisonTests;
 
 /// <summary>
 /// Declared-type vs runtime-type semantics, mirroring FluentAssertions.Equivalency.Specs and
-/// the subject of shouldly#1094: FluentAssertions selects members from the declared
-/// (compile-time) type by default; Shouldly always reflects over the runtime type.
+/// the subject of shouldly#1094: both libraries select members from the declared
+/// (compile-time) type of a member by default.
 /// </summary>
 public class InheritanceSpecs
 {
@@ -38,6 +38,6 @@ public class InheritanceSpecs
         Compare.Run(actual, expected).ShouldDiverge(
             shouldly: Outcome.Fail,
             fluentAssertions: Outcome.Pass,
-            because: "the static type Animal drives FluentAssertions' member selection at the root; Shouldly reflects over the runtime type Dog");
+            because: "the static type Animal drives FluentAssertions' member selection at the root; Shouldly's object-typed API cannot see the static type, so the root falls back to the expectation's runtime type Dog");
     }
 }

--- a/src/EquivalencyComparisonTests/InheritanceSpecs.cs
+++ b/src/EquivalencyComparisonTests/InheritanceSpecs.cs
@@ -15,10 +15,9 @@ public class InheritanceSpecs
         var actual = new PetOwner { Pet = new Dog { Name = "Rex", Breed = "Lab" } };
         var expected = new PetOwner { Pet = new Dog { Name = "Rex", Breed = "Poodle" } };
 
-        Compare.Run(actual, expected).ShouldDiverge(
-            shouldly: Outcome.Fail,
-            fluentAssertions: Outcome.Pass,
-            because: "the Pet member is declared as Animal, so FluentAssertions only compares Animal's members; Shouldly reflects over the runtime type Dog and sees the differing Breed");
+        // Since shouldly#1094, Shouldly selects members from the declared type Animal like
+        // FluentAssertions, so the derived-only Breed member is not compared.
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
     }
 
     [Fact]

--- a/src/EquivalencyComparisonTests/README.md
+++ b/src/EquivalencyComparisonTests/README.md
@@ -13,27 +13,25 @@ suite doubles as a progress metric for FluentAssertions convergence.
 
 ## Verified divergences (Shouldly 5.0-preview vs FluentAssertions 7.2 defaults)
 
-| Scenario | Shouldly | FluentAssertions |
-| --- | --- | --- |
-| Different types, identical shape (incl. anonymous-type expectations) | Fail — requires identical runtime types | Pass — structural, by the expectation's members |
-| Expectation with a subset of the subject's members | Fail | Pass — extra subject members are ignored |
-| Lists/sets with same elements, different order | Fail — ordered element-by-element | Pass — order-insensitive by default (byte arrays excepted) |
-| Array vs `List<T>` with identical elements | Fail — container types must match | Pass — container type ignored |
-| Dictionaries with same pairs, different insertion order | Fail — compared as ordered pair sequences | Pass — matched by key |
-| Dictionaries with reference-typed or collection values (equal, distinct instances) | Fail — `KeyValuePair` struct compared via `Equals`, so values are reference-compared (shouldly#767, shouldly#1077) | Pass — recurses into values |
-| Member declared as base type holding derived instances with differing derived-only members | Fail — reflects over runtime type | Pass — member selection uses the declared type (cf. shouldly#1094) |
-| Class overriding `Equals`: equal by members, unequal by `Equals` (or vice versa) | Compares members, ignores `Equals` | Honors the `Equals` override (value semantics) |
-| Different enum types with the same underlying value | Fail — types must match | Pass — enums compared by value |
-| `int 1` vs `long 1` | Fail — types must match | Pass — numeric types compared by value |
-| Types with indexers | **Error** — `NotSupportedException` | Pass — indexers skipped |
-| `Type`-valued members with different values | **Error** — walks `System.Type`'s reflection properties (shouldly#1050) | Fail cleanly — `Type` treated as a value |
-| Cyclic object graphs, identical shape | Pass — tracks visited pairs | Fail — cycles rejected by default |
-| Object graphs deeper than 10 levels | Pass — unbounded recursion | Fail — 10-level depth cap by default |
-| Multidimensional arrays, same flat content, different shape | Pass — flattens all `IEnumerable`s | Fail — checks rank and dimension lengths |
-| Two `new object()`s (no members) | Pass — vacuously equivalent | **Error** — "no members" `InvalidOperationException` |
+Every remaining divergence is deliberate; the rationale is recorded in the roadmap
+(shouldly#1265) and pinned by a `ShouldDiverge` test.
 
-Everywhere else tested — same-type member comparison, nested graphs, strings (ordinal,
-case-sensitive), public fields, private member exclusion, structs, records, `DateTime`
-(tick-exact, `Kind`-insensitive), `DateTimeOffset` (instant), `decimal` scale, `Guid`, NaN,
-nullable lifting, `Uri` (fragment-insensitive via `Uri.Equals`), null handling, duplicate
-multiplicity in collections — the two libraries agree.
+| Scenario | Shouldly | FluentAssertions | Why Shouldly diverges |
+| --- | --- | --- | --- |
+| Lists/arrays with same elements, different order (incl. nested in graphs) | Fail — ordered element-by-element | Pass — order-insensitive by default (byte arrays excepted) | Consistent with `ShouldBe`; respects the collection's contract; precise "element [i]" messages; a strict default fails loudly instead of masking ordering bugs. Opt out with `IgnoreOrder` |
+| Class overriding `Equals`: equal by members, unequal by `Equals` (or vice versa) | Compares members, ignores `Equals` | Honors the `Equals` override (value semantics) | People reach for equivalency precisely to compare structure; `ShouldBe` already honors `Equals`; avoids the false pass where `Equals` hides real data differences |
+| Different enum types with the same underlying value | Fail | Pass — enums compared by value | Two distinct enum types agreeing numerically is usually an accident |
+| Cyclic object graphs, identical shape | Pass — visited pairs tracked by reference | Fail — cycles rejected by default | Strictly more useful; no configuration needed |
+| Object graphs deeper than 10 levels | Pass — unbounded recursion | Fail — 10-level depth cap by default | Safe with correct cycle tracking |
+| Root objects held in base-typed references with differing derived-only members | Fail — the `object`-typed API cannot see the static type, so the root falls back to the expectation's runtime type | Pass — the generic API's static type drives member selection | API-shape consequence, not a semantic choice |
+| Two `new object()`s (no members) | Fail — vacuous-comparison guard with guidance | **Error** — "no members" `InvalidOperationException` | Both refuse a zero-member comparison; Shouldly fails the assertion with an actionable message instead of throwing |
+
+Everywhere else tested, the two libraries agree — including the scenarios that diverged before
+the v5 rewrite: cross-type and anonymous-type expectations (subset semantics, by the
+expectation's members), declared-type member selection, dictionaries matched by key with
+recursion into values, sets compared order-insensitively, container types ignored
+(array ≡ `List<T>`), lossless cross-numeric equality (`int 1` ≡ `long 1`), multidimensional
+array shape checks, indexers skipped, `Type`/`Uri` as leaf values, strings (ordinal,
+case-sensitive), public fields, private member exclusion, structs and records member-wise,
+`DateTime` (tick-exact, `Kind`-insensitive), `DateTimeOffset` (instant), `decimal` scale,
+`Guid`, NaN, nullable lifting, null handling, and duplicate multiplicity in collections.

--- a/src/EquivalencyComparisonTests/README.md
+++ b/src/EquivalencyComparisonTests/README.md
@@ -1,0 +1,39 @@
+# Equivalency comparison tests
+
+This project runs the same scenarios through Shouldly's `ShouldBeEquivalentTo` and
+FluentAssertions' `BeEquivalentTo` (v7.2, the last Apache-2.0 licensed version, default options)
+and asserts on *both* outcomes. It is an executable specification of where the two libraries
+agree and diverge, modeled on the scenarios in
+[FluentAssertions.Equivalency.Specs](https://github.com/fluentassertions/fluentassertions/tree/main/Tests/FluentAssertions.Equivalency.Specs).
+
+Each test either documents parity (`ShouldAgree`) or pins down a divergence (`ShouldDiverge`)
+with a `because:` explaining the behavioral difference. When Shouldly's equivalency defaults
+change, the affected divergence tests fail, forcing the change to be acknowledged here — the
+suite doubles as a progress metric for FluentAssertions convergence.
+
+## Verified divergences (Shouldly 5.0-preview vs FluentAssertions 7.2 defaults)
+
+| Scenario | Shouldly | FluentAssertions |
+| --- | --- | --- |
+| Different types, identical shape (incl. anonymous-type expectations) | Fail — requires identical runtime types | Pass — structural, by the expectation's members |
+| Expectation with a subset of the subject's members | Fail | Pass — extra subject members are ignored |
+| Lists/sets with same elements, different order | Fail — ordered element-by-element | Pass — order-insensitive by default (byte arrays excepted) |
+| Array vs `List<T>` with identical elements | Fail — container types must match | Pass — container type ignored |
+| Dictionaries with same pairs, different insertion order | Fail — compared as ordered pair sequences | Pass — matched by key |
+| Dictionaries with reference-typed or collection values (equal, distinct instances) | Fail — `KeyValuePair` struct compared via `Equals`, so values are reference-compared (shouldly#767, shouldly#1077) | Pass — recurses into values |
+| Member declared as base type holding derived instances with differing derived-only members | Fail — reflects over runtime type | Pass — member selection uses the declared type (cf. shouldly#1094) |
+| Class overriding `Equals`: equal by members, unequal by `Equals` (or vice versa) | Compares members, ignores `Equals` | Honors the `Equals` override (value semantics) |
+| Different enum types with the same underlying value | Fail — types must match | Pass — enums compared by value |
+| `int 1` vs `long 1` | Fail — types must match | Pass — numeric types compared by value |
+| Types with indexers | **Error** — `NotSupportedException` | Pass — indexers skipped |
+| `Type`-valued members with different values | **Error** — walks `System.Type`'s reflection properties (shouldly#1050) | Fail cleanly — `Type` treated as a value |
+| Cyclic object graphs, identical shape | Pass — tracks visited pairs | Fail — cycles rejected by default |
+| Object graphs deeper than 10 levels | Pass — unbounded recursion | Fail — 10-level depth cap by default |
+| Multidimensional arrays, same flat content, different shape | Pass — flattens all `IEnumerable`s | Fail — checks rank and dimension lengths |
+| Two `new object()`s (no members) | Pass — vacuously equivalent | **Error** — "no members" `InvalidOperationException` |
+
+Everywhere else tested — same-type member comparison, nested graphs, strings (ordinal,
+case-sensitive), public fields, private member exclusion, structs, records, `DateTime`
+(tick-exact, `Kind`-insensitive), `DateTimeOffset` (instant), `decimal` scale, `Guid`, NaN,
+nullable lifting, `Uri` (fragment-insensitive via `Uri.Equals`), null handling, duplicate
+multiplicity in collections — the two libraries agree.

--- a/src/EquivalencyComparisonTests/RecordAndEnumSpecs.cs
+++ b/src/EquivalencyComparisonTests/RecordAndEnumSpecs.cs
@@ -1,0 +1,66 @@
+using Xunit;
+
+namespace EquivalencyComparisonTests;
+
+/// <summary>
+/// Record and record-struct semantics, mirroring FluentAssertions.Equivalency.Specs/RecordSpecs.
+/// </summary>
+public class RecordSpecs
+{
+    [Fact]
+    public void Records_with_identical_values_are_equivalent()
+    {
+        Compare.Run(new PersonRecord("John", 30), new PersonRecord("John", 30)).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Records_with_differing_values_are_not_equivalent()
+    {
+        Compare.Run(new PersonRecord("John", 30), new PersonRecord("Jane", 30)).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Record_structs_with_identical_values_are_equivalent()
+    {
+        Compare.Run(new PointRecordStruct(1, 2), new PointRecordStruct(1, 2)).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Record_structs_with_differing_values_are_not_equivalent()
+    {
+        Compare.Run(new PointRecordStruct(1, 2), new PointRecordStruct(1, 3)).ShouldAgree(Outcome.Fail);
+    }
+}
+
+/// <summary>
+/// Enum semantics, mirroring FluentAssertions.Equivalency.Specs/EnumSpecs.
+/// </summary>
+public class EnumSpecs
+{
+    [Fact]
+    public void Equal_enum_values_are_equivalent()
+    {
+        Compare.Run(Color.Red, Color.Red).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Different_enum_values_are_not_equivalent()
+    {
+        Compare.Run(Color.Red, Color.Green).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Different_enum_types_with_the_same_underlying_value()
+    {
+        Compare.Run<object>(Color.Red, Shade.Crimson).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "FluentAssertions compares enums by underlying numeric value by default; Shouldly requires identical runtime types");
+    }
+
+    [Fact]
+    public void Enum_vs_its_underlying_integer_value_is_not_equivalent_in_either()
+    {
+        Compare.Run<object>(Color.Red, 1).ShouldAgree(Outcome.Fail);
+    }
+}

--- a/src/EquivalencyComparisonTests/RecursionSpecs.cs
+++ b/src/EquivalencyComparisonTests/RecursionSpecs.cs
@@ -1,0 +1,60 @@
+using Xunit;
+
+namespace EquivalencyComparisonTests;
+
+/// <summary>
+/// Cyclic reference and recursion-depth semantics, mirroring
+/// FluentAssertions.Equivalency.Specs/CyclicReferencesSpecs and the max-depth behavior in SelfReferenceSpecs.
+/// </summary>
+public class RecursionSpecs
+{
+    [Fact]
+    public void Cyclic_graphs_with_identical_shape()
+    {
+        var actual = new Node { Name = "root" };
+        actual.Next = actual;
+        var expected = new Node { Name = "root" };
+        expected.Next = expected;
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Pass,
+            fluentAssertions: Outcome.Fail,
+            because: "Shouldly tracks already-compared pairs and treats cycles as equivalent; FluentAssertions fails on cyclic references by default (IgnoringCyclicReferences is opt-in)");
+    }
+
+    [Fact]
+    public void Two_node_cycles_with_a_differing_member_are_not_equivalent_in_either()
+    {
+        var actualA = new Node { Name = "a" };
+        var actualB = new Node { Name = "b", Next = actualA };
+        actualA.Next = actualB;
+
+        var expectedA = new Node { Name = "a" };
+        var expectedB = new Node { Name = "different", Next = expectedA };
+        expectedA.Next = expectedB;
+
+        Compare.Run(actualA, expectedA).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Deep_acyclic_graphs_beyond_ten_levels()
+    {
+        Compare.Run(BuildChain(15), BuildChain(15)).ShouldDiverge(
+            shouldly: Outcome.Pass,
+            fluentAssertions: Outcome.Fail,
+            because: "FluentAssertions caps recursion at 10 levels by default (AllowingInfiniteRecursion is opt-in); Shouldly has no depth limit");
+    }
+
+    private static Node BuildChain(int depth)
+    {
+        var root = new Node { Name = "level0" };
+        var current = root;
+        for (var i = 1; i < depth; i++)
+        {
+            current.Next = new Node { Name = $"level{i}" };
+            current = current.Next;
+        }
+
+        return root;
+    }
+}

--- a/src/EquivalencyComparisonTests/StringAndSpecialTypeSpecs.cs
+++ b/src/EquivalencyComparisonTests/StringAndSpecialTypeSpecs.cs
@@ -66,10 +66,10 @@ public class SpecialTypeSpecs
         var actual = new TypeHolder { Type = typeof(string) };
         var expected = new TypeHolder { Type = typeof(int) };
 
-        Compare.Run(actual, expected).ShouldDiverge(
-            shouldly: Outcome.Error,
-            fluentAssertions: Outcome.Fail,
-            because: "Shouldly walks System.Type's reflection properties and blows up on members like DeclaringMethod (shouldly#1050); FluentAssertions compares Type as a value");
+        // Since shouldly#1094 the member is walked as its declared type System.Type, which no
+        // longer blows up (shouldly#1050) but still compares Type's properties rather than
+        // treating it as a leaf value the way FluentAssertions does.
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Fail);
     }
 
     [Fact]

--- a/src/EquivalencyComparisonTests/StringAndSpecialTypeSpecs.cs
+++ b/src/EquivalencyComparisonTests/StringAndSpecialTypeSpecs.cs
@@ -27,8 +27,8 @@ public class StringSpecs
 }
 
 /// <summary>
-/// Types both libraries treat as comparison leaves rather than walking their members —
-/// or fail to (see shouldly#1050 for Type, shouldly#1205 for Uri).
+/// Types both libraries treat as comparison leaves rather than walking their members
+/// (cf. shouldly#1050 for Type, shouldly#1205 for Uri).
 /// </summary>
 public class SpecialTypeSpecs
 {
@@ -66,9 +66,7 @@ public class SpecialTypeSpecs
         var actual = new TypeHolder { Type = typeof(string) };
         var expected = new TypeHolder { Type = typeof(int) };
 
-        // Since shouldly#1094 the member is walked as its declared type System.Type, which no
-        // longer blows up (shouldly#1050) but still compares Type's properties rather than
-        // treating it as a leaf value the way FluentAssertions does.
+        // Both treat Type as a leaf value compared with Equals (shouldly#1050).
         Compare.Run(actual, expected).ShouldAgree(Outcome.Fail);
     }
 
@@ -76,8 +74,8 @@ public class SpecialTypeSpecs
     public void Objects_with_no_members()
     {
         Compare.Run(new object(), new object()).ShouldDiverge(
-            shouldly: Outcome.Pass,
+            shouldly: Outcome.Fail,
             fluentAssertions: Outcome.Error,
-            because: "Shouldly treats a memberless object as vacuously equivalent; FluentAssertions throws because comparing objects without members is probably a mistake");
+            because: "both refuse to compare zero members, differently: Shouldly's vacuous-comparison guard fails the assertion with guidance; FluentAssertions throws an InvalidOperationException");
     }
 }

--- a/src/EquivalencyComparisonTests/StringAndSpecialTypeSpecs.cs
+++ b/src/EquivalencyComparisonTests/StringAndSpecialTypeSpecs.cs
@@ -1,0 +1,83 @@
+using Xunit;
+
+namespace EquivalencyComparisonTests;
+
+/// <summary>
+/// String comparison semantics.
+/// </summary>
+public class StringSpecs
+{
+    [Fact]
+    public void Identical_strings_are_equivalent()
+    {
+        Compare.Run("hello", "hello").ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Strings_differing_in_case_are_not_equivalent()
+    {
+        Compare.Run("hello", "HELLO").ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Strings_differing_in_trailing_whitespace_are_not_equivalent()
+    {
+        Compare.Run("hello", "hello ").ShouldAgree(Outcome.Fail);
+    }
+}
+
+/// <summary>
+/// Types both libraries treat as comparison leaves rather than walking their members —
+/// or fail to (see shouldly#1050 for Type, shouldly#1205 for Uri).
+/// </summary>
+public class SpecialTypeSpecs
+{
+    [Fact]
+    public void Equal_uris_are_equivalent()
+    {
+        Compare.Run(new Uri("https://example.com/a"), new Uri("https://example.com/a")).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Different_uris_are_not_equivalent()
+    {
+        Compare.Run(new Uri("https://example.com/a"), new Uri("https://example.com/b")).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Uris_differing_only_in_fragment_are_equivalent_in_both()
+    {
+        // Uri.Equals ignores the fragment; both libraries defer to it.
+        Compare.Run(new Uri("https://example.com/a#one"), new Uri("https://example.com/a#two")).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Equal_type_valued_members_are_equivalent()
+    {
+        var actual = new TypeHolder { Type = typeof(string) };
+        var expected = new TypeHolder { Type = typeof(string) };
+
+        Compare.Run(actual, expected).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Different_type_valued_members()
+    {
+        var actual = new TypeHolder { Type = typeof(string) };
+        var expected = new TypeHolder { Type = typeof(int) };
+
+        Compare.Run(actual, expected).ShouldDiverge(
+            shouldly: Outcome.Error,
+            fluentAssertions: Outcome.Fail,
+            because: "Shouldly walks System.Type's reflection properties and blows up on members like DeclaringMethod (shouldly#1050); FluentAssertions compares Type as a value");
+    }
+
+    [Fact]
+    public void Objects_with_no_members()
+    {
+        Compare.Run(new object(), new object()).ShouldDiverge(
+            shouldly: Outcome.Pass,
+            fluentAssertions: Outcome.Error,
+            because: "Shouldly treats a memberless object as vacuously equivalent; FluentAssertions throws because comparing objects without members is probably a mistake");
+    }
+}

--- a/src/EquivalencyComparisonTests/TestTypes.cs
+++ b/src/EquivalencyComparisonTests/TestTypes.cs
@@ -1,0 +1,130 @@
+namespace EquivalencyComparisonTests;
+
+public class Person
+{
+    public string? Name { get; set; }
+    public int Age { get; set; }
+}
+
+/// <summary>Structurally identical to <see cref="Person"/> but a different type.</summary>
+public class Customer
+{
+    public string? Name { get; set; }
+    public int Age { get; set; }
+}
+
+public class PersonWithAddress
+{
+    public string? Name { get; set; }
+    public Address? Address { get; set; }
+}
+
+public class Address
+{
+    public string? Street { get; set; }
+    public string? City { get; set; }
+}
+
+public class FieldHolder
+{
+    public string? PublicField;
+    private string? _privateField;
+
+    public FieldHolder(string? publicField, string? privateField)
+    {
+        PublicField = publicField;
+        _privateField = privateField;
+    }
+}
+
+public class PrivatePropertyHolder
+{
+    public string? PublicValue { get; set; }
+    private string? PrivateValue { get; set; }
+
+    public PrivatePropertyHolder(string? publicValue, string? privateValue)
+    {
+        PublicValue = publicValue;
+        PrivateValue = privateValue;
+    }
+}
+
+public class IndexerHolder
+{
+    public string? Name { get; set; }
+
+    public int this[int i] => i * 2;
+}
+
+/// <summary>Reference type with value semantics: Equals/GetHashCode use Id only.</summary>
+public class EqualsById
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+
+    public override bool Equals(object? obj) => obj is EqualsById other && other.Id == Id;
+    public override int GetHashCode() => Id;
+}
+
+/// <summary>Reference type whose Equals always reports inequality despite identical members.</summary>
+public class EqualsNever
+{
+    public string? Name { get; set; }
+
+    public override bool Equals(object? obj) => false;
+    public override int GetHashCode() => 0;
+}
+
+public class TypeHolder
+{
+    public Type? Type { get; set; }
+}
+
+public class Node
+{
+    public string? Name { get; set; }
+    public Node? Next { get; set; }
+}
+
+public class Animal
+{
+    public string? Name { get; set; }
+}
+
+public class Dog : Animal
+{
+    public string? Breed { get; set; }
+}
+
+public class PetOwner
+{
+    // Declared type is Animal; may hold a Dog at runtime.
+    public Animal? Pet { get; set; }
+}
+
+public record PersonRecord(string Name, int Age);
+
+public record struct PointRecordStruct(int X, int Y);
+
+public struct Point
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+}
+
+public enum Color
+{
+    Red = 1,
+    Green = 2,
+}
+
+public enum Shade
+{
+    Crimson = 1,
+    Emerald = 2,
+}
+
+public class OrderHolder
+{
+    public List<int> Values { get; set; } = [];
+}

--- a/src/EquivalencyComparisonTests/ValueTypeSpecs.cs
+++ b/src/EquivalencyComparisonTests/ValueTypeSpecs.cs
@@ -35,10 +35,8 @@ public class ValueTypeSpecs
     [Fact]
     public void Int_vs_long_with_the_same_numeric_value()
     {
-        Compare.Run<object>(1, 1L).ShouldDiverge(
-            shouldly: Outcome.Fail,
-            fluentAssertions: Outcome.Pass,
-            because: "FluentAssertions treats numeric types of the same value as equivalent; Shouldly requires identical runtime types");
+        // Both treat numeric types holding the same value as equivalent (lossless cross-numeric equality).
+        Compare.Run<object>(1, 1L).ShouldAgree(Outcome.Pass);
     }
 
     [Fact]

--- a/src/EquivalencyComparisonTests/ValueTypeSpecs.cs
+++ b/src/EquivalencyComparisonTests/ValueTypeSpecs.cs
@@ -1,0 +1,102 @@
+using Xunit;
+
+namespace EquivalencyComparisonTests;
+
+/// <summary>
+/// Value type, struct, and primitive semantics, mirroring FluentAssertions.Equivalency.Specs/StructSpecs
+/// and the primitive handling in BasicSpecs.
+/// </summary>
+public class ValueTypeSpecs
+{
+    [Fact]
+    public void Structs_with_identical_members_are_equivalent()
+    {
+        Compare.Run(new Point { X = 1, Y = 2 }, new Point { X = 1, Y = 2 }).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Structs_with_differing_members_are_not_equivalent()
+    {
+        Compare.Run(new Point { X = 1, Y = 2 }, new Point { X = 1, Y = 3 }).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Equal_integers_are_equivalent()
+    {
+        Compare.Run(42, 42).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Different_integers_are_not_equivalent()
+    {
+        Compare.Run(42, 43).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Int_vs_long_with_the_same_numeric_value()
+    {
+        Compare.Run<object>(1, 1L).ShouldDiverge(
+            shouldly: Outcome.Fail,
+            fluentAssertions: Outcome.Pass,
+            because: "FluentAssertions treats numeric types of the same value as equivalent; Shouldly requires identical runtime types");
+    }
+
+    [Fact]
+    public void Decimals_differing_only_in_scale_are_equivalent()
+    {
+        Compare.Run(1.0m, 1.00m).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void NaN_is_equivalent_to_NaN()
+    {
+        Compare.Run(double.NaN, double.NaN).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Equal_guids_are_equivalent()
+    {
+        var guid = Guid.NewGuid();
+        Compare.Run(guid, new Guid(guid.ToString())).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Equal_date_times_are_equivalent()
+    {
+        Compare.Run(new DateTime(2026, 7, 11), new DateTime(2026, 7, 11)).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Date_times_differing_by_one_tick_are_not_equivalent()
+    {
+        var now = new DateTime(2026, 7, 11, 12, 0, 0);
+        Compare.Run(now, now.AddTicks(1)).ShouldAgree(Outcome.Fail);
+    }
+
+    [Fact]
+    public void Date_times_with_same_ticks_but_different_kind_are_equivalent_in_both()
+    {
+        // DateTime.Equals ignores Kind; both libraries defer to it.
+        var utc = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Utc);
+        var local = new DateTime(2026, 7, 11, 12, 0, 0, DateTimeKind.Local);
+
+        Compare.Run(utc, local).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Date_time_offsets_with_same_instant_but_different_offsets()
+    {
+        var one = new DateTimeOffset(2026, 7, 11, 12, 0, 0, TimeSpan.Zero);
+        var two = new DateTimeOffset(2026, 7, 11, 14, 0, 0, TimeSpan.FromHours(2));
+
+        // DateTimeOffset.Equals compares the instant only; both libraries defer to it.
+        Compare.Run(one, two).ShouldAgree(Outcome.Pass);
+    }
+
+    [Fact]
+    public void Nullable_int_with_value_is_equivalent_to_plain_int()
+    {
+        int? actual = 5;
+        Compare.Run<object>(actual, 5).ShouldAgree(Outcome.Pass);
+    }
+}

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -144,13 +144,7 @@ namespace Shouldly
     [Shouldly.ShouldlyMethods]
     public static class ObjectGraphTestExtensions
     {
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Walks the actual/expected object graph using reflection over each runtime type\'s " +
-            "public fields and properties. The trimmer cannot statically determine which memb" +
-            "ers are read.")]
         public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Walks the actual/expected object graph using reflection over each runtime type\'s " +
-            "public fields and properties. The trimmer cannot statically determine which memb" +
-            "ers are read.")]
         public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, Shouldly.EquivalencyOptions options, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
     }
     [Shouldly.ShouldlyMethods]

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -44,6 +44,8 @@ namespace Shouldly
     public class EquivalencyOptions
     {
         public EquivalencyOptions() { }
+        public bool IgnoreOrder { get; set; }
+        public System.Collections.Generic.ICollection<string> MembersToIgnore { get; }
     }
     public enum EscapeStyle
     {

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -41,6 +41,10 @@ namespace Shouldly
         public static TException Throw<TException>(System.Action actual, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null)
             where TException : System.Exception { }
     }
+    public class EquivalencyOptions
+    {
+        public EquivalencyOptions() { }
+    }
     public enum EscapeStyle
     {
         CStyle = 0,
@@ -144,6 +148,10 @@ namespace Shouldly
             "public fields and properties. The trimmer cannot statically determine which memb" +
             "ers are read.")]
         public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Walks the actual/expected object graph using reflection over each runtime type\'s " +
+            "public fields and properties. The trimmer cannot statically determine which memb" +
+            "ers are read.")]
+        public static void ShouldBeEquivalentTo([System.Diagnostics.CodeAnalysis.NotNullIfNotNull("expected")] this object? actual, [System.Diagnostics.CodeAnalysis.NotNullIfNotNull("actual")] object? expected, Shouldly.EquivalencyOptions options, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
     }
     [Shouldly.ShouldlyMethods]
     public static class Should

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.ShouldFailWhenDictionaryIsTooLong.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.ShouldFailWhenDictionaryIsTooLong.approved.txt
@@ -1,0 +1,8 @@
+Comparing object equivalence, at path:
+subject [System.Collections.Generic.Dictionary<System.Int32, System.Int32>]
+
+    Found key(s) not present on the expectation
+[5]
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.ShouldFailWhenDictionaryIsTooShort.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.ShouldFailWhenDictionaryIsTooShort.approved.txt
@@ -1,0 +1,9 @@
+Comparing object equivalence, at path:
+subject [System.Collections.Generic.Dictionary<System.Int32, System.Int32>]
+
+    Expected key
+4
+    but was not found
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.ShouldFailWhenDictionaryValueDiffers.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.ShouldFailWhenDictionaryValueDiffers.approved.txt
@@ -1,10 +1,11 @@
 Comparing object equivalence, at path:
-subject [System.Int32]
+subject [System.Collections.Generic.Dictionary<System.String, System.Int32>]
+    ["b"] [System.Int32]
 
     Expected value to be
-5
+3
     but was
-"Hello"
+2
 
 Additional Info:
     Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/DictionaryScenario.cs
@@ -1,0 +1,94 @@
+namespace Shouldly.Tests.ShouldBeEquivalentTo;
+
+public class DictionaryScenario
+{
+    [Fact]
+    public void ShouldPassWhenDictionariesMatch()
+    {
+        var subject = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var expected = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldPassWhenDictionariesMatchInDifferentInsertionOrder()
+    {
+        var subject = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var expected = new Dictionary<string, int> { ["b"] = 2, ["a"] = 1 };
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldPassWhenDictionaryValuesAreComplex()
+    {
+        var subject = new Dictionary<string, FakeObject> { ["a"] = new() { Id = 1, Name = "One" } };
+        var expected = new Dictionary<string, FakeObject> { ["a"] = new() { Id = 1, Name = "One" } };
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldPassWhenDictionaryValuesAreCollections()
+    {
+        var subject = new Dictionary<string, List<int>> { ["a"] = [1, 2] };
+        var expected = new Dictionary<string, List<int>> { ["a"] = [1, 2] };
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldFailWhenDictionaryIsTooShort()
+    {
+        var subject = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 5
+        };
+        var expected = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 5,
+            [4] = 8
+        };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(expected, "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldFailWhenDictionaryIsTooLong()
+    {
+        var subject = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 5,
+            [4] = 8,
+            [5] = 13
+        };
+        var expected = new Dictionary<int, int>
+        {
+            [1] = 2,
+            [2] = 3,
+            [3] = 5,
+            [4] = 8
+        };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(expected, "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldFailWhenDictionaryValueDiffers()
+    {
+        var subject = new Dictionary<string, int> { ["a"] = 1, ["b"] = 2 };
+        var expected = new Dictionary<string, int> { ["a"] = 1, ["b"] = 3 };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(expected, "Some additional context"));
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/EqualsOverrideScenario.ShouldFailWhenAnEqualsEqualPairMasksALaterStructurallyDifferentPair.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/EqualsOverrideScenario.ShouldFailWhenAnEqualsEqualPairMasksALaterStructurallyDifferentPair.approved.txt
@@ -1,0 +1,12 @@
+Comparing object equivalence, at path:
+subject [Shouldly.Tests.ShouldBeEquivalentTo.KeyEquatableHolder]
+    Second [Shouldly.Tests.ShouldBeEquivalentTo.KeyEquatable]
+        Data [System.String]
+
+    Expected value to be
+"different"
+    but was
+"two"
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/EqualsOverrideScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/EqualsOverrideScenario.cs
@@ -1,0 +1,64 @@
+namespace Shouldly.Tests.ShouldBeEquivalentTo;
+
+public class EqualsOverrideScenario
+{
+    [Fact]
+    public void ShouldFailWhenAnEqualsEqualPairMasksALaterStructurallyDifferentPair()
+    {
+        // First and Second are Equals-equal (same Key) but structurally different. Visited-pair
+        // tracking must use reference identity: keyed on the members' own Equals/GetHashCode,
+        // comparing First records the pair in a way that also "covers" Second, and the differing
+        // Data on Second is silently never compared — a false pass.
+        var subject = new KeyEquatableHolder
+        {
+            First = new KeyEquatable { Key = "k", Data = "one" },
+            Second = new KeyEquatable { Key = "k", Data = "two" }
+        };
+
+        var expected = new KeyEquatableHolder
+        {
+            First = new KeyEquatable { Key = "k", Data = "one" },
+            Second = new KeyEquatable { Key = "k", Data = "different" }
+        };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(expected, "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldPassWhenEqualsEqualPairsAreAlsoStructurallyEqual()
+    {
+        var subject = new KeyEquatableHolder
+        {
+            First = new KeyEquatable { Key = "k", Data = "one" },
+            Second = new KeyEquatable { Key = "k", Data = "two" }
+        };
+
+        var expected = new KeyEquatableHolder
+        {
+            First = new KeyEquatable { Key = "k", Data = "one" },
+            Second = new KeyEquatable { Key = "k", Data = "two" }
+        };
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+}
+
+public class KeyEquatableHolder
+{
+    public KeyEquatable? First { get; set; }
+    public KeyEquatable? Second { get; set; }
+}
+
+/// <summary>Equality is by <see cref="Key"/> only; <see cref="Data"/> is ignored by Equals.</summary>
+public class KeyEquatable
+{
+    public string? Key { get; set; }
+    public string? Data { get; set; }
+
+    public override bool Equals(object? obj) =>
+        obj is KeyEquatable other && string.Equals(Key, other.Key, StringComparison.Ordinal);
+
+    public override int GetHashCode() =>
+        Key?.GetHashCode() ?? 0;
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/FakeObject.cs
@@ -25,4 +25,7 @@ public class IndexableObject
 
     // Indexing is different to standard properties, in that indexing is a property that takes an argument.
     public string this[int index] => _indexedStrings[index];
+
+    // Without at least one comparable member the vacuous-comparison guard would trip.
+    public int Count => _indexedStrings.Count;
 }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.ShouldFailWhenComparisonSelectsNoMembers.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.ShouldFailWhenComparisonSelectsNoMembers.approved.txt
@@ -1,0 +1,9 @@
+Comparing object equivalence, at path:
+subject [System.Object]
+
+    Found no public members to compare on
+System.Object
+    which would make the assertion vacuously pass; cast the expectation to a concrete type or assert on specific members instead
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.ShouldFailWhenExpectationMemberIsMissingOnActual.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.ShouldFailWhenExpectationMemberIsMissingOnActual.approved.txt
@@ -1,0 +1,11 @@
+Comparing object equivalence, at path:
+subject [<anonymous type>]
+    Nickname
+
+    Expected a public member named
+"Nickname"
+    but was not found on
+Shouldly.Tests.ShouldBeEquivalentTo.FakeObject
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.ShouldFailWhenObjectContainsInfiniteLoop.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.ShouldFailWhenObjectContainsInfiniteLoop.approved.txt
@@ -1,7 +1,7 @@
 Comparing object equivalence, at path:
 subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
     Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
-        Adjectives [System.String[]]
+        Adjectives [System.Collections.IEnumerable]
             Element [1] [System.String]
 
     Expected value to be

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.ShouldFailWhenObjectIsComplex.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.ShouldFailWhenObjectIsComplex.approved.txt
@@ -1,7 +1,7 @@
 Comparing object equivalence, at path:
 subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
     Child [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
-        Adjectives [System.String[]]
+        Adjectives [System.Collections.IEnumerable]
             Element [0] [System.String]
 
     Expected value to be

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.ShouldReportAllDifferences.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.ShouldReportAllDifferences.approved.txt
@@ -1,0 +1,22 @@
+Comparing object equivalence, found 2 differences:
+
+at path:
+subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Id [System.Int32]
+
+    Expected value to be
+6
+    but was
+5
+
+at path:
+subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Name [System.String]
+
+    Expected value to be
+"Sally"
+    but was
+"Bob"
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -169,6 +169,44 @@ public class ObjectScenario
     }
 
     [Fact]
+    public void ShouldPassWhenComplexObjectContainsPropertiesWithDifferentTypes()
+    {
+        var subject = new FakeObject
+        {
+            Id = 5,
+            Name = "Bob",
+            Adjectives = new[] { "funny", "wise" },
+            Colors = ["red", "blue"],
+            TitleField = "Mr",
+            Child = new()
+            {
+                Id = 6,
+                Name = "Sally",
+                Adjectives = new[] { "beautiful", "intelligent" },
+                Colors = ["purple", "orange"]
+            }
+        };
+
+        var expected = new FakeObject
+        {
+            Id = 5,
+            TitleField = "Mr",
+            Name = "Bob",
+            Adjectives = new List<string> { "funny", "wise" }.Where(_ => true),
+            Colors = new [] {"red", "blue"}.AsReadOnly(),
+            Child = new()
+            {
+                Id = 6,
+                Name = "Sally",
+                Adjectives = new List<string> { "beautiful", "intelligent" },
+                Colors = ["purple", "orange"]
+            }
+        };
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
     public void ShouldPassWhenObjectContainsInfiniteLoop()
     {
         var subject = new FakeObject

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -271,15 +271,52 @@ public class ObjectScenario
     }
 
     [Fact]
-    public void ShouldThrowSensibleErrorWhenIndexersUsed()
+    public void ShouldSkipIndexersWhenComparing()
     {
+        // Indexers cannot be compared (there is no general way to enumerate their values),
+        // so they are skipped rather than throwing.
         var subject = new IndexableObject(new List<string> { "foo", "bar" });
         var expected = new IndexableObject(new List<string> { "a", "b" });
-        var indexableObjectComparison = () => subject.ShouldBeEquivalentTo(expected);
 
-        indexableObjectComparison
-            .ShouldThrow<NotSupportedException>()
-            .Message
-            .ShouldBe("Comparing types that have indexers is not supported.");
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldReportAllDifferences()
+    {
+        var subject = new FakeObject { Id = 5, Name = "Bob", TitleField = "Mr" };
+        var expected = new FakeObject { Id = 6, Name = "Sally", TitleField = "Mr" };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(expected, "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldPassWhenExpectationIsAnonymousSubset()
+    {
+        var subject = new FakeObject { Id = 5, Name = "Bob", TitleField = "Mr" };
+
+        subject.ShouldBeEquivalentTo(new { Id = 5, Name = "Bob" });
+    }
+
+    [Fact]
+    public void ShouldFailWhenExpectationMemberIsMissingOnActual()
+    {
+        var subject = new FakeObject { Id = 5, Name = "Bob" };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(new { Id = 5, Nickname = "Bobby" }, "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldFailWhenComparisonSelectsNoMembers()
+    {
+        // A comparison that selects zero members would pass without asserting anything;
+        // fail loudly instead of silently weakening the assertion.
+        var subject = new object();
+        var expected = new object();
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(expected, "Some additional context"));
     }
 }

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/ObjectScenario.cs
@@ -169,6 +169,46 @@ public class ObjectScenario
     }
 
     [Fact]
+    public void ShouldPassWhenComplexObjectContainsPropertiesWithDifferentTypesUsingOptionsOverload()
+    {
+        var subject = new FakeObject
+        {
+            Id = 5,
+            Name = "Bob",
+            Adjectives = new[] { "funny", "wise" },
+            Colors = ["red", "blue"],
+            TitleField = "Mr",
+            Child = new()
+            {
+                Id = 6,
+                Name = "Sally",
+                Adjectives = new[] { "beautiful", "intelligent" },
+                Colors = ["purple", "orange"]
+            }
+        };
+
+        var expected = new FakeObject
+        {
+            Id = 5,
+            TitleField = "Mr",
+            Name = "Bob",
+            Adjectives = new List<string> { "funny", "wise" }.Where(_ => true),
+            Colors = new [] {"red", "blue"}.AsReadOnly(),
+            Child = new()
+            {
+                Id = 6,
+                Name = "Sally",
+                Adjectives = new List<string> { "beautiful", "intelligent" },
+                Colors = ["purple", "orange"]
+            }
+        };
+
+        var options = new EquivalencyOptions();
+
+        subject.ShouldBeEquivalentTo(expected, options);
+    }
+
+    [Fact]
     public void ShouldPassWhenComplexObjectContainsPropertiesWithDifferentTypes()
     {
         var subject = new FakeObject

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.ShouldFailWhenElementIsMissingWithIgnoreOrder.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.ShouldFailWhenElementIsMissingWithIgnoreOrder.approved.txt
@@ -1,0 +1,9 @@
+Comparing object equivalence, at path:
+subject [System.Collections.Generic.List<System.Int32>]
+
+    Expected an element equivalent to
+3
+    but was not found
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.ShouldFailWhenIgnoringEveryMemberOfAType.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.ShouldFailWhenIgnoringEveryMemberOfAType.approved.txt
@@ -1,0 +1,9 @@
+Comparing object equivalence, at path:
+subject [Shouldly.Tests.ShouldBeEquivalentTo.OptionsScenario+SingleMember]
+
+    Found no public members to compare on
+Shouldly.Tests.ShouldBeEquivalentTo.OptionsScenario+SingleMember
+    which would make the assertion vacuously pass; cast the expectation to a concrete type or assert on specific members instead
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.ShouldFailWhenNonIgnoredMemberDiffers.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.ShouldFailWhenNonIgnoredMemberDiffers.approved.txt
@@ -1,0 +1,11 @@
+Comparing object equivalence, at path:
+subject [Shouldly.Tests.ShouldBeEquivalentTo.FakeObject]
+    Id [System.Int32]
+
+    Expected value to be
+2
+    but was
+1
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.ShouldFailWhenOrderDiffersAndIgnoreOrderIsNotSet.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.ShouldFailWhenOrderDiffersAndIgnoreOrderIsNotSet.approved.txt
@@ -1,0 +1,22 @@
+Comparing object equivalence, found 2 differences:
+
+at path:
+subject [System.Collections.Generic.List<System.Int32>]
+    Element [0] [System.Int32]
+
+    Expected value to be
+3
+    but was
+1
+
+at path:
+subject [System.Collections.Generic.List<System.Int32>]
+    Element [2] [System.Int32]
+
+    Expected value to be
+1
+    but was
+3
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.cs
@@ -49,6 +49,27 @@ public class OptionsScenario
     }
 
     [Fact]
+    public void ShouldMatchAcrossHeterogeneousElementsWithIgnoreOrder()
+    {
+        // The looser {Id=1} expectation is equivalent to both actual elements, but the stricter
+        // {Id=1,Name="x"} expectation is equivalent to only one of them. A greedy first-match would
+        // let {Id=1} claim that element and then report the stricter expectation as missing;
+        // maximum bipartite matching pairs them so a complete matching is found.
+        var subject = new object[]
+        {
+            new { Id = 1, Name = "x" },
+            new { Id = 1, Name = "y" }
+        };
+        var expected = new object[]
+        {
+            new { Id = 1 },
+            new { Id = 1, Name = "x" }
+        };
+
+        subject.ShouldBeEquivalentTo(expected, new EquivalencyOptions { IgnoreOrder = true });
+    }
+
+    [Fact]
     public void ShouldPassWhenDifferingMemberIsIgnored()
     {
         var subject = new FakeObject { Id = 1, Name = "One" };

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/OptionsScenario.cs
@@ -1,0 +1,102 @@
+namespace Shouldly.Tests.ShouldBeEquivalentTo;
+
+public class OptionsScenario
+{
+    [Fact]
+    public void ShouldPassWhenOrderDiffersAndIgnoreOrderIsSet()
+    {
+        var subject = new List<FakeObject>
+        {
+            new() { Id = 1, Name = "One" },
+            new() { Id = 2, Name = "Two" }
+        };
+        var expected = new List<FakeObject>
+        {
+            new() { Id = 2, Name = "Two" },
+            new() { Id = 1, Name = "One" }
+        };
+
+        subject.ShouldBeEquivalentTo(expected, new EquivalencyOptions { IgnoreOrder = true });
+    }
+
+    [Fact]
+    public void ShouldPassWhenNestedCollectionOrderDiffersAndIgnoreOrderIsSet()
+    {
+        var subject = new FakeObject { Id = 1, Colors = ["red", "blue"] };
+        var expected = new FakeObject { Id = 1, Colors = ["blue", "red"] };
+
+        subject.ShouldBeEquivalentTo(expected, new EquivalencyOptions { IgnoreOrder = true });
+    }
+
+    [Fact]
+    public void ShouldFailWhenOrderDiffersAndIgnoreOrderIsNotSet()
+    {
+        var subject = new List<int> { 1, 2, 3 };
+        var expected = new List<int> { 3, 2, 1 };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(expected, "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldFailWhenElementIsMissingWithIgnoreOrder()
+    {
+        var subject = new List<int> { 1, 2, 6 };
+        var expected = new List<int> { 1, 2, 3 };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(expected, new EquivalencyOptions { IgnoreOrder = true }, "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldPassWhenDifferingMemberIsIgnored()
+    {
+        var subject = new FakeObject { Id = 1, Name = "One" };
+        var expected = new FakeObject { Id = 1, Name = "Completely different" };
+
+        var options = new EquivalencyOptions { MembersToIgnore = { "Name" } };
+
+        subject.ShouldBeEquivalentTo(expected, options);
+    }
+
+    [Fact]
+    public void ShouldIgnoreMembersAnywhereInTheGraph()
+    {
+        var subject = new FakeObject { Id = 1, Child = new() { Id = 2, Name = "child" } };
+        var expected = new FakeObject { Id = 1, Child = new() { Id = 2, Name = "different child" } };
+
+        var options = new EquivalencyOptions { MembersToIgnore = { "Name" } };
+
+        subject.ShouldBeEquivalentTo(expected, options);
+    }
+
+    [Fact]
+    public void ShouldFailWhenNonIgnoredMemberDiffers()
+    {
+        var subject = new FakeObject { Id = 1, Name = "One" };
+        var expected = new FakeObject { Id = 2, Name = "Completely different" };
+
+        var options = new EquivalencyOptions { MembersToIgnore = { "Name" } };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(expected, options, "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldFailWhenIgnoringEveryMemberOfAType()
+    {
+        // Ignoring every member would make the assertion vacuously pass; the guard fails instead.
+        var subject = new SingleMember { Name = "One" };
+        var expected = new SingleMember { Name = "Two" };
+
+        var options = new EquivalencyOptions { MembersToIgnore = { "Name" } };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(expected, options, "Some additional context"));
+    }
+
+    public class SingleMember
+    {
+        public string? Name { get; set; }
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.ShouldFailWhenSetIsTooLong.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.ShouldFailWhenSetIsTooLong.approved.txt
@@ -1,10 +1,11 @@
 Comparing object equivalence, at path:
-subject [System.Int32]
+subject [System.Collections.Generic.HashSet<System.Int32>]
+    Count
 
     Expected value to be
-5
+4
     but was
-"Hello"
+5
 
 Additional Info:
     Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.ShouldFailWhenSetIsTooShort.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.ShouldFailWhenSetIsTooShort.approved.txt
@@ -1,10 +1,11 @@
 Comparing object equivalence, at path:
-subject [System.Int32]
+subject [System.Collections.Generic.HashSet<System.Int32>]
+    Count
 
     Expected value to be
 5
     but was
-"Hello"
+4
 
 Additional Info:
     Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.ShouldFailWhenSetsDoNotMatch.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.ShouldFailWhenSetsDoNotMatch.approved.txt
@@ -1,0 +1,9 @@
+Comparing object equivalence, at path:
+subject [System.Collections.Generic.HashSet<System.Int32>]
+
+    Expected an element equivalent to
+5
+    but was not found
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.cs
@@ -19,6 +19,17 @@ public class SetScenario
     }
 
     [Fact]
+    public void ShouldPassForLargeSetsInDifferentOrder()
+    {
+        // Exercises the greedy fast path of the order-insensitive matcher: every element matches,
+        // so no augmenting-path fallback is needed even at size.
+        var subject = new HashSet<int>(Enumerable.Range(0, 2000));
+        var expected = new HashSet<int>(Enumerable.Range(0, 2000).Reverse());
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
     public void ShouldFailWhenSetIsTooShort()
     {
         var subject = new HashSet<int> { 1, 2, 3, 4 };

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/SetScenario.cs
@@ -1,0 +1,47 @@
+namespace Shouldly.Tests.ShouldBeEquivalentTo;
+
+public class SetScenario
+{
+    [Fact]
+    public void ShouldPassWhenSetsMatch()
+    {
+        var subject = new HashSet<int> { 1, 2, 3 };
+
+        subject.ShouldBeEquivalentTo(new HashSet<int> { 1, 2, 3 });
+    }
+
+    [Fact]
+    public void ShouldPassWhenSetsMatchInDifferentOrder()
+    {
+        var subject = new HashSet<int> { 1, 2, 3 };
+
+        subject.ShouldBeEquivalentTo(new HashSet<int> { 3, 2, 1 });
+    }
+
+    [Fact]
+    public void ShouldFailWhenSetIsTooShort()
+    {
+        var subject = new HashSet<int> { 1, 2, 3, 4 };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(new HashSet<int> { 1, 2, 3, 4, 5 }, "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldFailWhenSetIsTooLong()
+    {
+        var subject = new HashSet<int> { 1, 2, 3, 4, 5 };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(new HashSet<int> { 1, 2, 3, 4 }, "Some additional context"));
+    }
+
+    [Fact]
+    public void ShouldFailWhenSetsDoNotMatch()
+    {
+        var subject = new HashSet<int> { 1, 2, 6, 4, 3 };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(new HashSet<int> { 1, 2, 3, 4, 5 }, "Some additional context"));
+    }
+}

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.ShouldFailWhenTypesDiffer.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.ShouldFailWhenTypesDiffer.approved.txt
@@ -1,10 +1,11 @@
 Comparing object equivalence, at path:
-subject [System.Int32]
+subject [Shouldly.Tests.ShouldBeEquivalentTo.TypeScenario+TypeHolder]
+    Type [System.Type]
 
     Expected value to be
-5
+System.String
     but was
-"Hello"
+System.Int32
 
 Additional Info:
     Some additional context

--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/TypeScenario.cs
@@ -9,4 +9,41 @@ public class TypeScenario
         Verify.ShouldFail(() =>
             subject.ShouldBeEquivalentTo(5, "Some additional context"));
     }
+
+    [Fact]
+    public void ShouldPassWhenTypesAreEqual()
+    {
+        typeof(int).ShouldBeEquivalentTo(typeof(int));
+    }
+
+    [Fact]
+    public void ShouldPassWhenTypeIsPropertyOfContainingObject()
+    {
+        var subject = new TypeHolder { Type = typeof(int) };
+        var expected = new TypeHolder { Type = typeof(int) };
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldPassForListOfTypes()
+    {
+        new List<Type> { typeof(int), typeof(string) }
+            .ShouldBeEquivalentTo(new List<Type> { typeof(int), typeof(string) });
+    }
+
+    [Fact]
+    public void ShouldFailWhenTypesDiffer()
+    {
+        var subject = new TypeHolder { Type = typeof(int) };
+        var expected = new TypeHolder { Type = typeof(string) };
+
+        Verify.ShouldFail(() =>
+            subject.ShouldBeEquivalentTo(expected, "Some additional context"));
+    }
+
+    public class TypeHolder
+    {
+        public Type Type { get; set; } = null!;
+    }
 }

--- a/src/Shouldly/Equivalency/EquivalencyComparison.cs
+++ b/src/Shouldly/Equivalency/EquivalencyComparison.cs
@@ -208,14 +208,18 @@ internal sealed class EquivalencyComparison
             return;
         }
 
-        var unmatched = new List<object?>(actualList);
-        foreach (var expectedElement in expectedList)
+        // Pair expected elements to distinct equivalent actual elements with maximum bipartite
+        // matching, so a complete pairing is found whenever one exists. A greedy first-match can
+        // otherwise orphan an expected element whose only equivalent partner was already claimed.
+        var matchOfExpected = MatchByEquivalence(
+            expectedList.Count,
+            actualList.Count,
+            (e, a) => IsEquivalent(actualList[a], expectedList[e], elementType));
+
+        for (var i = 0; i < expectedList.Count; i++)
         {
-            var matchIndex = unmatched.FindIndex(candidate => IsEquivalent(candidate, expectedElement, elementType));
-            if (matchIndex < 0)
-                AddDifference(EquivalencyDifferenceKind.MissingElement, path, expectedElement, actual);
-            else
-                unmatched.RemoveAt(matchIndex);
+            if (matchOfExpected[i] < 0)
+                AddDifference(EquivalencyDifferenceKind.MissingElement, path, expectedList[i], actual);
         }
     }
 
@@ -229,24 +233,40 @@ internal sealed class EquivalencyComparison
         }
 
         var expectedEntries = shape.GetEntries(expected).ToList();
-        var unmatched = actualShape.GetEntries(actual).ToList();
+        var actualEntries = actualShape.GetEntries(actual).ToList();
 
-        foreach (var expectedEntry in expectedEntries)
+        // Match keys with maximum bipartite matching (see CompareUnordered) so that, when keys are
+        // themselves complex and a key is equivalent to more than one candidate, a greedy pairing
+        // cannot wrongly leave a matchable key unmatched.
+        var matchOfExpected = MatchByEquivalence(
+            expectedEntries.Count,
+            actualEntries.Count,
+            (e, a) => IsEquivalent(actualEntries[a].Key, expectedEntries[e].Key, shape.KeyType));
+
+        var matchedActual = new bool[actualEntries.Count];
+
+        for (var i = 0; i < expectedEntries.Count; i++)
         {
-            var matchIndex = unmatched.FindIndex(candidate => IsEquivalent(candidate.Key, expectedEntry.Key, shape.KeyType));
+            var matchIndex = matchOfExpected[i];
             if (matchIndex < 0)
             {
-                AddDifference(EquivalencyDifferenceKind.MissingKey, path, expectedEntry.Key, actual);
+                AddDifference(EquivalencyDifferenceKind.MissingKey, path, expectedEntries[i].Key, actual);
                 continue;
             }
 
-            var actualEntry = unmatched[matchIndex];
-            unmatched.RemoveAt(matchIndex);
-            CompareNodes(actualEntry.Value, expectedEntry.Value, shape.ValueType, Append(path, $"[{expectedEntry.Key.ToStringAwesomely()}]"));
+            matchedActual[matchIndex] = true;
+            CompareNodes(actualEntries[matchIndex].Value, expectedEntries[i].Value, shape.ValueType, Append(path, $"[{expectedEntries[i].Key.ToStringAwesomely()}]"));
         }
 
-        if (unmatched.Count > 0)
-            AddDifference(EquivalencyDifferenceKind.UnexpectedKeys, path, expected, unmatched.Select(entry => entry.Key).ToList());
+        var unexpectedKeys = new List<object?>();
+        for (var j = 0; j < actualEntries.Count; j++)
+        {
+            if (!matchedActual[j])
+                unexpectedKeys.Add(actualEntries[j].Key);
+        }
+
+        if (unexpectedKeys.Count > 0)
+            AddDifference(EquivalencyDifferenceKind.UnexpectedKeys, path, expected, unexpectedKeys);
     }
 
     /// <summary>Runs a full sub-comparison, discarding differences; used for order-insensitive matching.</summary>
@@ -255,6 +275,96 @@ internal sealed class EquivalencyComparison
         var comparison = new EquivalencyComparison(_shapes, _options);
         comparison.CompareNodes(actual, expected, declaredType, []);
         return comparison._differences.Count == 0;
+    }
+
+    /// <summary>
+    /// Maximum bipartite matching between expected and actual elements, where
+    /// <paramref name="equivalent"/>(e, a) reports whether expected element e is equivalent to
+    /// actual element a. Returns an array indexed by expected element giving its matched actual
+    /// index, or -1 when it cannot be matched.
+    ///
+    /// A greedy first pass resolves the common case (everything matches, or a genuine mismatch)
+    /// without a full N*N equivalence matrix; only the expected elements it leaves unmatched fall
+    /// back to augmenting-path search, which can reshuffle earlier assignments to free a partner.
+    /// Equivalence results are memoized, so no element pair is ever compared twice. This keeps the
+    /// order-insensitive path close to greedy cost on normal inputs while still finding a complete
+    /// matching whenever one exists.
+    /// </summary>
+    private static int[] MatchByEquivalence(int expectedCount, int actualCount, Func<int, int, bool> equivalent)
+    {
+        var cache = new Dictionary<long, bool>();
+        bool CanMatch(int expectedIndex, int actualIndex)
+        {
+            var key = (long)expectedIndex * actualCount + actualIndex;
+            if (!cache.TryGetValue(key, out var result))
+            {
+                result = equivalent(expectedIndex, actualIndex);
+                cache[key] = result;
+            }
+
+            return result;
+        }
+
+        var matchOfActual = new int[actualCount];
+        for (var actualIndex = 0; actualIndex < actualCount; actualIndex++)
+            matchOfActual[actualIndex] = -1;
+
+        // Greedy warm-start: each expected element claims the first still-free equivalent actual.
+        List<int>? unmatchedGreedily = null;
+        for (var expectedIndex = 0; expectedIndex < expectedCount; expectedIndex++)
+        {
+            var matched = false;
+            for (var actualIndex = 0; actualIndex < actualCount; actualIndex++)
+            {
+                if (matchOfActual[actualIndex] < 0 && CanMatch(expectedIndex, actualIndex))
+                {
+                    matchOfActual[actualIndex] = expectedIndex;
+                    matched = true;
+                    break;
+                }
+            }
+
+            if (!matched)
+                (unmatchedGreedily ??= []).Add(expectedIndex);
+        }
+
+        // Only the greedy leftovers can start an augmenting path; already-matched elements stay
+        // matched, so attempting to augment them would never improve the matching.
+        if (unmatchedGreedily != null)
+        {
+            foreach (var expectedIndex in unmatchedGreedily)
+                Augment(expectedIndex, matchOfActual, CanMatch, actualCount, new bool[actualCount]);
+        }
+
+        var matchOfExpected = new int[expectedCount];
+        for (var expectedIndex = 0; expectedIndex < expectedCount; expectedIndex++)
+            matchOfExpected[expectedIndex] = -1;
+
+        for (var actualIndex = 0; actualIndex < actualCount; actualIndex++)
+        {
+            if (matchOfActual[actualIndex] >= 0)
+                matchOfExpected[matchOfActual[actualIndex]] = actualIndex;
+        }
+
+        return matchOfExpected;
+
+        static bool Augment(int expectedIndex, int[] matchOfActual, Func<int, int, bool> canMatch, int actualCount, bool[] seen)
+        {
+            for (var actualIndex = 0; actualIndex < actualCount; actualIndex++)
+            {
+                if (seen[actualIndex] || !canMatch(expectedIndex, actualIndex))
+                    continue;
+
+                seen[actualIndex] = true;
+                if (matchOfActual[actualIndex] < 0 || Augment(matchOfActual[actualIndex], matchOfActual, canMatch, actualCount, seen))
+                {
+                    matchOfActual[actualIndex] = expectedIndex;
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 
     private static bool LeafEquals(object actual, object expected)

--- a/src/Shouldly/Equivalency/EquivalencyComparison.cs
+++ b/src/Shouldly/Equivalency/EquivalencyComparison.cs
@@ -1,0 +1,344 @@
+namespace Shouldly.Equivalency;
+
+/// <summary>
+/// The equivalency engine: walks the actual/expected graphs with a per-node strategy
+/// (leaf / dictionary / set / sequence / member-wise), selecting members from the
+/// expectation's declared types with subset semantics, and collects every difference
+/// instead of stopping at the first.
+/// </summary>
+internal sealed class EquivalencyComparison
+{
+    private readonly IEquivalencyShapeProvider _shapes;
+    private readonly EquivalencyOptions _options;
+    private readonly List<EquivalencyDifference> _differences = [];
+    private readonly HashSet<VisitedPair> _visitedPairs = [];
+
+    private EquivalencyComparison(IEquivalencyShapeProvider shapes, EquivalencyOptions options)
+    {
+        _shapes = shapes;
+        _options = options;
+    }
+
+    public static void Assert(
+        object? actual,
+        object? expected,
+        EquivalencyOptions options,
+        string? customMessage,
+        string shouldlyMethod,
+        string? actualExpression)
+    {
+        var comparison = new EquivalencyComparison(EquivalencyShapes.Current, options);
+        comparison.CompareNodes(actual, expected, null, []);
+
+        if (comparison._differences.Count == 0)
+            return;
+
+        throw new ShouldAssertException(
+            new ExpectedEquivalenceShouldlyMessage(comparison._differences, expected, actual, customMessage, shouldlyMethod, actualExpression).ToString());
+    }
+
+    private void CompareNodes(object? actual, object? expected, Type? declaredType, List<string> path)
+    {
+        if (actual is null || expected is null)
+        {
+            // The path is deliberately left un-annotated with a type: with one side null there
+            // is no single compared type to report.
+            if (!(actual is null && expected is null))
+                AddDifference(EquivalencyDifferenceKind.ValueMismatch, path, expected, actual);
+
+            return;
+        }
+
+        // Member selection is driven by declared types; members declared as object fall back to
+        // the expectation's runtime type so anonymous types and object-typed members compare
+        // their real members rather than none.
+        var comparisonType = declaredType is null || declaredType == typeof(object)
+            ? expected.GetType()
+            : declaredType;
+        comparisonType = Nullable.GetUnderlyingType(comparisonType) ?? comparisonType;
+
+        var annotatedPath = AnnotateWithType(path, comparisonType);
+
+        var shape = _shapes.GetShape(comparisonType);
+        switch (shape.Kind)
+        {
+            case EquivalencyNodeKind.Leaf:
+                if (!LeafEquals(actual, expected))
+                    AddDifference(EquivalencyDifferenceKind.ValueMismatch, annotatedPath, expected, actual);
+                break;
+
+            case EquivalencyNodeKind.Dictionary:
+                CompareDictionaries(actual, expected, shape, annotatedPath);
+                break;
+
+            case EquivalencyNodeKind.Set:
+                CompareUnordered(actual, expected, shape.ElementType, annotatedPath);
+                break;
+
+            case EquivalencyNodeKind.Sequence:
+                CompareSequences(actual, expected, shape.ElementType, annotatedPath);
+                break;
+
+            default:
+                CompareComplex(actual, expected, shape, annotatedPath);
+                break;
+        }
+    }
+
+    private void CompareComplex(object actual, object expected, EquivalencyTypeShape shape, List<string> path)
+    {
+        if (ReferenceEquals(actual, expected))
+            return;
+
+        // Cycle tracking by reference identity; value types cannot participate in cycles.
+        if (actual is not ValueType && expected is not ValueType && !_visitedPairs.Add(new(actual, expected)))
+            return;
+
+        var members = shape.Members;
+        if (members.Count == 0)
+        {
+            AddDifference(EquivalencyDifferenceKind.VacuousComparison, path, expected, actual, GetDisplayName(shape.Type));
+            return;
+        }
+
+        var actualType = actual.GetType();
+        var actualShape = actualType == shape.Type ? shape : _shapes.GetShape(actualType);
+
+        foreach (var member in members)
+        {
+            var memberPath = Append(path, member.Name);
+            var actualMember = actualShape.FindMember(member.Name);
+            if (actualMember is null)
+            {
+                AddDifference(EquivalencyDifferenceKind.MissingMember, memberPath, member.Name, actual, GetDisplayName(actualType));
+                continue;
+            }
+
+            CompareNodes(actualMember.GetValue(actual), member.GetValue(expected), member.DeclaredType, memberPath);
+        }
+    }
+
+    private void CompareSequences(object actual, object expected, Type? elementType, List<string> path)
+    {
+        if (expected is Array { Rank: > 1 } || actual is Array { Rank: > 1 })
+        {
+            CompareMultidimensionalArrays(actual, expected, elementType, path);
+            return;
+        }
+
+        if (actual is not IEnumerable actualEnumerable)
+        {
+            AddDifference(EquivalencyDifferenceKind.ValueMismatch, path, expected, actual);
+            return;
+        }
+
+        var expectedList = ((IEnumerable)expected).Cast<object?>().ToList();
+        var actualList = actualEnumerable.Cast<object?>().ToList();
+
+        if (actualList.Count != expectedList.Count)
+        {
+            AddDifference(EquivalencyDifferenceKind.ValueMismatch, Append(path, "Count"), expectedList.Count, actualList.Count);
+            return;
+        }
+
+        for (var i = 0; i < actualList.Count; i++)
+            CompareNodes(actualList[i], expectedList[i], elementType, Append(path, $"Element [{i}]"));
+    }
+
+    private void CompareMultidimensionalArrays(object actual, object expected, Type? elementType, List<string> path)
+    {
+        if (expected is not Array expectedArray || actual is not Array actualArray || actualArray.Rank != expectedArray.Rank)
+        {
+            AddDifference(EquivalencyDifferenceKind.ValueMismatch, path, expected, actual);
+            return;
+        }
+
+        for (var dimension = 0; dimension < expectedArray.Rank; dimension++)
+        {
+            if (actualArray.GetLength(dimension) != expectedArray.GetLength(dimension))
+            {
+                AddDifference(
+                    EquivalencyDifferenceKind.ValueMismatch,
+                    Append(path, $"GetLength({dimension})"),
+                    expectedArray.GetLength(dimension),
+                    actualArray.GetLength(dimension));
+                return;
+            }
+        }
+
+        var indices = new int[expectedArray.Rank];
+        var expectedFlat = expectedArray.Cast<object?>().ToList();
+        var actualFlat = actualArray.Cast<object?>().ToList();
+        for (var i = 0; i < expectedFlat.Count; i++)
+        {
+            CompareNodes(actualFlat[i], expectedFlat[i], elementType, Append(path, $"Element [{string.Join(",", indices)}]"));
+
+            for (var dimension = expectedArray.Rank - 1; dimension >= 0; dimension--)
+            {
+                if (++indices[dimension] < expectedArray.GetLength(dimension))
+                    break;
+
+                indices[dimension] = 0;
+            }
+        }
+    }
+
+    private void CompareUnordered(object actual, object expected, Type? elementType, List<string> path)
+    {
+        if (actual is not IEnumerable actualEnumerable)
+        {
+            AddDifference(EquivalencyDifferenceKind.ValueMismatch, path, expected, actual);
+            return;
+        }
+
+        var expectedList = ((IEnumerable)expected).Cast<object?>().ToList();
+        var actualList = actualEnumerable.Cast<object?>().ToList();
+
+        if (actualList.Count != expectedList.Count)
+        {
+            AddDifference(EquivalencyDifferenceKind.ValueMismatch, Append(path, "Count"), expectedList.Count, actualList.Count);
+            return;
+        }
+
+        var unmatched = new List<object?>(actualList);
+        foreach (var expectedElement in expectedList)
+        {
+            var matchIndex = unmatched.FindIndex(candidate => IsEquivalent(candidate, expectedElement, elementType));
+            if (matchIndex < 0)
+                AddDifference(EquivalencyDifferenceKind.MissingElement, path, expectedElement, actual);
+            else
+                unmatched.RemoveAt(matchIndex);
+        }
+    }
+
+    private void CompareDictionaries(object actual, object expected, EquivalencyTypeShape shape, List<string> path)
+    {
+        var actualShape = _shapes.GetShape(actual.GetType());
+        if (actualShape.Kind != EquivalencyNodeKind.Dictionary)
+        {
+            AddDifference(EquivalencyDifferenceKind.ValueMismatch, path, expected, actual);
+            return;
+        }
+
+        var expectedEntries = shape.GetEntries(expected).ToList();
+        var unmatched = actualShape.GetEntries(actual).ToList();
+
+        foreach (var expectedEntry in expectedEntries)
+        {
+            var matchIndex = unmatched.FindIndex(candidate => IsEquivalent(candidate.Key, expectedEntry.Key, shape.KeyType));
+            if (matchIndex < 0)
+            {
+                AddDifference(EquivalencyDifferenceKind.MissingKey, path, expectedEntry.Key, actual);
+                continue;
+            }
+
+            var actualEntry = unmatched[matchIndex];
+            unmatched.RemoveAt(matchIndex);
+            CompareNodes(actualEntry.Value, expectedEntry.Value, shape.ValueType, Append(path, $"[{expectedEntry.Key.ToStringAwesomely()}]"));
+        }
+
+        if (unmatched.Count > 0)
+            AddDifference(EquivalencyDifferenceKind.UnexpectedKeys, path, expected, unmatched.Select(entry => entry.Key).ToList());
+    }
+
+    /// <summary>Runs a full sub-comparison, discarding differences; used for order-insensitive matching.</summary>
+    private bool IsEquivalent(object? actual, object? expected, Type? declaredType)
+    {
+        var comparison = new EquivalencyComparison(_shapes, _options);
+        comparison.CompareNodes(actual, expected, declaredType, []);
+        return comparison._differences.Count == 0;
+    }
+
+    private static bool LeafEquals(object actual, object expected)
+    {
+        if (actual.GetType() != expected.GetType() && IsNumeric(actual) && IsNumeric(expected))
+            return NumericEquals(actual, expected);
+
+        return actual.Equals(expected);
+    }
+
+    private static bool IsNumeric(object value) =>
+        value is not Enum
+        && Convert.GetTypeCode(value) is
+            TypeCode.SByte or TypeCode.Byte or
+            TypeCode.Int16 or TypeCode.UInt16 or
+            TypeCode.Int32 or TypeCode.UInt32 or
+            TypeCode.Int64 or TypeCode.UInt64 or
+            TypeCode.Single or TypeCode.Double or
+            TypeCode.Decimal;
+
+    private static bool NumericEquals(object actual, object expected)
+    {
+        if (actual is float or double || expected is float or double)
+            return Convert.ToDouble(actual).Equals(Convert.ToDouble(expected));
+
+        // Integral and decimal values compare exactly through decimal.
+        return Convert.ToDecimal(actual) == Convert.ToDecimal(expected);
+    }
+
+    private void AddDifference(EquivalencyDifferenceKind kind, List<string> path, object? expected, object? actual, string? detail = null) =>
+        _differences.Add(new(kind, path, expected, actual, detail));
+
+    private static List<string> AnnotateWithType(List<string> path, Type type)
+    {
+        var annotated = new List<string>(path);
+        var typeName = $" [{GetDisplayName(type)}]";
+        if (annotated.Count == 0)
+            annotated.Add(typeName);
+        else
+            annotated[annotated.Count - 1] += typeName;
+
+        return annotated;
+    }
+
+    /// <summary>
+    /// A stable, readable type name: generic arguments rendered recursively rather than
+    /// assembly-qualified (which would leak runtime versions into failure messages), and
+    /// compiler-generated anonymous type names hidden.
+    /// </summary>
+    private static string GetDisplayName(Type type)
+    {
+        if (type.IsArray)
+            return GetDisplayName(type.GetElementType()!) + "[" + new string(',', type.GetArrayRank() - 1) + "]";
+
+        if (Nullable.GetUnderlyingType(type) is { } underlying)
+            return GetDisplayName(underlying) + "?";
+
+        if (!type.IsGenericType)
+            return type.FullName ?? type.Name;
+
+        if (type.Name.Contains("AnonymousType"))
+            return "<anonymous type>";
+
+        var name = type.FullName ?? type.Name;
+        var backtick = name.IndexOf('`');
+        if (backtick >= 0)
+            name = name.Substring(0, backtick);
+
+        return $"{name}<{string.Join(", ", type.GetGenericArguments().Select(GetDisplayName))}>";
+    }
+
+    private static List<string> Append(List<string> path, string segment) =>
+        [.. path, segment];
+
+    private readonly struct VisitedPair : IEquatable<VisitedPair>
+    {
+        private readonly object _actual;
+        private readonly object _expected;
+
+        public VisitedPair(object actual, object expected)
+        {
+            _actual = actual;
+            _expected = expected;
+        }
+
+        public bool Equals(VisitedPair other) =>
+            ReferenceEquals(_actual, other._actual) && ReferenceEquals(_expected, other._expected);
+
+        public override bool Equals(object? obj) =>
+            obj is VisitedPair other && Equals(other);
+
+        public override int GetHashCode() =>
+            (RuntimeHelpers.GetHashCode(_actual) * 397) ^ RuntimeHelpers.GetHashCode(_expected);
+    }
+}

--- a/src/Shouldly/Equivalency/EquivalencyComparison.cs
+++ b/src/Shouldly/Equivalency/EquivalencyComparison.cs
@@ -94,18 +94,17 @@ internal sealed class EquivalencyComparison
         if (actual is not ValueType && expected is not ValueType && !_visitedPairs.Add(new(actual, expected)))
             return;
 
-        var members = shape.Members;
-        if (members.Count == 0)
-        {
-            AddDifference(EquivalencyDifferenceKind.VacuousComparison, path, expected, actual, GetDisplayName(shape.Type));
-            return;
-        }
-
         var actualType = actual.GetType();
         var actualShape = actualType == shape.Type ? shape : _shapes.GetShape(actualType);
 
-        foreach (var member in members)
+        var comparedAny = false;
+        foreach (var member in shape.Members)
         {
+            if (_options.MembersToIgnore.Contains(member.Name))
+                continue;
+
+            comparedAny = true;
+
             var memberPath = Append(path, member.Name);
             var actualMember = actualShape.FindMember(member.Name);
             if (actualMember is null)
@@ -116,6 +115,9 @@ internal sealed class EquivalencyComparison
 
             CompareNodes(actualMember.GetValue(actual), member.GetValue(expected), member.DeclaredType, memberPath);
         }
+
+        if (!comparedAny)
+            AddDifference(EquivalencyDifferenceKind.VacuousComparison, path, expected, actual, GetDisplayName(shape.Type));
     }
 
     private void CompareSequences(object actual, object expected, Type? elementType, List<string> path)
@@ -123,6 +125,12 @@ internal sealed class EquivalencyComparison
         if (expected is Array { Rank: > 1 } || actual is Array { Rank: > 1 })
         {
             CompareMultidimensionalArrays(actual, expected, elementType, path);
+            return;
+        }
+
+        if (_options.IgnoreOrder)
+        {
+            CompareUnordered(actual, expected, elementType, path);
             return;
         }
 

--- a/src/Shouldly/Equivalency/EquivalencyDifference.cs
+++ b/src/Shouldly/Equivalency/EquivalencyDifference.cs
@@ -1,0 +1,49 @@
+namespace Shouldly.Equivalency;
+
+internal enum EquivalencyDifferenceKind
+{
+    /// <summary>The values at the path are not equal.</summary>
+    ValueMismatch,
+
+    /// <summary>A member present on the expectation does not exist on the actual object.</summary>
+    MissingMember,
+
+    /// <summary>A key present in the expected dictionary was not found in the actual dictionary.</summary>
+    MissingKey,
+
+    /// <summary>The actual dictionary contains keys the expectation does not.</summary>
+    UnexpectedKeys,
+
+    /// <summary>No element in the actual collection is equivalent to an expected element (order-insensitive).</summary>
+    MissingElement,
+
+    /// <summary>The comparison selected zero members, which would make the assertion vacuously pass.</summary>
+    VacuousComparison,
+}
+
+/// <summary>
+/// One difference found while comparing two object graphs, anchored to a path from the root.
+/// </summary>
+internal sealed class EquivalencyDifference
+{
+    public EquivalencyDifference(EquivalencyDifferenceKind kind, IReadOnlyList<string> pathSegments, object? expected, object? actual, string? detail = null)
+    {
+        Kind = kind;
+        PathSegments = pathSegments;
+        Expected = expected;
+        Actual = actual;
+        Detail = detail;
+    }
+
+    public EquivalencyDifferenceKind Kind { get; }
+
+    /// <summary>Path segments from the root, each annotated with the compared type where known.</summary>
+    public IReadOnlyList<string> PathSegments { get; }
+
+    public object? Expected { get; }
+
+    public object? Actual { get; }
+
+    /// <summary>Kind-specific detail, e.g. the type name a member was missing on.</summary>
+    public string? Detail { get; }
+}

--- a/src/Shouldly/Equivalency/EquivalencyNodeKind.cs
+++ b/src/Shouldly/Equivalency/EquivalencyNodeKind.cs
@@ -1,0 +1,22 @@
+namespace Shouldly.Equivalency;
+
+/// <summary>
+/// The comparison strategy for a node in the object graph, selected from the node's type.
+/// </summary>
+internal enum EquivalencyNodeKind
+{
+    /// <summary>Compared with <see cref="object.Equals(object)"/> (plus lossless cross-numeric equality).</summary>
+    Leaf,
+
+    /// <summary>Matched by key; values compared recursively.</summary>
+    Dictionary,
+
+    /// <summary>Order-insensitive element matching.</summary>
+    Set,
+
+    /// <summary>Order-sensitive element-by-element comparison; container type ignored.</summary>
+    Sequence,
+
+    /// <summary>Member-wise recursive comparison over public properties and fields.</summary>
+    Complex,
+}

--- a/src/Shouldly/Equivalency/EquivalencyShapes.cs
+++ b/src/Shouldly/Equivalency/EquivalencyShapes.cs
@@ -1,0 +1,38 @@
+namespace Shouldly.Equivalency;
+
+/// <summary>
+/// Resolves the shape provider the equivalency engine uses. In the box this is the reflection
+/// provider, gated behind the "Shouldly.Equivalency.IsReflectionEnabledByDefault" feature switch
+/// (the same pattern as System.Text.Json's reflection default): trimmed/AOT publishes can disable
+/// the switch so the reflection path is removed entirely, and a companion source-generation
+/// package can register an AOT-safe provider instead.
+/// </summary>
+internal static class EquivalencyShapes
+{
+    private const string ReflectionSwitchName = "Shouldly.Equivalency.IsReflectionEnabledByDefault";
+
+    private static IEquivalencyShapeProvider? _customProvider;
+
+    internal static bool IsReflectionEnabledByDefault =>
+        !AppContext.TryGetSwitch(ReflectionSwitchName, out var enabled) || enabled;
+
+    /// <summary>Registers a replacement provider (used by source-generated backends).</summary>
+    internal static void SetProvider(IEquivalencyShapeProvider? provider) =>
+        _customProvider = provider;
+
+    internal static IEquivalencyShapeProvider Current =>
+        _customProvider
+        ?? (IsReflectionEnabledByDefault
+            ? GetReflectionProvider()
+            : throw new NotSupportedException(
+                $"Reflection-based equivalency comparison is disabled (the \"{ReflectionSwitchName}\" feature switch is off) " +
+                "and no equivalency shape provider is registered. Reference the Shouldly equivalency source-generation " +
+                "package and register shapes for the compared types, or re-enable the feature switch."));
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "Guarded by the Shouldly.Equivalency.IsReflectionEnabledByDefault feature switch. " +
+                        "Trimmed publishes that disable the switch stub this property to false (ILLink.Substitutions.xml), " +
+                        "removing the reflection provider entirely; comparisons then require a registered provider.")]
+    private static IEquivalencyShapeProvider GetReflectionProvider() =>
+        ReflectionShapeProvider.Instance;
+}

--- a/src/Shouldly/Equivalency/EquivalencyTypeShape.cs
+++ b/src/Shouldly/Equivalency/EquivalencyTypeShape.cs
@@ -1,0 +1,42 @@
+namespace Shouldly.Equivalency;
+
+/// <summary>
+/// The engine's view of a type: its comparison strategy plus read-only accessors for members,
+/// elements, and dictionary entries. The in-box implementation is reflection-based
+/// (<see cref="ReflectionShapeProvider"/>); the abstraction exists so a source-generated,
+/// AOT-safe provider can be swapped in without touching the engine.
+/// </summary>
+internal abstract class EquivalencyTypeShape
+{
+    public abstract Type Type { get; }
+
+    public abstract EquivalencyNodeKind Kind { get; }
+
+    /// <summary>Public instance fields and readable, non-indexer properties (Complex nodes).</summary>
+    public abstract IReadOnlyList<EquivalencyMemberShape> Members { get; }
+
+    public abstract EquivalencyMemberShape? FindMember(string name);
+
+    /// <summary>The declared element type of a Sequence or Set, when statically known.</summary>
+    public abstract Type? ElementType { get; }
+
+    /// <summary>The declared key type of a Dictionary, when statically known.</summary>
+    public abstract Type? KeyType { get; }
+
+    /// <summary>The declared value type of a Dictionary, when statically known.</summary>
+    public abstract Type? ValueType { get; }
+
+    /// <summary>Enumerates the entries of a Dictionary instance of this shape's type.</summary>
+    public abstract IEnumerable<KeyValuePair<object?, object?>> GetEntries(object instance);
+}
+
+/// <summary>A single readable member (public instance field or property) of a Complex node.</summary>
+internal abstract class EquivalencyMemberShape
+{
+    public abstract string Name { get; }
+
+    /// <summary>The member's declared (compile-time) type, which drives the child node's comparison strategy.</summary>
+    public abstract Type DeclaredType { get; }
+
+    public abstract object? GetValue(object instance);
+}

--- a/src/Shouldly/Equivalency/IEquivalencyShapeProvider.cs
+++ b/src/Shouldly/Equivalency/IEquivalencyShapeProvider.cs
@@ -1,0 +1,9 @@
+namespace Shouldly.Equivalency;
+
+/// <summary>
+/// Supplies <see cref="EquivalencyTypeShape"/>s to the equivalency engine.
+/// </summary>
+internal interface IEquivalencyShapeProvider
+{
+    EquivalencyTypeShape GetShape(Type type);
+}

--- a/src/Shouldly/Equivalency/ReflectionShapeProvider.cs
+++ b/src/Shouldly/Equivalency/ReflectionShapeProvider.cs
@@ -1,0 +1,296 @@
+using System.Collections.Concurrent;
+
+namespace Shouldly.Equivalency;
+
+/// <summary>
+/// The in-box, reflection-based shape provider. All reflection over user types is contained
+/// here; the engine itself only consumes <see cref="EquivalencyTypeShape"/>.
+/// </summary>
+internal sealed class ReflectionShapeProvider : IEquivalencyShapeProvider
+{
+    public static readonly ReflectionShapeProvider Instance = new();
+
+    private readonly ConcurrentDictionary<Type, EquivalencyTypeShape> _cache = new();
+
+    private ReflectionShapeProvider()
+    {
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2026",
+        Justification = "This provider is only constructed while the Shouldly.Equivalency.IsReflectionEnabledByDefault feature switch is on. " +
+                        "Trimmed publishes that disable the switch remove it entirely; see EquivalencyShapes.")]
+    public EquivalencyTypeShape GetShape(Type type) =>
+        _cache.GetOrAdd(type, static t => CreateShape(t));
+
+    [RequiresUnreferencedCode("Reflects over the fields, properties, and interfaces of arbitrary types.")]
+    private static EquivalencyTypeShape CreateShape(Type type)
+    {
+        var kind = GetKind(type);
+
+        Type? elementType = null;
+        Type? keyType = null;
+        Type? valueType = null;
+        PropertyInfo? kvpKeyProperty = null;
+        PropertyInfo? kvpValueProperty = null;
+        IReadOnlyList<EquivalencyMemberShape> members = [];
+
+        switch (kind)
+        {
+            case EquivalencyNodeKind.Dictionary:
+                var dictionaryInterface =
+                    FindGenericInterface(type, typeof(IDictionary<,>)) ??
+                    FindGenericInterface(type, typeof(IReadOnlyDictionary<,>));
+                if (dictionaryInterface != null)
+                {
+                    var arguments = dictionaryInterface.GetGenericArguments();
+                    keyType = arguments[0];
+                    valueType = arguments[1];
+
+                    // The already-constructed KeyValuePair<K,V> type comes from the enumerable
+                    // interface, avoiding MakeGenericType (which is not AOT-safe).
+                    var kvpType = FindGenericInterface(type, typeof(IEnumerable<>))?.GetGenericArguments()[0];
+                    if (kvpType is { IsGenericType: true } && kvpType.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+                    {
+                        kvpKeyProperty = kvpType.GetProperty(nameof(KeyValuePair<int, int>.Key));
+                        kvpValueProperty = kvpType.GetProperty(nameof(KeyValuePair<int, int>.Value));
+                    }
+                }
+
+                break;
+
+            case EquivalencyNodeKind.Set:
+            case EquivalencyNodeKind.Sequence:
+                elementType = type.IsArray
+                    ? type.GetElementType()
+                    : FindGenericInterface(type, typeof(IEnumerable<>))?.GetGenericArguments()[0];
+                break;
+
+            case EquivalencyNodeKind.Complex:
+                members = CreateMembers(type);
+                break;
+        }
+
+        return new ReflectionTypeShape(type, kind, members, elementType, keyType, valueType, kvpKeyProperty, kvpValueProperty);
+    }
+
+    [RequiresUnreferencedCode("Reflects over the interfaces of arbitrary types.")]
+    private static EquivalencyNodeKind GetKind(Type type)
+    {
+        if (IsLeaf(type))
+            return EquivalencyNodeKind.Leaf;
+
+        if (typeof(IDictionary).IsAssignableFrom(type)
+            || FindGenericInterface(type, typeof(IDictionary<,>)) != null
+            || FindGenericInterface(type, typeof(IReadOnlyDictionary<,>)) != null)
+            return EquivalencyNodeKind.Dictionary;
+
+        if (FindGenericInterface(type, typeof(ISet<>)) != null
+            || FindGenericInterfaceByName(type, "System.Collections.Generic.IReadOnlySet`1") != null)
+            return EquivalencyNodeKind.Set;
+
+        if (typeof(IEnumerable).IsAssignableFrom(type))
+            return EquivalencyNodeKind.Sequence;
+
+        return EquivalencyNodeKind.Complex;
+    }
+
+    private static bool IsLeaf(Type type)
+    {
+        type = Nullable.GetUnderlyingType(type) ?? type;
+
+        if (type.IsPrimitive || type.IsEnum)
+            return true;
+
+        if (type == typeof(string)
+            || type == typeof(decimal)
+            || type == typeof(Guid)
+            || type == typeof(DateTime)
+            || type == typeof(DateTimeOffset)
+            || type == typeof(TimeSpan)
+            || type == typeof(Uri)
+            || type == typeof(Version))
+            return true;
+
+        // Reflection objects and delegates have well-defined identity semantics via Equals and
+        // reflection-heavy object graphs; walking their members is never what the user wants.
+        if (typeof(MemberInfo).IsAssignableFrom(type) || typeof(Delegate).IsAssignableFrom(type))
+            return true;
+
+        // Value-semantic System types that may not exist on every TFM Shouldly compiles against.
+        return type.FullName is
+            "System.DateOnly" or
+            "System.TimeOnly" or
+            "System.Half" or
+            "System.Int128" or
+            "System.UInt128" or
+            "System.Text.Rune" or
+            "System.Numerics.BigInteger";
+    }
+
+    [RequiresUnreferencedCode("Reflects over the interfaces of arbitrary types.")]
+    private static Type? FindGenericInterface(Type type, Type genericDefinition)
+    {
+        if (type.IsInterface && type.IsGenericType && type.GetGenericTypeDefinition() == genericDefinition)
+            return type;
+
+        foreach (var candidate in type.GetInterfaces())
+        {
+            if (candidate.IsGenericType && candidate.GetGenericTypeDefinition() == genericDefinition)
+                return candidate;
+        }
+
+        return null;
+    }
+
+    [RequiresUnreferencedCode("Reflects over the interfaces of arbitrary types.")]
+    private static Type? FindGenericInterfaceByName(Type type, string genericDefinitionFullName)
+    {
+        if (type.IsInterface && type.IsGenericType && type.GetGenericTypeDefinition().FullName == genericDefinitionFullName)
+            return type;
+
+        foreach (var candidate in type.GetInterfaces())
+        {
+            if (candidate.IsGenericType && candidate.GetGenericTypeDefinition().FullName == genericDefinitionFullName)
+                return candidate;
+        }
+
+        return null;
+    }
+
+    [RequiresUnreferencedCode("Reflects over the fields and properties of arbitrary types.")]
+    private static IReadOnlyList<EquivalencyMemberShape> CreateMembers(Type type)
+    {
+        const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.Instance;
+
+        // Interfaces don't inherit members through GetProperties; flatten the hierarchy.
+        var sources = type.IsInterface
+            ? new[] { type }.Concat(type.GetInterfaces())
+            : [type];
+
+        var members = new List<EquivalencyMemberShape>();
+        var byName = new Dictionary<string, MemberInfo>(StringComparer.Ordinal);
+
+        foreach (var source in sources)
+        {
+            foreach (var field in source.GetFields(bindingFlags))
+                AddMember(field, field.DeclaringType);
+
+            foreach (var property in source.GetProperties(bindingFlags))
+            {
+                if (property.GetIndexParameters().Length != 0 || !property.CanRead)
+                    continue;
+
+                AddMember(property, property.DeclaringType);
+            }
+        }
+
+        return members;
+
+        void AddMember(MemberInfo member, Type? declaringType)
+        {
+            if (byName.TryGetValue(member.Name, out var existing))
+            {
+                // A member can appear twice when shadowed with `new`; keep the most derived one.
+                if (existing.DeclaringType != null && declaringType != null && existing.DeclaringType.IsAssignableFrom(declaringType))
+                {
+                    members[members.FindIndex(m => m.Name == member.Name)] = new ReflectionMemberShape(member);
+                    byName[member.Name] = member;
+                }
+
+                return;
+            }
+
+            byName.Add(member.Name, member);
+            members.Add(new ReflectionMemberShape(member));
+        }
+    }
+
+    private sealed class ReflectionTypeShape : EquivalencyTypeShape
+    {
+        private readonly IReadOnlyList<EquivalencyMemberShape> _members;
+        private readonly PropertyInfo? _kvpKeyProperty;
+        private readonly PropertyInfo? _kvpValueProperty;
+
+        public ReflectionTypeShape(
+            Type type,
+            EquivalencyNodeKind kind,
+            IReadOnlyList<EquivalencyMemberShape> members,
+            Type? elementType,
+            Type? keyType,
+            Type? valueType,
+            PropertyInfo? kvpKeyProperty,
+            PropertyInfo? kvpValueProperty)
+        {
+            Type = type;
+            Kind = kind;
+            _members = members;
+            ElementType = elementType;
+            KeyType = keyType;
+            ValueType = valueType;
+            _kvpKeyProperty = kvpKeyProperty;
+            _kvpValueProperty = kvpValueProperty;
+        }
+
+        public override Type Type { get; }
+
+        public override EquivalencyNodeKind Kind { get; }
+
+        public override IReadOnlyList<EquivalencyMemberShape> Members => _members;
+
+        public override Type? ElementType { get; }
+
+        public override Type? KeyType { get; }
+
+        public override Type? ValueType { get; }
+
+        public override EquivalencyMemberShape? FindMember(string name)
+        {
+            foreach (var member in _members)
+            {
+                if (string.Equals(member.Name, name, StringComparison.Ordinal))
+                    return member;
+            }
+
+            return null;
+        }
+
+        public override IEnumerable<KeyValuePair<object?, object?>> GetEntries(object instance)
+        {
+            if (instance is IDictionary dictionary)
+            {
+                foreach (DictionaryEntry entry in dictionary)
+                    yield return new(entry.Key, entry.Value);
+
+                yield break;
+            }
+
+            if (_kvpKeyProperty == null || _kvpValueProperty == null)
+                throw new InvalidOperationException($"Cannot enumerate entries of dictionary type {Type.FullName}.");
+
+            foreach (var pair in (IEnumerable)instance)
+                yield return new(_kvpKeyProperty.GetValue(pair), _kvpValueProperty.GetValue(pair));
+        }
+    }
+
+    private sealed class ReflectionMemberShape : EquivalencyMemberShape
+    {
+        private readonly MemberInfo _member;
+
+        public ReflectionMemberShape(MemberInfo member) =>
+            _member = member;
+
+        public override string Name => _member.Name;
+
+        public override Type DeclaredType => _member switch
+        {
+            PropertyInfo property => property.PropertyType,
+            _ => ((FieldInfo)_member).FieldType,
+        };
+
+        public override object? GetValue(object instance) => _member switch
+        {
+            PropertyInfo property => property.GetValue(instance),
+            _ => ((FieldInfo)_member).GetValue(instance),
+        };
+    }
+}

--- a/src/Shouldly/EquivalencyOptions.cs
+++ b/src/Shouldly/EquivalencyOptions.cs
@@ -5,4 +5,15 @@ namespace Shouldly;
 /// </summary>
 public class EquivalencyOptions
 {
+    /// <summary>
+    /// When true, collections are compared order-insensitively: every expected element must have
+    /// an equivalent element in the actual collection, regardless of position. Sets are always
+    /// compared order-insensitively.
+    /// </summary>
+    public bool IgnoreOrder { get; set; }
+
+    /// <summary>
+    /// Names of members to skip wherever they appear in the compared object graphs.
+    /// </summary>
+    public ICollection<string> MembersToIgnore { get; } = new HashSet<string>(StringComparer.Ordinal);
 }

--- a/src/Shouldly/EquivalencyOptions.cs
+++ b/src/Shouldly/EquivalencyOptions.cs
@@ -1,0 +1,8 @@
+namespace Shouldly;
+
+/// <summary>
+/// Options controlling how <c>ShouldBeEquivalentTo</c> compares object graphs.
+/// </summary>
+public class EquivalencyOptions
+{
+}

--- a/src/Shouldly/ILLink.Substitutions.xml
+++ b/src/Shouldly/ILLink.Substitutions.xml
@@ -1,0 +1,10 @@
+<linker>
+  <assembly fullname="Shouldly">
+    <!-- When a trimmed/AOT publish disables the feature switch, the reflection-based equivalency
+         shape provider becomes unreachable and is removed; ShouldBeEquivalentTo then requires a
+         registered (source-generated) provider and fails with an actionable error otherwise. -->
+    <type fullname="Shouldly.Equivalency.EquivalencyShapes" feature="Shouldly.Equivalency.IsReflectionEnabledByDefault" featurevalue="false">
+      <method signature="System.Boolean get_IsReflectionEnabledByDefault()" body="stub" value="false" />
+    </type>
+  </assembly>
+</linker>

--- a/src/Shouldly/Internals/ShouldlyAssertionContext.cs
+++ b/src/Shouldly/Internals/ShouldlyAssertionContext.cs
@@ -79,6 +79,12 @@ public class ShouldlyAssertionContext : IShouldlyAssertionContext
     public IEnumerable<string>? Path { get; set; }
 
     /// <summary>
+    /// The differences collected by an equivalency comparison, when this context belongs to a
+    /// ShouldBeEquivalentTo failure.
+    /// </summary>
+    internal IReadOnlyList<Equivalency.EquivalencyDifference>? EquivalencyDifferences { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the ShouldlyAssertionContext class
     /// </summary>
     /// <param name="shouldlyMethod">The name of the should method being called</param>

--- a/src/Shouldly/MessageGenerators/ShouldBeEquivalentToMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeEquivalentToMessageGenerator.cs
@@ -1,3 +1,5 @@
+using Shouldly.Equivalency;
+
 namespace Shouldly.MessageGenerators;
 
 class ShouldBeEquivalentToMessageGenerator : ShouldlyMessageGenerator
@@ -7,26 +9,102 @@ class ShouldBeEquivalentToMessageGenerator : ShouldlyMessageGenerator
     public override bool CanProcess(IShouldlyAssertionContext context) =>
         context.ShouldMethod == "ShouldBeEquivalentTo";
 
-    public override string GenerateErrorMessage(IShouldlyAssertionContext context) =>
-        $"""
-         Comparing object equivalence, at path:
-         {FormatPath(context)}
+    public override string GenerateErrorMessage(IShouldlyAssertionContext context)
+    {
+        if (context is ShouldlyAssertionContext { EquivalencyDifferences: { Count: > 0 } differences })
+            return GenerateFromDifferences(context, differences);
 
+        return $"""
+                Comparing object equivalence, at path:
+                {FormatPath(context.CodePart, context.Path)}
+
+                {GenerateValueMismatchBody(context.Expected, context.Actual)}
+                """;
+    }
+
+    private static string GenerateFromDifferences(IShouldlyAssertionContext context, IReadOnlyList<EquivalencyDifference> differences)
+    {
+        if (differences.Count == 1)
+        {
+            return $"""
+                    Comparing object equivalence, at path:
+                    {FormatPath(context.CodePart, differences[0].PathSegments)}
+
+                    {GenerateBody(differences[0])}
+                    """;
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"Comparing object equivalence, found {differences.Count} differences:");
+        foreach (var difference in differences)
+        {
+            sb.AppendLine();
+            sb.AppendLine("at path:");
+            sb.AppendLine(FormatPath(context.CodePart, difference.PathSegments));
+            sb.AppendLine();
+            sb.AppendLine(GenerateBody(difference));
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string GenerateBody(EquivalencyDifference difference) => difference.Kind switch
+    {
+        EquivalencyDifferenceKind.MissingMember =>
+            $"""
+                 Expected a public member named
+             {difference.Expected.ToStringAwesomely()}
+                 but was not found on
+             {difference.Detail}
+             """,
+
+        EquivalencyDifferenceKind.MissingKey =>
+            $"""
+                 Expected key
+             {difference.Expected.ToStringAwesomely()}
+                 but was not found
+             """,
+
+        EquivalencyDifferenceKind.UnexpectedKeys =>
+            $"""
+                 Found key(s) not present on the expectation
+             {difference.Actual.ToStringAwesomely()}
+             """,
+
+        EquivalencyDifferenceKind.MissingElement =>
+            $"""
+                 Expected an element equivalent to
+             {difference.Expected.ToStringAwesomely()}
+                 but was not found
+             """,
+
+        EquivalencyDifferenceKind.VacuousComparison =>
+            $"""
+                 Found no public members to compare on
+             {difference.Detail}
+                 which would make the assertion vacuously pass; cast the expectation to a concrete type or assert on specific members instead
+             """,
+
+        _ => GenerateValueMismatchBody(difference.Expected, difference.Actual),
+    };
+
+    private static string GenerateValueMismatchBody(object? expected, object? actual) =>
+        $"""
              Expected value to be
-         {context.Expected.ToStringAwesomely()}
+         {expected.ToStringAwesomely()}
              but was
-         {context.Actual.ToStringAwesomely()}
+         {actual.ToStringAwesomely()}
          """;
 
-    private static string FormatPath(IShouldlyAssertionContext context)
+    private static string FormatPath(string? codePart, IEnumerable<string>? path)
     {
-        var result = new StringBuilder(context.CodePart);
-        if (context.Path != null)
+        var result = new StringBuilder(codePart);
+        if (path != null)
         {
             var i = 0;
-            foreach (var part in context.Path)
+            foreach (var part in path)
             {
-                result.Append(new string(' ', i++ * IndentSize));
+                result.Append(' ', i++ * IndentSize);
                 result.AppendLine(part);
             }
         }

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -11,6 +11,9 @@
     <None Include="..\..\assets\logo_128x128.png" Pack="true" PackagePath="assets" />
     <None Include="buildTransitive\Shouldly.targets" Pack="true" PackagePath="buildTransitive\Shouldly.targets" />
     <InternalsVisibleTo Include="Shouldly.Approvals" Key="$(ShouldlyPublicKey)" />
+    <EmbeddedResource Include="ILLink.Substitutions.xml">
+      <LogicalName>ILLink.Substitutions.xml</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -22,13 +22,14 @@ public static partial class ObjectGraphTestExtensions
         string? customMessage = null,
         [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
-        CompareObjects(actual, expected, new List<string>(), new Dictionary<object, IList<object?>>(), customMessage, actualExpression: actualExpression);
+        CompareObjects(actual, expected, null, new List<string>(), new Dictionary<object, IList<object?>>(), customMessage, actualExpression: actualExpression);
     }
 
     [RequiresUnreferencedCode("Reflects over fields and properties of the runtime type.")]
     private static void CompareObjects(
         [NotNullIfNotNull(nameof(expected))] this object? actual,
         [NotNullIfNotNull(nameof(actual))] object? expected,
+        Type? forcedType,
         IList<string> path,
         IDictionary<object, IList<object?>> previousComparisons,
         string? customMessage,
@@ -38,7 +39,9 @@ public static partial class ObjectGraphTestExtensions
         if (BothValuesAreNull(actual, expected, path, customMessage, shouldlyMethod, actualExpression))
             return;
 
-        var type = GetTypeToCompare(actual, expected, path, customMessage, shouldlyMethod, actualExpression);
+        var type = forcedType ?? GetTypeToCompare(actual, expected, path, customMessage, shouldlyMethod, actualExpression);
+
+        AddTypeToPath(type, path);
 
         if (type == typeof(string))
         {
@@ -95,13 +98,16 @@ public static partial class ObjectGraphTestExtensions
         if (actualType != expectedType)
             ThrowException(actualType, expectedType, path, customMessage, shouldlyMethod, actualExpression);
 
+        return actualType;
+    }
+
+    private static void AddTypeToPath(Type actualType, IList<string> path)
+    {
         var typeName = $" [{actualType.FullName}]";
         if (path.Count == 0)
             path.Add(typeName);
         else
             path[path.Count - 1] += typeName;
-
-        return actualType;
     }
 
     private static void CompareValueTypes(ValueType actual, ValueType expected, IEnumerable<string> path,
@@ -165,7 +171,7 @@ public static partial class ObjectGraphTestExtensions
         for (var i = 0; i < actualList.Count; i++)
         {
             var newPath = path.Concat([$"Element [{i}]"]);
-            CompareObjects(actualList[i], expectedList[i], newPath.ToList(), previousComparisons, customMessage, shouldlyMethod, actualExpression);
+            CompareObjects(actualList[i], expectedList[i], null, newPath.ToList(), previousComparisons, customMessage, shouldlyMethod, actualExpression);
         }
     }
 
@@ -181,7 +187,7 @@ public static partial class ObjectGraphTestExtensions
             var expectedValue = field.GetValue(expected);
 
             var newPath = path.Concat([field.Name]);
-            CompareObjects(actualValue, expectedValue, newPath.ToList(), previousComparisons, customMessage, shouldlyMethod, actualExpression);
+            CompareObjects(actualValue, expectedValue, field.FieldType, newPath.ToList(), previousComparisons, customMessage, shouldlyMethod, actualExpression);
         }
     }
 
@@ -204,7 +210,7 @@ public static partial class ObjectGraphTestExtensions
             var expectedValue = property.GetValue(expected, []);
 
             var newPath = path.Concat([property.Name]);
-            CompareObjects(actualValue, expectedValue, newPath.ToList(), previousComparisons, customMessage, shouldlyMethod, actualExpression);
+            CompareObjects(actualValue, expectedValue, property.PropertyType, newPath.ToList(), previousComparisons, customMessage, shouldlyMethod, actualExpression);
         }
     }
 

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -25,6 +25,21 @@ public static partial class ObjectGraphTestExtensions
         CompareObjects(actual, expected, null, new List<string>(), new Dictionary<object, IList<object?>>(), customMessage, actualExpression: actualExpression);
     }
 
+    /// <summary>
+    /// Asserts that an object is equivalent to another object by comparing all properties and fields,
+    /// using the supplied <paramref name="options"/> to customize the comparison.
+    /// </summary>
+    [RequiresUnreferencedCode("Walks the actual/expected object graph using reflection over each runtime type's public fields and properties. The trimmer cannot statically determine which members are read.")]
+    public static void ShouldBeEquivalentTo(
+        [NotNullIfNotNull(nameof(expected))] this object? actual,
+        [NotNullIfNotNull(nameof(actual))] object? expected,
+        EquivalencyOptions options,
+        string? customMessage = null,
+        [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
+    {
+        CompareObjects(actual, expected, null, new List<string>(), new Dictionary<object, IList<object?>>(), customMessage, actualExpression: actualExpression);
+    }
+
     [RequiresUnreferencedCode("Reflects over fields and properties of the runtime type.")]
     private static void CompareObjects(
         [NotNullIfNotNull(nameof(expected))] this object? actual,

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -22,7 +22,7 @@ public static partial class ObjectGraphTestExtensions
         string? customMessage = null,
         [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
-        CompareObjects(actual, expected, null, new List<string>(), new Dictionary<object, IList<object?>>(), customMessage, actualExpression: actualExpression);
+        CompareObjects(actual, expected, null, new List<string>(), new Dictionary<object, IList<object?>>(ReferenceEqualityComparer.Instance), customMessage, actualExpression: actualExpression);
     }
 
     /// <summary>
@@ -37,7 +37,7 @@ public static partial class ObjectGraphTestExtensions
         string? customMessage = null,
         [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
-        CompareObjects(actual, expected, null, new List<string>(), new Dictionary<object, IList<object?>>(), customMessage, actualExpression: actualExpression);
+        CompareObjects(actual, expected, null, new List<string>(), new Dictionary<object, IList<object?>>(ReferenceEqualityComparer.Instance), customMessage, actualExpression: actualExpression);
     }
 
     [RequiresUnreferencedCode("Reflects over fields and properties of the runtime type.")]
@@ -240,7 +240,7 @@ public static partial class ObjectGraphTestExtensions
 
     private static bool Contains(this IDictionary<object, IList<object?>> comparisons, object actual, object? expected) =>
         comparisons.TryGetValue(actual, out var list)
-        && list.Contains(expected);
+        && list.Any(item => ReferenceEquals(item, expected));
 
     private static void Record(this IDictionary<object, IList<object?>> comparisons, object actual, object? expected)
     {
@@ -252,5 +252,19 @@ public static partial class ObjectGraphTestExtensions
         {
             comparisons.Add(actual, new List<object?>([expected]));
         }
+    }
+
+    /// <summary>
+    /// Visited pairs must be tracked by reference identity: tracking with a type's own
+    /// Equals/GetHashCode lets an earlier comparison of an Equals-equal pair suppress the
+    /// comparison of a later, structurally different pair (a silent false pass).
+    /// </summary>
+    private sealed class ReferenceEqualityComparer : IEqualityComparer<object>
+    {
+        public static readonly ReferenceEqualityComparer Instance = new();
+
+        bool IEqualityComparer<object>.Equals(object? x, object? y) => ReferenceEquals(x, y);
+
+        int IEqualityComparer<object>.GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/ObjectGraphTestExtensions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using Shouldly.Equivalency;
 
 namespace Shouldly;
 
@@ -9,27 +10,26 @@ namespace Shouldly;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class ObjectGraphTestExtensions
 {
-    private const BindingFlags DefaultBindingFlags = BindingFlags.Public | BindingFlags.Instance;
-
     /// <summary>
-    /// Asserts that an object is equivalent to another object by comparing all properties and fields.
-    /// Supports value types, reference types, strings, and enumerables.
+    /// Asserts that an object is equivalent to another object: leaf values (primitives, strings,
+    /// dates, and other value-semantic types) are compared with Equals, dictionaries are matched
+    /// by key, sets order-insensitively, other collections element-by-element in order, and
+    /// everything else member-wise over the expectation's public properties and fields, recursively.
+    /// All differences are collected and reported with their paths.
     /// </summary>
-    [RequiresUnreferencedCode("Walks the actual/expected object graph using reflection over each runtime type's public fields and properties. The trimmer cannot statically determine which members are read.")]
     public static void ShouldBeEquivalentTo(
         [NotNullIfNotNull(nameof(expected))] this object? actual,
         [NotNullIfNotNull(nameof(actual))] object? expected,
         string? customMessage = null,
         [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
-        CompareObjects(actual, expected, null, new List<string>(), new Dictionary<object, IList<object?>>(ReferenceEqualityComparer.Instance), customMessage, actualExpression: actualExpression);
+        EquivalencyComparison.Assert(actual, expected, new(), customMessage, "ShouldBeEquivalentTo", actualExpression);
     }
 
     /// <summary>
-    /// Asserts that an object is equivalent to another object by comparing all properties and fields,
-    /// using the supplied <paramref name="options"/> to customize the comparison.
+    /// Asserts that an object is equivalent to another object, using the supplied
+    /// <paramref name="options"/> to customize the comparison.
     /// </summary>
-    [RequiresUnreferencedCode("Walks the actual/expected object graph using reflection over each runtime type's public fields and properties. The trimmer cannot statically determine which members are read.")]
     public static void ShouldBeEquivalentTo(
         [NotNullIfNotNull(nameof(expected))] this object? actual,
         [NotNullIfNotNull(nameof(actual))] object? expected,
@@ -37,234 +37,6 @@ public static partial class ObjectGraphTestExtensions
         string? customMessage = null,
         [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
-        CompareObjects(actual, expected, null, new List<string>(), new Dictionary<object, IList<object?>>(ReferenceEqualityComparer.Instance), customMessage, actualExpression: actualExpression);
-    }
-
-    [RequiresUnreferencedCode("Reflects over fields and properties of the runtime type.")]
-    private static void CompareObjects(
-        [NotNullIfNotNull(nameof(expected))] this object? actual,
-        [NotNullIfNotNull(nameof(actual))] object? expected,
-        Type? forcedType,
-        IList<string> path,
-        IDictionary<object, IList<object?>> previousComparisons,
-        string? customMessage,
-        [CallerMemberName] string shouldlyMethod = null!,
-        string? actualExpression = null)
-    {
-        if (BothValuesAreNull(actual, expected, path, customMessage, shouldlyMethod, actualExpression))
-            return;
-
-        var type = forcedType ?? GetTypeToCompare(actual, expected, path, customMessage, shouldlyMethod, actualExpression);
-
-        AddTypeToPath(type, path);
-
-        if (type == typeof(string))
-        {
-            CompareStrings((string)actual, (string)expected, path, customMessage, shouldlyMethod, actualExpression);
-        }
-        else if (type == typeof(Uri))
-        {
-            CompareUris((Uri)actual, (Uri)expected, path, customMessage, shouldlyMethod, actualExpression);
-        }
-        else if (typeof(IEnumerable).IsAssignableFrom(type))
-        {
-            CompareEnumerables((IEnumerable)actual, (IEnumerable)expected, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
-        }
-        else if (type.IsValueType)
-        {
-            CompareValueTypes((ValueType)actual, (ValueType)expected, path, customMessage, shouldlyMethod, actualExpression);
-        }
-        else
-        {
-            CompareReferenceTypes(actual, expected, type, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
-        }
-    }
-
-    private static bool BothValuesAreNull(
-        [NotNullWhen(false)] object? actual,
-        [NotNullWhen(false)] object? expected,
-        IEnumerable<string> path,
-        string? customMessage,
-        [CallerMemberName] string shouldlyMethod = null!,
-        string? actualExpression = null)
-    {
-        if (expected == null)
-        {
-            if (actual == null)
-                return true;
-
-            ThrowException(actual, expected, path, customMessage, shouldlyMethod, actualExpression);
-        }
-        else if (actual == null)
-        {
-            ThrowException(actual, expected, path, customMessage, shouldlyMethod, actualExpression);
-        }
-
-        return false;
-    }
-
-    private static Type GetTypeToCompare(object actual, object expected, IList<string> path,
-        string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
-        string? actualExpression = null)
-    {
-        var expectedType = expected.GetType();
-        var actualType = actual.GetType();
-
-        if (actualType != expectedType)
-            ThrowException(actualType, expectedType, path, customMessage, shouldlyMethod, actualExpression);
-
-        return actualType;
-    }
-
-    private static void AddTypeToPath(Type actualType, IList<string> path)
-    {
-        var typeName = $" [{actualType.FullName}]";
-        if (path.Count == 0)
-            path.Add(typeName);
-        else
-            path[path.Count - 1] += typeName;
-    }
-
-    private static void CompareValueTypes(ValueType actual, ValueType expected, IEnumerable<string> path,
-        string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
-        string? actualExpression = null)
-    {
-        if (!actual.Equals(expected))
-            ThrowException(actual, expected, path, customMessage, shouldlyMethod, actualExpression);
-    }
-
-    [RequiresUnreferencedCode("Reflects over fields and properties of the runtime type.")]
-    private static void CompareReferenceTypes(object actual, object expected, Type type,
-        IList<string> path, IDictionary<object, IList<object?>> previousComparisons,
-        string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
-        string? actualExpression = null)
-    {
-        if (ReferenceEquals(actual, expected) ||
-            previousComparisons.Contains(actual, expected))
-            return;
-
-        previousComparisons.Record(actual, expected);
-
-        var fields = type.GetFields(DefaultBindingFlags);
-        CompareFields(actual, expected, fields, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
-
-        var properties = type.GetProperties(DefaultBindingFlags);
-        CompareProperties(actual, expected, properties, path, previousComparisons, customMessage, shouldlyMethod, actualExpression);
-    }
-
-    private static void CompareStrings(string actual, string expected, IEnumerable<string> path,
-        string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
-        string? actualExpression = null)
-    {
-        if (!actual.Equals(expected, StringComparison.Ordinal))
-            ThrowException(actual, expected, path, customMessage, shouldlyMethod, actualExpression);
-    }
-
-    private static void CompareUris(Uri actual, Uri expected, IEnumerable<string> path,
-        string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
-        string? actualExpression = null)
-    {
-        if (!actual.Equals(expected))
-            ThrowException(actual, expected, path, customMessage, shouldlyMethod, actualExpression);
-    }
-
-    [RequiresUnreferencedCode("Recurses into CompareObjects which reflects over the runtime type.")]
-    private static void CompareEnumerables(IEnumerable actual, IEnumerable expected,
-        IEnumerable<string> path, IDictionary<object, IList<object?>> previousComparisons,
-        string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
-        string? actualExpression = null)
-    {
-        var expectedList = expected.Cast<object?>().ToList();
-        var actualList = actual.Cast<object?>().ToList();
-
-        if (actualList.Count != expectedList.Count)
-        {
-            var newPath = path.Concat(["Count"]);
-            ThrowException(actualList.Count, expectedList.Count, newPath, customMessage, shouldlyMethod, actualExpression);
-        }
-
-        for (var i = 0; i < actualList.Count; i++)
-        {
-            var newPath = path.Concat([$"Element [{i}]"]);
-            CompareObjects(actualList[i], expectedList[i], null, newPath.ToList(), previousComparisons, customMessage, shouldlyMethod, actualExpression);
-        }
-    }
-
-    [RequiresUnreferencedCode("Recurses into CompareObjects which reflects over the runtime type.")]
-    private static void CompareFields(object actual, object expected, IEnumerable<FieldInfo> fields,
-        IList<string> path, IDictionary<object, IList<object?>> previousComparisons,
-        string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
-        string? actualExpression = null)
-    {
-        foreach (var field in fields)
-        {
-            var actualValue = field.GetValue(actual);
-            var expectedValue = field.GetValue(expected);
-
-            var newPath = path.Concat([field.Name]);
-            CompareObjects(actualValue, expectedValue, field.FieldType, newPath.ToList(), previousComparisons, customMessage, shouldlyMethod, actualExpression);
-        }
-    }
-
-    [RequiresUnreferencedCode("Recurses into CompareObjects which reflects over the runtime type.")]
-    private static void CompareProperties(object actual, object expected, IEnumerable<PropertyInfo> properties,
-        IList<string> path, IDictionary<object, IList<object?>> previousComparisons,
-        string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
-        string? actualExpression = null)
-    {
-        foreach (var property in properties)
-        {
-            if (property.GetIndexParameters().Length != 0)
-            {
-                // There's no sensible way to compare indexers, as there does not exist a way to obtain a collection
-                // of all values in a way that's common to all indexer implementations.
-                throw new NotSupportedException("Comparing types that have indexers is not supported.");
-            }
-
-            var actualValue = property.GetValue(actual, []);
-            var expectedValue = property.GetValue(expected, []);
-
-            var newPath = path.Concat([property.Name]);
-            CompareObjects(actualValue, expectedValue, property.PropertyType, newPath.ToList(), previousComparisons, customMessage, shouldlyMethod, actualExpression);
-        }
-    }
-
-    [DoesNotReturn]
-    private static void ThrowException(object? actual, object? expected, IEnumerable<string> path,
-        string? customMessage, [CallerMemberName] string shouldlyMethod = null!,
-        string? actualExpression = null)
-    {
-        throw new ShouldAssertException(
-            new ExpectedEquivalenceShouldlyMessage(expected, actual, path, customMessage, shouldlyMethod, actualExpression).ToString());
-    }
-
-    private static bool Contains(this IDictionary<object, IList<object?>> comparisons, object actual, object? expected) =>
-        comparisons.TryGetValue(actual, out var list)
-        && list.Any(item => ReferenceEquals(item, expected));
-
-    private static void Record(this IDictionary<object, IList<object?>> comparisons, object actual, object? expected)
-    {
-        if (comparisons.TryGetValue(actual, out var list))
-        {
-            list.Add(expected);
-        }
-        else
-        {
-            comparisons.Add(actual, new List<object?>([expected]));
-        }
-    }
-
-    /// <summary>
-    /// Visited pairs must be tracked by reference identity: tracking with a type's own
-    /// Equals/GetHashCode lets an earlier comparison of an Equals-equal pair suppress the
-    /// comparison of a later, structurally different pair (a silent false pass).
-    /// </summary>
-    private sealed class ReferenceEqualityComparer : IEqualityComparer<object>
-    {
-        public static readonly ReferenceEqualityComparer Instance = new();
-
-        bool IEqualityComparer<object>.Equals(object? x, object? y) => ReferenceEquals(x, y);
-
-        int IEqualityComparer<object>.GetHashCode(object obj) => RuntimeHelpers.GetHashCode(obj);
+        EquivalencyComparison.Assert(actual, expected, options, customMessage, "ShouldBeEquivalentTo", actualExpression);
     }
 }

--- a/src/Shouldly/ShouldlyMessage.cs
+++ b/src/Shouldly/ShouldlyMessage.cs
@@ -202,6 +202,18 @@ public class ExpectedEquivalenceShouldlyMessage : ShouldlyMessage
         };
         if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage;
     }
+
+    /// <summary>
+    /// Creates a new message from the differences collected by an equivalency comparison.
+    /// </summary>
+    internal ExpectedEquivalenceShouldlyMessage(IReadOnlyList<Equivalency.EquivalencyDifference> differences, object? expected, object? actual, string? customMessage, string shouldlyMethod, string? actualExpression)
+    {
+        ShouldlyAssertionContext = new ShouldlyAssertionContext(shouldlyMethod, expected, actual, actualExpression: actualExpression)
+        {
+            EquivalencyDifferences = differences
+        };
+        if (customMessage != null) ShouldlyAssertionContext.CustomMessage = customMessage;
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
Rewrites `ShouldBeEquivalentTo` as a per-node strategy engine that walks the actual/expected graphs choosing a comparison per node (leaf, dictionary, set, sequence, or member-wise), selects members from the expectation's declared types with subset semantics, and collects every difference with its path instead of stopping at the first. Reflection over user types is isolated behind an `IEquivalencyShapeProvider` abstraction gated by the `Shouldly.Equivalency.IsReflectionEnabledByDefault` feature switch (with `ILLink.Substitutions.xml`) so trimmed/AOT publishes can swap in a source-generated provider. Adds an `EquivalencyOptions` overload supporting `IgnoreOrder` and `MembersToIgnore`, and uses maximum bipartite matching (greedy warm-start plus augmenting-path fallback with memoized equivalence) for order-insensitive collections and dictionary keys so a complete pairing is found whenever one exists. Ships an extensive `EquivalencyComparisonTests` behavioural spec project alongside new scenario/approved-output tests and a 4-to-5 upgrade guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)