### PR TITLE
Make approval-test path scrubbing work from any checkout location

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -49,15 +49,8 @@ if (Test-Path $testResultsDir) {
 $testProjects = @(
     "src/Shouldly.Tests/Shouldly.Tests.csproj"
     "src/EquivalencyComparisonTests/EquivalencyComparisonTests.csproj"
+    "src/DocumentationExamples/DocumentationExamples.csproj"
 )
-
-# Add DocumentationExamples project only on Windows
-if ($IsWindows) {
-    $testProjects += "src/DocumentationExamples/DocumentationExamples.csproj"
-    Write-Host "Running on Windows. Including DocumentationExamples project." -ForegroundColor Cyan
-} else {
-    Write-Host "Not running on Windows. Skipping DocumentationExamples project." -ForegroundColor Yellow
-}
 
 # Run tests for each project
 foreach ($project in $testProjects) {

--- a/src/DocumentationExamples/DocExampleWriter.cs
+++ b/src/DocumentationExamples/DocExampleWriter.cs
@@ -8,8 +8,21 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 public static class DocExampleWriter
 {
-    private static readonly Regex scrubberRegex = new(@"\w:.+?shouldly\\src", RegexOptions.Compiled);
-    private static readonly Func<string, string> scrubber = v => scrubberRegex.Replace(v, "C:\\PathToCode\\shouldly\\src");
+    private static readonly Regex windowsPathRegex = new(@"\w:.+?\\src\\DocumentationExamples", RegexOptions.Compiled);
+    private static readonly Regex unixPathRegex = new(@"/[^""\r\n]+?/src/DocumentationExamples", RegexOptions.Compiled);
+    private static readonly Regex scrubbedPathRegex = new(@"C:\\PathToCode\\shouldly\\src\\DocumentationExamples[^""\s]*", RegexOptions.Compiled);
+    private static readonly Regex unixCopyCommandRegex = new(@"^cp (?=""C:\\PathToCode)", RegexOptions.Compiled | RegexOptions.Multiline);
+
+    // The approved files are generated with Windows paths and commands; rewrite unix
+    // equivalents to that form so the tests pass on any OS and checkout location.
+    private static readonly Func<string, string> scrubber = v =>
+    {
+        v = windowsPathRegex.Replace(v, @"C:\PathToCode\shouldly\src\DocumentationExamples");
+        v = unixPathRegex.Replace(v, @"C:\PathToCode\shouldly\src\DocumentationExamples");
+        v = scrubbedPathRegex.Replace(v, m => m.Value.Replace('/', '\\'));
+        v = unixCopyCommandRegex.Replace(v, "copy /Y ");
+        return v;
+    };
 
     private static readonly ConcurrentDictionary<string, List<MethodDeclarationSyntax>> FileMethodsLookup = new();
 

--- a/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
+++ b/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
@@ -6,9 +6,11 @@ namespace Shouldly.Tests.ShouldMatchApproved;
 
 public class ShouldMatchApprovedScenarios
 {
+    // Anchors on the repo-relative `src/Shouldly.Tests` suffix so the checkout can live
+    // anywhere (e.g. /tmp, a worktree, or a folder not named "shouldly").
     private readonly Func<string, string> _scrubber = v => RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-        ? Regex.Replace(v, @"\w:.+?shouldly(?:\\[^\\]+)*?\\src", "C:\\PathToCode\\shouldly\\src")
-        : Regex.Replace(v, @"\/([U,u]sers|[H,h]ome).+?shouldly(?:\/[^\/]+)*?\/src", "/PathToCode/shouldly/src");
+        ? Regex.Replace(v, @"\w:.+?\\src\\Shouldly\.Tests", @"C:\PathToCode\shouldly\src\Shouldly.Tests")
+        : Regex.Replace(v, @"/[^""\r\n]+?/src/Shouldly\.Tests", "/PathToCode/shouldly/src/Shouldly.Tests");
 
     [Fact]
     public void Simple()


### PR DESCRIPTION
## Problem

The `ShouldMatchApproved` scenario tests bake absolute paths into their expected messages and rely on scrubbers to normalize them to a `PathToCode` placeholder. Those scrubbers made assumptions about where the repo lives:

- **Shouldly.Tests** (`ShouldMatchApprovedScenarios`): the unix regex required the path to start with `/Users` or `/home` **and** contain `shouldly`. Clone to `/tmp`, a git worktree, or a folder not named "shouldly" and `MissingApprovedFile` / `DifferencesUseShouldlyMessages` fail.
- **DocumentationExamples** (`DocExampleWriter`): the scrubber only handled Windows drive-letter paths, which is why `build.ps1` skipped the whole project off-Windows.

## Fix

- Anchor scrubbing on the stable repo-relative suffix (`src/Shouldly.Tests` / `src/DocumentationExamples`) instead of guessing the prefix, so any checkout location works. The match is constrained to not cross quotes or newlines so the two quoted paths on the `cp`/`copy` line scrub independently.
- `DocExampleWriter` now also rewrites unix paths, separators, and `cp` commands to the Windows form captured in the approved files, so the docs tests are deterministic on every OS.
- `build.ps1` now runs `DocumentationExamples` on all OSes instead of Windows only — the CI matrix on this PR is the cross-platform verification.

## Verification

From a `/tmp` git worktree on macOS (fails on master, 2 tests in each project): Shouldly.Tests 893/893, DocumentationExamples 83/83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)