### PR TITLE
docs: document v5 ShouldMatchApproved config-surface breaks (4to5 guide)

### DIFF
--- a/documentation/documentation/upgrade/4to5.md
+++ b/documentation/documentation/upgrade/4to5.md
@@ -6,6 +6,33 @@ This is a work in progress. Please send a PR with any amendments.
 
 `ShouldContain`, `ShouldNotContain`, `ShouldStartWith`, `ShouldEndWith`, `ShouldNotStartWith`, and `ShouldNotEndWith` defaulted to `Case.Insensitive` in v4, while `ShouldBe` compared case-sensitively. In v5 all string assertions are case-sensitive by default, aligning with `ShouldBe`, C# string semantics, and other assertion libraries. `Case.Insensitive` remains available as an opt-in.
 
+## The `Shouldly.Configuration` namespace has been removed
+
+The approval-test configuration types — `ShouldMatchConfiguration`, `ShouldMatchConfigurationBuilder`, `FirstNonShouldlyMethodFinder`, `ITestMethodFinder`, and friends — lived in the `Shouldly.Configuration` namespace in v4. In v5 they have been collapsed into the root `Shouldly` namespace, and `Shouldly.Configuration` no longer exists.
+
+Any `using Shouldly.Configuration;` now fails to compile with **`CS0234`**:
+
+```csharp
+using Shouldly.Configuration;
+// error CS0234: The type or namespace name 'Configuration' does not exist in the namespace 'Shouldly'
+```
+
+Delete the `using Shouldly.Configuration;` line — the types resolve via `using Shouldly;`.
+
+## `ShouldMatchApprovedDefaults` has moved
+
+The static `ShouldMatchApprovedDefaults` builder used to configure approval tests has moved off `ShouldlyConfiguration` and onto a new `ShouldMatchConfiguration` class. Code referencing the old accessor fails to compile with **`CS0117`**:
+
+```csharp
+// v4 — compiles
+ShouldlyConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
+
+// v5 — error CS0117: 'ShouldlyConfiguration' does not contain a definition for 'ShouldMatchApprovedDefaults'
+ShouldMatchConfiguration.ShouldMatchApprovedDefaults.LocateTestMethodUsingAttribute<TestAttribute>();
+```
+
+Change the class name only. This is the typical pattern for teams using `ShouldMatchApproved` with a non-xUnit test framework (e.g. configuring test-method location in an NUnit `[SetUp]`). Both types live in the root `Shouldly` namespace, so no `using` change is needed beyond `using Shouldly;`.
+
 ## `ShouldBeEquivalentTo` has been rewritten
 
 The comparison engine behind `ShouldBeEquivalentTo` was rewritten for v5 (see [the roadmap](https://github.com/shouldly/shouldly/issues/1265) for the full rationale). The public API is unchanged, plus a new optional `EquivalencyOptions` parameter.


### PR DESCRIPTION
Documents two intentional v5 source breaks in the 4→5 migration guide, both found while dogfooding `5.0.0-preview.2` against real repositories. Doc-only — no code change.

## Breaks covered

- **`Shouldly.Configuration` namespace removed** (`CS0234`) — the approval-test config types (`ShouldMatchConfiguration`, `ShouldMatchConfigurationBuilder`, `FirstNonShouldlyMethodFinder`, `ITestMethodFinder`, …) were collapsed into the root `Shouldly` namespace. Fix: drop the `using Shouldly.Configuration;` line. Fixes #1280.
- **`ShouldlyConfiguration.ShouldMatchApprovedDefaults` moved** (`CS0117`) — the static builder now lives on the new `ShouldMatchConfiguration` class. Fix: rename the class only. Fixes #1279.

Both are part of the same ShouldMatchApproved configuration-surface refactor, so they're documented in adjacent sections.

## Why doc-only

Both fixes are one-line mechanical renames and consistent with the deliberate v5 namespace collapse. A forwarding member on `ShouldlyConfiguration` was considered (per #1279) but rejected — it would partially re-introduce the surface v5 intentionally trimmed, and can't cover the removed namespace anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)