### PR TITLE
build: add net10.0 as a shipping target for Shouldly and Shouldly.DiffEngine

### DIFF
--- a/src/Shouldly.DiffEngine/Shouldly.DiffEngine.csproj
+++ b/src/Shouldly.DiffEngine/Shouldly.DiffEngine.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>


### PR DESCRIPTION
Adds `net10.0` to the multi-target set of both shipping libraries so the packages ship a native .NET 10 asset alongside the existing TFMs (`Shouldly`: `netstandard2.0;net8.0;net9.0;net10.0`; `Shouldly.DiffEngine`: `net472;net8.0;net9.0;net10.0`). The existing `IsAotCompatible` and netstandard/PolySharp-only conditions already handle net10.0 correctly, so no condition changes were needed. This is purely additive — no existing TFMs were dropped. Verified with a clean `dotnet build -c Release` (0 warnings) producing `net10.0/` output for both projects. (Test projects already moved to net10.0 in a prior change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)