### PR TITLE
Bump version to 5.0.0-preview.2

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>14</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>5.0.0-preview.1</Version>
+    <Version>5.0.0-preview.2</Version>
     <AnalysisLevel>5</AnalysisLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Bumps `<Version>` in `src/Directory.Build.props` from `5.0.0-preview.1` to `5.0.0-preview.2` to prepare the next preview release.

## Release process
Once this is merged to `master`, tag the merge commit with `5.0.0-preview.2` and push the tag. That triggers `.github/workflows/publish.yml`, which validates the tag matches `<Version>`, runs `./build.ps1` (build + pack + test), and pushes the package to NuGet via OIDC trusted publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)