### PR TITLE
fix: keep dictionary assertions unambiguous under LangVersion < 13 (#1284)

### DIFF
--- a/src/LangVersionCompatTests/DictionaryAssertionAmbiguityTests.cs
+++ b/src/LangVersionCompatTests/DictionaryAssertionAmbiguityTests.cs
@@ -1,0 +1,58 @@
+using Shouldly;
+using Xunit;
+
+namespace LangVersionCompatTests;
+
+/// <summary>
+/// Regression guard for https://github.com/shouldly/shouldly/issues/1284.
+///
+/// This project is pinned to <c>LangVersion 12</c> (see the .csproj). The v5 dictionary
+/// assertions previously shipped a pair of sibling-interface overloads —
+/// <c>IDictionary&lt;,&gt;</c> and (on net9.0+) <c>IReadOnlyDictionary&lt;,&gt;</c> — with the
+/// read-only one decorated <c>[OverloadResolutionPriority(1)]</c> to break the tie. Because a
+/// concrete <c>Dictionary&lt;,&gt;</c> implements both interfaces, calling e.g.
+/// <c>dict.ShouldContainKey(key)</c> on it failed with CS0121 on any <c>LangVersion &lt; 13</c>,
+/// where <c>[OverloadResolutionPriority]</c> is silently a no-op. Unlike #1278 these are sibling
+/// interfaces with no "more specific" tie-break, so equalising arity could not help.
+///
+/// The fix collapses each assertion to a single overload typed to the shared base,
+/// <c>IEnumerable&lt;KeyValuePair&lt;TKey, TValue&gt;&gt;</c>. The <em>compilation</em> of this
+/// file is the primary regression test; the runtime assertions confirm each call still binds and
+/// dispatches correctly for the concrete, mutable-interface, and read-only-interface receivers.
+/// </summary>
+public class DictionaryAssertionAmbiguityTests
+{
+    [Fact]
+    public void Concrete_dictionary_binds_without_ambiguity()
+    {
+        // The exact repro from the issue: a Dictionary<,> implements both dictionary interfaces.
+        var dict = new Dictionary<string, int> { ["a"] = 1 };
+
+        dict.ShouldContainKey("a");
+        dict.ShouldNotContainKey("b");
+        dict.ShouldContainKeyAndValue("a", 1);
+        dict.ShouldNotContainValueForKey("a", 2);
+    }
+
+    [Fact]
+    public void Mutable_dictionary_interface_binds()
+    {
+        IDictionary<string, int> dict = new Dictionary<string, int> { ["a"] = 1 };
+
+        dict.ShouldContainKey("a");
+        dict.ShouldNotContainKey("b");
+        dict.ShouldContainKeyAndValue("a", 1);
+        dict.ShouldNotContainValueForKey("a", 2);
+    }
+
+    [Fact]
+    public void ReadOnly_dictionary_interface_binds()
+    {
+        IReadOnlyDictionary<string, int> dict = new Dictionary<string, int> { ["a"] = 1 };
+
+        dict.ShouldContainKey("a");
+        dict.ShouldNotContainKey("b");
+        dict.ShouldContainKeyAndValue("a", 1);
+        dict.ShouldNotContainValueForKey("a", 2);
+    }
+}

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -202,25 +202,13 @@ namespace Shouldly
     [Shouldly.ShouldlyMethods]
     public static class ShouldBeDictionaryTestExtensions
     {
-        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
+        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> dictionary, TKey key, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
             where TKey :  notnull { }
-        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-        public static void ShouldContainKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
+        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> dictionary, TKey key, TValue val, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
             where TKey :  notnull { }
-        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
+        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> dictionary, TKey key, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
             where TKey :  notnull { }
-        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-        public static void ShouldContainKeyAndValue<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
-            where TKey :  notnull { }
-        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
-            where TKey :  notnull { }
-        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-        public static void ShouldNotContainKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
-            where TKey :  notnull { }
-        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
-            where TKey :  notnull { }
-        [System.Runtime.CompilerServices.OverloadResolutionPriority(1)]
-        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
+        public static void ShouldNotContainValueForKey<TKey, TValue>(this System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<TKey, TValue>> dictionary, TKey key, TValue val, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("dictionary")] string? actualExpression = null)
             where TKey :  notnull { }
     }
     [Shouldly.ShouldlyMethods]

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
@@ -10,97 +10,87 @@ namespace Shouldly;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static partial class ShouldBeDictionaryTestExtensions
 {
+    // These assertions accept IEnumerable<KeyValuePair<TKey, TValue>> — the single interface that
+    // both IDictionary<,> and IReadOnlyDictionary<,> derive from — rather than one overload per
+    // interface. A concrete Dictionary<,> (and most BCL dictionaries) implements *both* interfaces,
+    // so a pair of sibling-interface overloads is ambiguous (CS0121) on any LangVersion < 13, where
+    // [OverloadResolutionPriority] is silently a no-op. Neither interface is more specific than the
+    // other, so there is no tie-break to fall back on (unlike the scalar-vs-enumerable ShouldBe case
+    // in #1278). Collapsing to the shared base type keeps a single unambiguous overload at every
+    // LangVersion and TFM, while still covering IDictionary-only and IReadOnlyDictionary-only types.
+    // See issue #1284.
+
     /// <summary>
     /// Asserts that the dictionary contains the specified key.
     /// </summary>
-    public static void ShouldContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null,
+    public static void ShouldContainKey<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key, string? customMessage = null,
         [CallerArgumentExpression(nameof(dictionary))] string? actualExpression = null)
         where TKey : notnull
     {
-        if (!dictionary.ContainsKey(key))
+        if (!ContainsKey(dictionary, key))
             throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage, actualExpression: actualExpression).ToString());
     }
 
     /// <summary>
     /// Asserts that the dictionary does not contain the specified key.
     /// </summary>
-    public static void ShouldNotContainKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null,
+    public static void ShouldNotContainKey<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key, string? customMessage = null,
         [CallerArgumentExpression(nameof(dictionary))] string? actualExpression = null)
         where TKey : notnull
     {
-        if (dictionary.ContainsKey(key))
+        if (ContainsKey(dictionary, key))
             throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage, actualExpression: actualExpression).ToString());
     }
 
     /// <summary>
     /// Asserts that the dictionary contains the specified key with the specified value.
     /// </summary>
-    public static void ShouldContainKeyAndValue<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null,
+    public static void ShouldContainKeyAndValue<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key, TValue val, string? customMessage = null,
         [CallerArgumentExpression(nameof(dictionary))] string? actualExpression = null)
         where TKey : notnull
     {
-        if (!dictionary.ContainsKey(key) || !Equals(dictionary[key], val))
+        if (!TryGetValue(dictionary, key, out var actual) || !Equals(actual, val))
             throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage, actualExpression: actualExpression).ToString());
     }
 
     /// <summary>
     /// Asserts that the dictionary does not contain the specified value for the specified key.
     /// </summary>
-    public static void ShouldNotContainValueForKey<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null,
+    public static void ShouldNotContainValueForKey<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key, TValue val, string? customMessage = null,
         [CallerArgumentExpression(nameof(dictionary))] string? actualExpression = null)
         where TKey : notnull
     {
-        if (!dictionary.ContainsKey(key) || Equals(dictionary[key], val))
-            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key,  customMessage, actualExpression: actualExpression).ToString());
-    }
-
-#if NET9_0_OR_GREATER
-    /// <summary>
-    /// Asserts that the read-only dictionary contains the specified key.
-    /// </summary>
-    [OverloadResolutionPriority(1)]
-    public static void ShouldContainKey<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null,
-        [CallerArgumentExpression(nameof(dictionary))] string? actualExpression = null)
-        where TKey : notnull
-    {
-        if (!dictionary.ContainsKey(key))
-            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage, actualExpression: actualExpression).ToString());
-    }
-
-    /// <summary>
-    /// Asserts that the read-only dictionary does not contain the specified key.
-    /// </summary>
-    [OverloadResolutionPriority(1)]
-    public static void ShouldNotContainKey<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, string? customMessage = null,
-        [CallerArgumentExpression(nameof(dictionary))] string? actualExpression = null)
-        where TKey : notnull
-    {
-        if (dictionary.ContainsKey(key))
-            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(key, dictionary, customMessage, actualExpression: actualExpression).ToString());
-    }
-
-    /// <summary>
-    /// Asserts that the read-only dictionary contains the specified key with the specified value.
-    /// </summary>
-    [OverloadResolutionPriority(1)]
-    public static void ShouldContainKeyAndValue<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null,
-        [CallerArgumentExpression(nameof(dictionary))] string? actualExpression = null)
-        where TKey : notnull
-    {
-        if (!dictionary.ContainsKey(key) || !Equals(dictionary[key], val))
+        if (!TryGetValue(dictionary, key, out var actual) || Equals(actual, val))
             throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage, actualExpression: actualExpression).ToString());
     }
 
-    /// <summary>
-    /// Asserts that the read-only dictionary does not contain the specified value for the specified key.
-    /// </summary>
-    [OverloadResolutionPriority(1)]
-    public static void ShouldNotContainValueForKey<TKey, TValue>(this IReadOnlyDictionary<TKey, TValue> dictionary, TKey key, TValue val, string? customMessage = null,
-        [CallerArgumentExpression(nameof(dictionary))] string? actualExpression = null)
+    private static bool ContainsKey<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key)
+        where TKey : notnull =>
+        TryGetValue(dictionary, key, out _);
+
+    private static bool TryGetValue<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key, out TValue value)
         where TKey : notnull
     {
-        if (!dictionary.ContainsKey(key) || Equals(dictionary[key], val))
-            throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage, actualExpression: actualExpression).ToString());
+        // Prefer the dictionaries' own key comparers via their ContainsKey/TryGetValue members;
+        // fall back to a linear scan for any other IEnumerable<KeyValuePair<,>> the caller passes.
+        switch (dictionary)
+        {
+            case IReadOnlyDictionary<TKey, TValue> readOnlyDictionary:
+                return readOnlyDictionary.TryGetValue(key, out value!);
+            case IDictionary<TKey, TValue> mutableDictionary:
+                return mutableDictionary.TryGetValue(key, out value!);
+            default:
+                foreach (var pair in dictionary)
+                {
+                    if (EqualityComparer<TKey>.Default.Equals(pair.Key, key))
+                    {
+                        value = pair.Value;
+                        return true;
+                    }
+                }
+
+                value = default!;
+                return false;
+        }
     }
-#endif
 }


### PR DESCRIPTION
Fixes #1284. The net9.0+ `IReadOnlyDictionary<,>` overloads of `ShouldContainKey`, `ShouldNotContainKey`, `ShouldContainKeyAndValue` and `ShouldNotContainValueForKey` relied on `[OverloadResolutionPriority(1)]` to beat their `IDictionary<,>` siblings, but that attribute is a silent no-op below C# 13, so a `Dictionary<,>` receiver (which implements both interfaces) failed with CS0121 for consumers at `LangVersion < 13` — and unlike #1278 these sibling interfaces have no "more specific" tie-break to fall back on.

This collapses each assertion to a single overload typed to the shared base `IEnumerable<KeyValuePair<TKey, TValue>>`, dispatching at runtime via a `TryGetValue` helper (`IReadOnlyDictionary` → `IDictionary` → linear scan). This removes the `OverloadResolutionPriority` reliance and the `#if NET9_0_OR_GREATER` split entirely, stays unambiguous at every LangVersion/TFM, and now supports both interface-only dictionary types on all TFMs. Behavior and error messages are unchanged for real dictionaries.

### Public surface change: assertions now bind on any `IEnumerable<KeyValuePair<,>>`

Because the single overload is typed to the shared base interface, these four assertions now also bind on non-dictionary key/value sequences (`List<KeyValuePair<,>>`, arrays, LINQ projections, etc.), not just `IDictionary`/`IReadOnlyDictionary`. Calling this out explicitly for reviewers.

This is a deliberate trade-off and is consistent with the original design discussion in #984 (which introduced the `IReadOnlyDictionary` overload and the `[OverloadResolutionPriority]` / `NET9_0_OR_GREATER` scheme). That discussion's concern was consistently that coverage was too *narrow* — it noted the concrete-overload approach would leave types like `ImmutableDictionary`, `FrozenDictionary`, `ReadOnlyDictionary` and `ConcurrentDictionary` "out in the cold" — and it deliberately kept `IDictionary` support so values statically typed as `IDictionary<,>` could still be asserted on. The base-type approach satisfies both intents more completely: all of those concrete types are now covered on every TFM (not just net9.0+), dispatching through the type's own comparer-aware `TryGetValue`, so a custom key comparer is still honored. The only case using the default comparer is the new linear-scan fallback for a bare `IEnumerable<KeyValuePair<,>>`, which has no comparer of its own to honor.

Adds a `LangVersion 12` regression project whose successful compile guards against the ambiguity returning, and updates the public-API approval snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
