### PR TITLE
Revert "build: add net10.0 as a shipping target for Shouldly and Shouldly.DiffEngine"

### DIFF
--- a/src/Shouldly.DiffEngine/Shouldly.DiffEngine.csproj
+++ b/src/Shouldly.DiffEngine/Shouldly.DiffEngine.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Shouldly/Shouldly.csproj
+++ b/src/Shouldly/Shouldly.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
   </PropertyGroup>


### PR DESCRIPTION
Reverts shouldly/shouldly#1292

My brain failed, we don't need to do this, and I should know that 😅 