### PR TITLE
docs: document ShouldMatchApprovedDefaults move in 4→5 migration guide

### DIFF
--- a/documentation/documentation/upgrade/4to5.md
+++ b/documentation/documentation/upgrade/4to5.md
@@ -6,6 +6,20 @@ This is a work in progress. Please send a PR with any amendments.
 
 `ShouldContain`, `ShouldNotContain`, `ShouldStartWith`, `ShouldEndWith`, `ShouldNotStartWith`, and `ShouldNotEndWith` defaulted to `Case.Insensitive` in v4, while `ShouldBe` compared case-sensitively. In v5 all string assertions are case-sensitive by default, aligning with `ShouldBe`, C# string semantics, and other assertion libraries. `Case.Insensitive` remains available as an opt-in.
 
+## Approval-test configuration moved to `ShouldMatchConfiguration`
+
+The default configuration for `ShouldMatchApproved` — used to set the test-method finder, file extension, filename generator, and so on — has moved off `ShouldlyConfiguration` onto a dedicated `ShouldMatchConfiguration` class. Code that references `ShouldlyConfiguration.ShouldMatchApprovedDefaults` fails to compile with `CS0117`. Change the class name; the member and its fluent API are unchanged:
+
+```csharp
+// v4
+ShouldlyConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
+
+// v5
+ShouldMatchConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
+```
+
+This is the typical setup for teams using `ShouldMatchApproved` with a non-xUnit test framework (for example a NUnit `[SetUp]` that calls `LocateTestMethodUsingAttribute<TestAttribute>()`).
+
 ## `ShouldBeEquivalentTo` has been rewritten
 
 The comparison engine behind `ShouldBeEquivalentTo` was rewritten for v5 (see [the roadmap](https://github.com/shouldly/shouldly/issues/1265) for the full rationale). The public API is unchanged, plus a new optional `EquivalencyOptions` parameter.


### PR DESCRIPTION
Fixes #1279.

In v5 `ShouldMatchApprovedDefaults` moved from `ShouldlyConfiguration` to a dedicated `ShouldMatchConfiguration` class, so existing code (e.g. GitVersion's NUnit `[SetUp]` calling `LocateTestMethodUsingAttribute<TestAttribute>()`) fails to compile with `CS0117`. This adds a section to the 4→5 migration guide showing the one-token rename with before/after usage. The current class naming was left as-is deliberately — grouping approval config on its own class keeps `ShouldlyConfiguration` (global config) cohesive, and re-renaming would just add a second breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)