### PR TITLE
Reduce public surface of approval test-method finders

### DIFF
--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -86,23 +86,6 @@ namespace Shouldly
         public ExpectedShouldlyMessage(object? expected, string? customMessage, [System.Runtime.CompilerServices.CallerMemberName] string shouldlyMethod = null, string? actualExpression = null) { }
     }
     public delegate string FilenameGenerator(Shouldly.TestMethodInfo testMethodInfo, string? discriminator, string fileType, string fileExtension);
-    public class FindMethodUsingAttribute<T> : Shouldly.ITestMethodFinder
-        where T : System.Attribute
-    {
-        public FindMethodUsingAttribute() { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Walks the stack trace via StackFrame.GetMethod() and reflects over types and attr" +
-            "ibutes to locate a method with the requested attribute. Method metadata may be t" +
-            "rimmed away.")]
-        public Shouldly.TestMethodInfo GetTestMethodInfo(System.Diagnostics.StackTrace stackTrace, int startAt = 0) { }
-    }
-    public class FirstNonShouldlyMethodFinder : Shouldly.ITestMethodFinder
-    {
-        public FirstNonShouldlyMethodFinder() { }
-        public int Offset { get; set; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Walks the stack trace via StackFrame.GetMethod() to locate the first non-Shouldly" +
-            " method. Method metadata may be trimmed away.")]
-        public Shouldly.TestMethodInfo GetTestMethodInfo(System.Diagnostics.StackTrace stackTrace, int startAt = 0) { }
-    }
     [Shouldly.ShouldlyMethods]
     public static class GuidShouldBeTestExtensions
     {
@@ -137,12 +120,6 @@ namespace Shouldly
         Shouldly.SortDirection SortDirection { get; set; }
         System.TimeSpan? Timeout { get; set; }
         object? Tolerance { get; set; }
-    }
-    public interface ITestMethodFinder
-    {
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Implementations walk the stack trace via StackFrame.GetMethod() to locate the tes" +
-            "t method. Method metadata may be trimmed away.")]
-        Shouldly.TestMethodInfo GetTestMethodInfo(System.Diagnostics.StackTrace stackTrace, int startAt = 0);
     }
     [Shouldly.ShouldlyMethods]
     public static class ObjectGraphTestExtensions
@@ -419,7 +396,6 @@ namespace Shouldly
         public bool PreventDiff { get; set; }
         public System.Func<string, string>? Scrubber { get; set; }
         public Shouldly.StringCompareShould StringCompareOptions { get; set; }
-        public Shouldly.ITestMethodFinder TestMethodFinder { get; set; }
         public static Shouldly.ShouldMatchConfigurationBuilder ShouldMatchApprovedDefaults { get; }
     }
     public class ShouldMatchConfigurationBuilder
@@ -616,9 +592,6 @@ namespace Shouldly
     }
     public class TestMethodInfo
     {
-        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses StackFrame.GetMethod() and reflects over the declaring type to detect async " +
-            "state machines. Method metadata may be trimmed away.")]
-        public TestMethodInfo(System.Diagnostics.StackFrame callingFrame) { }
         public string? DeclaringTypeName { get; }
         public string? MethodName { get; }
         public string? SourceFileDirectory { get; }

--- a/src/Shouldly/FindMethodUsingAttribute.cs
+++ b/src/Shouldly/FindMethodUsingAttribute.cs
@@ -4,7 +4,7 @@ namespace Shouldly;
 /// Finds a test method in the stack trace that has a specific attribute
 /// </summary>
 /// <typeparam name="T">The attribute type to search for</typeparam>
-public class FindMethodUsingAttribute<T> : ITestMethodFinder where T : Attribute
+internal class FindMethodUsingAttribute<T> : ITestMethodFinder where T : Attribute
 {
     /// <inheritdoc/>
     [RequiresUnreferencedCode("Walks the stack trace via StackFrame.GetMethod() and reflects over types and attributes to locate a method with the requested attribute. Method metadata may be trimmed away.")]

--- a/src/Shouldly/FirstNonShouldlyMethodFinder.cs
+++ b/src/Shouldly/FirstNonShouldlyMethodFinder.cs
@@ -5,7 +5,7 @@ namespace Shouldly;
 /// <summary>
 /// Finds the first method in the stack trace that is not from the Shouldly library
 /// </summary>
-public class FirstNonShouldlyMethodFinder : ITestMethodFinder
+internal class FirstNonShouldlyMethodFinder : ITestMethodFinder
 {
     private static readonly Regex AnonMethod = new(@"<(\w|_)+>b_.+");
 

--- a/src/Shouldly/ITestMethodFinder.cs
+++ b/src/Shouldly/ITestMethodFinder.cs
@@ -3,7 +3,7 @@ namespace Shouldly;
 /// <summary>
 /// Interface for finding test methods in a stack trace
 /// </summary>
-public interface ITestMethodFinder
+internal interface ITestMethodFinder
 {
     /// <summary>
     /// Gets test method information from the stack trace

--- a/src/Shouldly/ShouldMatchConfiguration.cs
+++ b/src/Shouldly/ShouldMatchConfiguration.cs
@@ -70,7 +70,7 @@ public class ShouldMatchConfiguration
     /// <summary>
     /// The test method finder to use to locate the test method
     /// </summary>
-    public ITestMethodFinder TestMethodFinder { get; set; } = new FirstNonShouldlyMethodFinder();
+    internal ITestMethodFinder TestMethodFinder { get; set; } = new FirstNonShouldlyMethodFinder();
 
     /// <summary>
     /// Optional subfolder for approval files

--- a/src/Shouldly/TestMethodInfo.cs
+++ b/src/Shouldly/TestMethodInfo.cs
@@ -12,7 +12,7 @@ public class TestMethodInfo
     /// </summary>
     /// <param name="callingFrame">The stack frame of the calling method</param>
     [RequiresUnreferencedCode("Uses StackFrame.GetMethod() and reflects over the declaring type to detect async state machines. Method metadata may be trimmed away.")]
-    public TestMethodInfo(StackFrame callingFrame)
+    internal TestMethodInfo(StackFrame callingFrame)
     {
         var fileName = callingFrame.GetFileName();
         fileName = DeterministicBuildHelpers.ResolveDeterministicPaths(fileName);


### PR DESCRIPTION
Hides the internal plumbing of the `ShouldMatchApproved` test-method-finder subsystem, keeping only the config/builder entry points and the read-only `TestMethodInfo` (which custom `FilenameGenerator` lambdas still read) on the public surface. `ITestMethodFinder`, `FirstNonShouldlyMethodFinder`, and `FindMethodUsingAttribute<T>` become `internal` since they're only reachable via the `UseCallerLocation()` / `LocateTestMethodUsingAttribute<T>()` builder methods, and both `ShouldMatchConfiguration.TestMethodFinder` and `TestMethodInfo`'s constructor become `internal` too. The approved public-API baseline is updated to match. All 927 tests pass, and the runtime stack-frame walk that populates `TestMethodInfo` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)