### PR TITLE
Fix FluentAssertions Dependabot ignore rule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,5 +24,3 @@ updates:
     versions:
     - 16.9.1
   - dependency-name: FluentAssertions
-    update-types:
-    - all


### PR DESCRIPTION
The FluentAssertions ignore entry in `.github/dependabot.yml` used `update-types: [all]`, which is not a valid Dependabot value — only `version-update:semver-major/minor/patch` are accepted — so it silently matched nothing and bump PRs kept being opened (e.g. #1273).

This changes the entry to a bare `dependency-name: FluentAssertions` with no `versions`/`update-types`, which tells Dependabot to ignore all updates for the package across all directories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)