### PR TITLE
fix: restore variadic ShouldBeOneOf calls

### DIFF
--- a/src/LangVersionCompatTests/ShouldBeOneOfCompatibilityTests.cs
+++ b/src/LangVersionCompatTests/ShouldBeOneOfCompatibilityTests.cs
@@ -1,0 +1,19 @@
+using Shouldly;
+using Xunit;
+
+namespace LangVersionCompatTests;
+
+public class ShouldBeOneOfCompatibilityTests
+{
+    [Fact]
+    public void Individual_values_bind_to_the_params_overload()
+    {
+        1.ShouldBeOneOf(1, 2, 3);
+    }
+
+    [Fact]
+    public void Array_and_custom_message_overload_remains_available()
+    {
+        1.ShouldBeOneOf([1, 2, 3], "value should match");
+    }
+}

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -325,6 +325,7 @@ namespace Shouldly
         public static void ShouldBeNegative(this short actual, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void ShouldBeOfType([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, System.Type expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static T ShouldBeOfType<T>([System.Diagnostics.CodeAnalysis.NotNull] this object? actual, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
+        public static void ShouldBeOneOf<T>(this T? actual, params T[] expected) { }
         public static void ShouldBeOneOf<T>(this T? actual, T[] expected, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void ShouldBeOneOf<T>(this T? actual, T[] expected, System.Collections.Generic.IEqualityComparer<T> comparer, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }
         public static void ShouldBePositive(this decimal actual, string? customMessage = null, [System.Runtime.CompilerServices.CallerArgumentExpression("actual")] string? actualExpression = null) { }

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeRangeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeRangeTestExtensions.cs
@@ -5,6 +5,14 @@ public static partial class ShouldBeTestExtensions
     /// <summary>
     /// Asserts that the actual value is one of the expected values.
     /// </summary>
+    public static void ShouldBeOneOf<T>(this T? actual, params T[] expected)
+    {
+        ShouldBeOneOf(actual, expected, customMessage: null, actualExpression: null);
+    }
+
+    /// <summary>
+    /// Asserts that the actual value is one of the expected values.
+    /// </summary>
     public static void ShouldBeOneOf<T>(this T? actual, T[] expected, string? customMessage = null,
         [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {


### PR DESCRIPTION
## Summary

- restore the `params` overload for `ShouldBeOneOf` so individual expected values compile again
- add C# 12 compatibility coverage for variadic calls and the existing array-plus-message overload
- update the approved public API surface

## Validation

- `dotnet test --project src/LangVersionCompatTests/LangVersionCompatTests.csproj --configuration Release` (8 passed)
- `git diff --check upstream/master...HEAD`

The full `Shouldly.Tests` project exceeded 10 minutes during its local build, so the complete suite is deferred to CI.

Fixes #1277
