### PR TITLE
Report elements outside the subset using the supplied comparer

### DIFF
--- a/src/Shouldly.Tests/ShouldBeSubsetOf/ComparerScenario.ComparerPartialMatchShouldFail.approved.txt
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/ComparerScenario.ComparerPartialMatchShouldFail.approved.txt
@@ -1,0 +1,9 @@
+comparison1
+    should be subset of
+["a"]
+    but
+["Z"]
+    is outside subset
+
+Additional Info:
+    Some additional context

--- a/src/Shouldly.Tests/ShouldBeSubsetOf/ComparerScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeSubsetOf/ComparerScenario.cs
@@ -19,6 +19,16 @@ public class ComparerScenario
     }
 
     [Fact]
+    public void ComparerPartialMatchShouldFail()
+    {
+        var comparison1 = new[] { "A", "Z" };
+        var comparison2 = new[] { "a" };
+
+        Verify.ShouldFail(() =>
+            comparison1.ShouldBeSubsetOf(comparison2, StringComparer.OrdinalIgnoreCase, "Some additional context"));
+    }
+
+    [Fact]
     public void ComparerNotEqualsShouldFail()
     {
         var comparison1 = new[]

--- a/src/Shouldly/MessageGenerators/ShouldBeSubsetOfMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeSubsetOfMessageGenerator.cs
@@ -12,8 +12,7 @@ class ShouldBeSubsetOfMessageGenerator : ShouldlyMessageGenerator
         var codePart = context.CodePart;
         var expected = context.Expected.ToStringAwesomely();
 
-        // The extension method computes the elements outside the subset (honoring any
-        // custom comparer) and passes them as the actual value, so no recomputation happens here.
+        // The extension method computes the elements outside the subset (honoring any custom comparer) and passes them as the actual value, so no recomputation happens here.
         var missing = (context.Actual as IEnumerable ?? Enumerable.Empty<object>()).Cast<object>().ToList();
 
         return

--- a/src/Shouldly/MessageGenerators/ShouldBeSubsetOfMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/ShouldBeSubsetOfMessageGenerator.cs
@@ -11,11 +11,10 @@ class ShouldBeSubsetOfMessageGenerator : ShouldlyMessageGenerator
     {
         var codePart = context.CodePart;
         var expected = context.Expected.ToStringAwesomely();
-        var actualEnumerable = (context.Actual as IEnumerable ?? Enumerable.Empty<object>()).Cast<object>();
-        var expectedEnumerable = (context.Expected as IEnumerable ?? Enumerable.Empty<object>()).Cast<object>();
 
-        var missing = actualEnumerable.Except(expectedEnumerable).ToList();
-        var count = missing.Count;
+        // The extension method computes the elements outside the subset (honoring any
+        // custom comparer) and passes them as the actual value, so no recomputation happens here.
+        var missing = (context.Actual as IEnumerable ?? Enumerable.Empty<object>()).Cast<object>().ToList();
 
         return
             $"""
@@ -24,7 +23,7 @@ class ShouldBeSubsetOfMessageGenerator : ShouldlyMessageGenerator
              {expected}
                  but
              {missing.ToStringAwesomely()}
-                 {(count > 1 ? "are" : "is")} outside subset
+                 {(missing.Count > 1 ? "are" : "is")} outside subset
              """;
     }
 }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeEnumerableTestExtensions.cs
@@ -185,9 +185,9 @@ public static partial class ShouldBeEnumerableTestExtensions
         if (actual.Equals(expected))
             return;
 
-        var missing = actual.Except(expected);
-        if (missing.Any())
-            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage, actualExpression: actualExpression).ToString());
+        var missing = actual.Except(expected).ToList();
+        if (missing.Count > 0)
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, missing, customMessage, actualExpression: actualExpression).ToString());
     }
 
     /// <summary>
@@ -199,9 +199,9 @@ public static partial class ShouldBeEnumerableTestExtensions
         if (actual.Equals(expected))
             return;
 
-        var missing = actual.Except(expected, comparer);
-        if (missing.Any())
-            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, actual, customMessage, actualExpression: actualExpression).ToString());
+        var missing = actual.Except(expected, comparer).ToList();
+        if (missing.Count > 0)
+            throw new ShouldAssertException(new ExpectedActualShouldlyMessage(expected, missing, customMessage, actualExpression: actualExpression).ToString());
     }
 
     /// <summary>


### PR DESCRIPTION
`ShouldBeSubsetOf` with a custom comparer asserts with the supplied comparer, but the message generator recomputed the "outside subset" list with default equality, so it could report elements the comparer had matched.

For example, `new[] { "A", "Z" }.ShouldBeSubsetOf(["a"], StringComparer.OrdinalIgnoreCase)` fails because of `"Z"` but reported both `"A"` and `"Z"`.

The extension methods now materialize the out-of-subset elements and pass them to the message generator.