### PR TITLE
Document the ShouldBeOneOf params removal in the 4->5 upgrade guide

### DIFF
--- a/documentation/documentation/enumerable/oneOf.md
+++ b/documentation/documentation/enumerable/oneOf.md
@@ -1,5 +1,13 @@
 # BeOneOf
 
+The candidates are passed as a single collection, not as individual arguments:
+
+```cs
+status.ShouldBeOneOf([Status.Active, Status.Pending]);
+```
+
+This was a `params` array in v4 — see the [4 to 5 upgrade guide](../upgrade/4to5.md).
+
 
 ## ShouldBeOneOf
 

--- a/documentation/documentation/equality/oneOf.md
+++ b/documentation/documentation/equality/oneOf.md
@@ -2,6 +2,14 @@
 
 `ShouldNotBeOneOf` is the inverse of `ShouldBeOneOf`.
 
+The candidates are passed as a single collection, not as individual arguments:
+
+```cs
+status.ShouldBeOneOf([Status.Active, Status.Pending]);
+```
+
+This was a `params` array in v4 — see the [4 to 5 upgrade guide](../upgrade/4to5.md).
+
 
 ## ShouldBeOneOf
 

--- a/documentation/documentation/upgrade/4to5.md
+++ b/documentation/documentation/upgrade/4to5.md
@@ -2,6 +2,32 @@
 
 This is a work in progress. Please send a PR with any amendments.
 
+## `ShouldBeOneOf` and friends take a collection, not `params`
+
+`ShouldBeOneOf`, `ShouldNotBeOneOf`, and `ShouldBeOfTypes` were variadic in v4. In v5 they take their candidates as a single collection, so call sites passing individual values fail with **`CS1503`**:
+
+```csharp
+// v4 — compiles
+result.ShouldBeOneOf(Status.Active, Status.Pending, Status.Closed);
+
+// v5 — error CS1503: Argument 2: cannot convert from 'Status' to 'Status[]'
+result.ShouldBeOneOf([Status.Active, Status.Pending, Status.Closed]);
+```
+
+Wrap the values in a collection expression, or in `new[] { … }` below C# 12. Call sites that already pass an array or a collection expression are unaffected.
+
+This is the most widely hit compile break in the upgrade — `ShouldBeOneOf(a, b, c)` was the canonical v4 spelling — but it is a purely mechanical fix and the compiler points at every occurrence.
+
+The `params` array was dropped because a `params` parameter must come last, which leaves no room for the `[CallerArgumentExpression]` parameter these assertions now carry. That parameter is why the failure message reports your source text:
+
+```
+result
+    should be one of
+[Status.Active, Status.Pending, Status.Closed]
+    but was
+Status.Draft
+```
+
 ## String assertions default to case-sensitive comparison
 
 `ShouldContain`, `ShouldNotContain`, `ShouldStartWith`, `ShouldEndWith`, `ShouldNotStartWith`, and `ShouldNotEndWith` defaulted to `Case.Insensitive` in v4, while `ShouldBe` compared case-sensitively. In v5 all string assertions are case-sensitive by default, aligning with `ShouldBe`, C# string semantics, and other assertion libraries. `Case.Insensitive` remains available as an opt-in.


### PR DESCRIPTION
Fixes #1277.

v5 dropped the `params` modifier from `ShouldBeOneOf`, `ShouldNotBeOneOf` and `ShouldBeOfTypes` so they could carry a `[CallerArgumentExpression]` parameter, which has to come last — that broke the canonical `ShouldBeOneOf(a, b, c)` spelling with `CS1503`, and nothing said so. This adds a 4→5 upgrade guide entry covering the affected methods, the error, the mechanical fix, and why `params` had to go, plus a short note on both `oneOf` documentation pages.

Restoring the overloads was implemented and verified first, then rejected: it would not have removed the need for a migration note, only made it subtler (variadic would work, except with a single candidate, and its failure messages are quietly worse than the collection form's), and it would have left a permanently supported second-class path in the public API. Documenting it instead is consistent with how v5's other breaks are handled, and this one is at least compiler-flagged at every call site.

Documentation only — no source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)