### PR TITLE
Bound string failure messages and add MaxStringLengthInMessages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ docs/_build/
 **/.vs
 *.user
 *.received.*
-src/TestResults/
+TestResults/
 src/TestDiffTools/Main.approved.txt
 tools/*
 !tools/packages.config

--- a/documentation/documentation/configuration.md
+++ b/documentation/documentation/configuration.md
@@ -26,3 +26,59 @@ Types which also are IEnumerable of themselves.
 An example is `Newtonsoft.Json.Linq.JToken` which looks like this `class JToken : IEnumerable<JToken>`.
 
 **Default value:** Newtonsoft.Json.Linq.JToken
+
+
+## MaxStringLengthInMessages
+
+How many characters of the actual and expected values a string assertion echoes back in its
+failure message. Longer values are truncated, and the message says so along with the value's
+full length:
+
+```
+actual
+    should be
+"Lorem ipsum dolor sit amet" (truncated to 1000 of 42317 characters, see ShouldlyConfiguration.MaxStringLengthInMessages)
+```
+
+This only bounds the verbatim echo. The `difference` section is always computed from the full,
+untruncated values, so lowering this can never hide a difference — it just trims the surrounding
+noise. Raise it when you want more of the raw value in the message:
+
+```csharp
+ShouldlyConfiguration.MaxStringLengthInMessages = 20000;
+```
+
+Scoped to the logical call context, so it flows through `async`/`await` and concurrent tests get
+their own value.
+
+**Default value:** 1000
+
+Note that the `difference` section has its own fixed limits, independent of this setting: it shows
+at most 3 differing regions, at most 20 changed lines per side in line mode, and windows each
+region to roughly 60 characters of surrounding context. `ShouldContain` and friends separately clip
+the searched string to 100 characters, since the useful information there is the substring, not the
+haystack.
+
+
+## DiffStyle
+
+Character set used for the markers that point at a difference. `Unicode` uses `▼`/`▲`, `Ascii`
+uses `v`/`^` for terminals that can't render the arrows.
+
+**Default value:** `DiffStyle.Unicode`
+
+
+## EscapeStyle
+
+How control characters are rendered in difference output.
+
+| Value              | `\r\n` renders as |
+| ------------------ | ----------------- |
+| `CStyle`           | `\r`, `\n`        |
+| `ControlPictures`  | `␍`, `␊`          |
+| `Descriptive`      | `<CR>`, `<LF>`    |
+
+Scoped to the logical call context, so it flows through `async`/`await` and concurrent tests get
+their own value.
+
+**Default value:** `EscapeStyle.CStyle`

--- a/documentation/documentation/upgrade/4to5.md
+++ b/documentation/documentation/upgrade/4to5.md
@@ -32,6 +32,20 @@ Status.Draft
 
 `ShouldContain`, `ShouldNotContain`, `ShouldStartWith`, `ShouldEndWith`, `ShouldNotStartWith`, and `ShouldNotEndWith` defaulted to `Case.Insensitive` in v4, while `ShouldBe` compared case-sensitively. In v5 all string assertions are case-sensitive by default, aligning with `ShouldBe`, C# string semantics, and other assertion libraries. `Case.Insensitive` remains available as an opt-in.
 
+## String failure messages echo less of the value
+
+In v4, `ShouldBe` on strings echoed the actual and expected values up to a hardcoded 5000 characters, silently, and computed the `difference` section from those already-truncated values. Two long strings differing past character 5000 therefore produced a 10 KB message showing two identical-looking values and no difference at all.
+
+In v5 the difference is always computed from the full values, and only the echo is clipped — to [`ShouldlyConfiguration.MaxStringLengthInMessages`](../configuration.md#maxstringlengthinmessages), which now defaults to **1000**. Truncation is announced rather than silent:
+
+```
+"Lorem ipsum dolor sit amet" (truncated to 1000 of 42317 characters, see ShouldlyConfiguration.MaxStringLengthInMessages)
+```
+
+Messages for long strings get substantially shorter, and the `difference` section carries the information the raw echo used to bury. If you were relying on the old volume of output, set `ShouldlyConfiguration.MaxStringLengthInMessages = 5000;`.
+
+Line-mode diffs also now cap at 20 changed lines per side, with an `... and N more line(s)` marker.
+
 ## The `Shouldly.Configuration` namespace has been removed
 
 The approval-test configuration types — `ShouldMatchConfiguration`, `ShouldMatchConfigurationBuilder`, and friends — lived in the `Shouldly.Configuration` namespace in v4. In v5 they have been collapsed into the root `Shouldly` namespace, and `Shouldly.Configuration` no longer exists. (`FirstNonShouldlyMethodFinder`, `ITestMethodFinder`, and `FindMethodUsingAttribute<T>` are gone entirely — see [`ShouldMatchApproved` no longer walks the stack](#shouldmatchapproved-no-longer-walks-the-stack).)

--- a/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
+++ b/src/Shouldly.Tests/ConventionTests/ApprovePublicApi.ShouldlyApi.approved.cs
@@ -529,6 +529,7 @@ namespace Shouldly
         public static System.Collections.Generic.List<string> CompareAsObjectTypes { get; }
         public static Shouldly.DiffStyle DiffStyle { get; set; }
         public static Shouldly.EscapeStyle EscapeStyle { get; set; }
+        public static int MaxStringLengthInMessages { get; set; }
         public static System.IDisposable AllowStackWalking() { }
         public static System.IDisposable AssertCallerArgumentExpressionIsUsed() { }
         public static System.IDisposable DisableSourceInErrors() { }

--- a/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
+++ b/src/Shouldly.Tests/ShouldMatchApproved/ShouldMatchApprovedScenarios.cs
@@ -68,8 +68,9 @@ public class ShouldMatchApprovedScenarios
         }
 
         exception.ShouldNotBeNull();
-        // text is limited to 5000 char. but then the diff results in 5000*2+some extraneous text
-        exception.Message.Length.ShouldBeLessThan(12000);
+        // Each echoed value is capped at ShouldlyConfiguration.MaxStringLengthInMessages,
+        // and the difference section is windowed, so the whole message stays small.
+        exception.Message.Length.ShouldBeLessThan(3000);
     }
 
     [Fact]

--- a/src/Shouldly.Tests/Strings/MessageTruncation.cs
+++ b/src/Shouldly.Tests/Strings/MessageTruncation.cs
@@ -1,0 +1,124 @@
+namespace Shouldly.Tests.Strings;
+
+public class MessageTruncation
+{
+    [Fact]
+    public void DifferenceBeyondTheEchoBudgetIsStillShown()
+    {
+        var shared = new string('a', ShouldlyConfiguration.MaxStringLengthInMessages + 5000);
+        var actual = shared + "XXXX";
+        var expected = shared + "YYYY";
+
+        var message = Should.Throw<ShouldAssertException>(() => actual.ShouldBe(expected)).Message;
+
+        // The echoed values are clipped long before this point, so the only way these can
+        // show up is if the difference was computed from the untruncated values.
+        message.ShouldContain("difference");
+        message.ShouldContain("XXXX");
+        message.ShouldContain("YYYY");
+    }
+
+    [Fact]
+    public void TruncatedValuesSayHowMuchWasCut()
+    {
+        var limit = ShouldlyConfiguration.MaxStringLengthInMessages;
+        var actual = new string('a', limit + 1);
+
+        var message = Should.Throw<ShouldAssertException>(() => actual.ShouldBe("b")).Message;
+
+        message.ShouldContain($"(truncated to {limit} of {limit + 1} characters, " +
+                              "see ShouldlyConfiguration.MaxStringLengthInMessages)");
+    }
+
+    [Fact]
+    public void ValuesWithinTheBudgetAreNotAnnotated()
+    {
+        var actual = new string('a', ShouldlyConfiguration.MaxStringLengthInMessages);
+
+        var message = Should.Throw<ShouldAssertException>(() => actual.ShouldBe("b")).Message;
+
+        message.ShouldNotContain("truncated");
+    }
+
+    [Fact]
+    public void RaisingTheLimitEchoesMore()
+    {
+        var actual = new string('a', 4000) + "X";
+
+        using (MaxStringLengthScope.Of(5000))
+        {
+            var message = Should.Throw<ShouldAssertException>(() => actual.ShouldBe("b")).Message;
+
+            message.ShouldNotContain("truncated");
+            message.ShouldContain(actual);
+        }
+    }
+
+    [Fact]
+    public void LoweringTheLimitEchoesLess()
+    {
+        var actual = new string('a', 30);
+
+        using (MaxStringLengthScope.Of(10))
+        {
+            var message = Should.Throw<ShouldAssertException>(() => actual.ShouldBe("b")).Message;
+
+            message.ShouldContain("(truncated to 10 of 30 characters");
+        }
+    }
+
+    [Fact]
+    public void TheLimitMustBePositive()
+    {
+        Should.Throw<ArgumentOutOfRangeException>(() => ShouldlyConfiguration.MaxStringLengthInMessages = 0);
+    }
+
+    [Fact]
+    public void LineDiffCapsTheNumberOfChangedLines()
+    {
+        var actual = string.Join("\n", Enumerable.Range(0, 100).Select(i => $"a{i}"));
+        var expected = string.Join("\n", Enumerable.Range(0, 100).Select(i => $"b{i}"));
+
+        var message = Should.Throw<ShouldAssertException>(() => actual.ShouldBe(expected)).Message;
+
+        // 100 changed lines per side, 20 shown.
+        message.ShouldContain("Expected: ... and 80 more line(s)");
+        message.ShouldContain("Actual:   ... and 80 more line(s)");
+    }
+
+    [Fact]
+    public void LargeMultiLineValuesStillProduceABoundedMessage()
+    {
+        // Well past the point where splitting both values into per-line arrays would be
+        // wasteful: the highlighter must fall back to the O(1) character-mode diff rather
+        // than materialising line arrays for the whole input.
+        var actual = string.Join("\n", Enumerable.Range(0, 50_000).Select(i => $"line {i} a"));
+        var expected = string.Join("\n", Enumerable.Range(0, 50_000).Select(i => $"line {i} b"));
+
+        var message = Should.Throw<ShouldAssertException>(() => actual.ShouldBe(expected)).Message;
+
+        // A difference is still reported, and the whole message stays small. The line-mode
+        // "... more line(s)" marker must be absent: its presence would mean both values were
+        // split into full per-line arrays instead of taking the O(1) character-mode path.
+        message.ShouldContain("difference");
+        message.ShouldNotContain("more line(s)");
+        message.Length.ShouldBeLessThan(5000);
+    }
+
+    // MaxStringLengthInMessages is AsyncLocal-backed, so an override here can't leak
+    // into tests running in parallel — it still needs restoring for later tests on this context.
+    private static class MaxStringLengthScope
+    {
+        public static IDisposable Of(int value)
+        {
+            var previous = ShouldlyConfiguration.MaxStringLengthInMessages;
+            ShouldlyConfiguration.MaxStringLengthInMessages = value;
+            return new Restore(previous);
+        }
+
+        private sealed class Restore(int previous) : IDisposable
+        {
+            public void Dispose() => ShouldlyConfiguration.MaxStringLengthInMessages = previous;
+        }
+    }
+}

--- a/src/Shouldly/DifferenceHighlighting/LineDiffFormatter.cs
+++ b/src/Shouldly/DifferenceHighlighting/LineDiffFormatter.cs
@@ -4,6 +4,10 @@ class LineDiffFormatter
 {
     private const int MaxContextLines = 2;
 
+    // Cap on the changed lines shown per side. The differ runs on untruncated values, so
+    // without this a pair of large, wholly different documents would echo both in full.
+    private const int MaxChangedLines = 20;
+
     private readonly Case _caseSensitivity;
 
     public LineDiffFormatter(Case caseSensitivity)
@@ -59,16 +63,10 @@ class LineDiffFormatter
         }
 
         // Expected lines (removed from expected)
-        for (var i = expectedChangeStart; i < expectedChangeEnd; i++)
-        {
-            sb.AppendLine($"{ExpectedPrefix}{DisplayLine(expectedLines[i])}");
-        }
+        AppendChangedLines(sb, expectedLines, expectedChangeStart, expectedChangeEnd, ExpectedPrefix);
 
         // Actual lines (added in actual)
-        for (var i = actualChangeStart; i < actualChangeEnd; i++)
-        {
-            sb.AppendLine($"{ActualPrefix}{DisplayLine(actualLines[i])}");
-        }
+        AppendChangedLines(sb, actualLines, actualChangeStart, actualChangeEnd, ActualPrefix);
 
         // Up marker below actual line
         if (charDiffPos >= 0)
@@ -92,6 +90,20 @@ class LineDiffFormatter
             sb.Length -= Environment.NewLine.Length;
 
         return sb.ToString();
+    }
+
+    private static void AppendChangedLines(StringBuilder sb, string[] lines, int start, int end, string prefix)
+    {
+        var shown = Math.Min(end - start, MaxChangedLines);
+
+        for (var i = start; i < start + shown; i++)
+        {
+            sb.AppendLine($"{prefix}{DisplayLine(lines[i])}");
+        }
+
+        var hidden = end - start - shown;
+        if (hidden > 0)
+            sb.AppendLine($"{prefix}... and {hidden} more line(s)");
     }
 
     private static string DisplayLine(string line)

--- a/src/Shouldly/DifferenceHighlighting/StringDifferenceHighlighter.cs
+++ b/src/Shouldly/DifferenceHighlighting/StringDifferenceHighlighter.cs
@@ -5,6 +5,12 @@ class StringDifferenceHighlighter : IStringDifferenceHighlighter
     private const int MaxContextChars = 20;
     private const int MaxDisplayLength = 60;
     private const int MaxDiffRegions = 3;
+    private const int MaxHintScanLength = 100_000;
+
+    // Line mode splits both whole strings into per-line arrays before diffing, so its memory
+    // cost is proportional to the input. Past this size fall back to character mode, which walks
+    // the differing span in O(1) memory, rather than allocating line arrays for a multi-MB value.
+    private const int MaxLineModeLength = 100_000;
 
     private readonly Case _sensitivity;
     private readonly Func<string, string> _transform;
@@ -30,8 +36,9 @@ class StringDifferenceHighlighter : IStringDifferenceHighlighter
         var actualHasNewline = actual.Contains('\n');
         var maxLen = Math.Max(expected.Length, actual.Length);
 
-        if ((expectedHasNewline && actualHasNewline)
-            || ((expectedHasNewline || actualHasNewline) && maxLen > MaxDisplayLength))
+        if (maxLen <= MaxLineModeLength
+            && ((expectedHasNewline && actualHasNewline)
+                || ((expectedHasNewline || actualHasNewline) && maxLen > MaxDisplayLength)))
             return FormatLineMode(expected, actual);
 
         return FormatCharacterMode(expected, actual);
@@ -68,16 +75,14 @@ class StringDifferenceHighlighter : IStringDifferenceHighlighter
             return result;
         }
 
-        // For long strings, find individual diff positions within the diff region
-        var diffPositions = FindDiffPositions(expected, actual, commonPrefix, commonSuffix);
-        var regions = ConsolidateDiffPositions(diffPositions);
+        // For long strings, find individual diff regions within the diff span
+        var (regions, totalDiffs) = FindDiffRegions(expected, actual, commonPrefix, commonSuffix);
 
-        if (regions.Count == 0) return "";
+        if (totalDiffs == 0) return "";
 
         var output = new StringBuilder();
 
-        var totalDiffs = regions.Count;
-        var showCount = Math.Min(totalDiffs, MaxDiffRegions);
+        var showCount = regions.Count;
 
         if (totalDiffs > 1)
             output.AppendLine($"{totalDiffs} differences");
@@ -125,46 +130,51 @@ class StringDifferenceHighlighter : IStringDifferenceHighlighter
         return output.ToString();
     }
 
-    private List<int> FindDiffPositions(string expected, string actual, int commonPrefix, int commonSuffix)
+    // Walks the differing span once, consolidating adjacent positions into regions as it goes.
+    // Only the first MaxDiffRegions regions are retained — the rest are counted and dropped — so
+    // comparing two entirely different multi-megabyte strings stays O(1) in memory.
+    private (List<DiffRegion> Regions, int Total) FindDiffRegions(string expected, string actual, int commonPrefix, int commonSuffix)
     {
-        var positions = new List<int>();
+        var regions = new List<DiffRegion>();
+        var total = 0;
         var expectedEnd = expected.Length - commonSuffix;
         var actualEnd = actual.Length - commonSuffix;
         var maxEnd = Math.Max(expectedEnd, actualEnd);
 
-        for (var i = commonPrefix; i < maxEnd; i++)
+        var start = -1;
+        var end = -1;
+
+        void Close()
         {
-            if (!CharAtIndexIsEqual(expected, actual, i))
-                positions.Add(i);
+            total++;
+            if (regions.Count < MaxDiffRegions)
+                regions.Add(new DiffRegion(start, end));
         }
 
-        return positions;
-    }
-
-    private static List<DiffRegion> ConsolidateDiffPositions(List<int> positions)
-    {
-        if (positions.Count == 0) return [];
-
-        var regions = new List<DiffRegion>();
-        var start = positions[0];
-        var end = positions[0];
-
-        for (var i = 1; i < positions.Count; i++)
+        for (var i = commonPrefix; i < maxEnd; i++)
         {
-            if (positions[i] - end <= 5) // Merge nearby diffs
+            if (CharAtIndexIsEqual(expected, actual, i))
+                continue;
+
+            if (start < 0)
             {
-                end = positions[i];
+                start = end = i;
+            }
+            else if (i - end <= 5) // Merge nearby diffs
+            {
+                end = i;
             }
             else
             {
-                regions.Add(new DiffRegion(start, end));
-                start = positions[i];
-                end = positions[i];
+                Close();
+                start = end = i;
             }
         }
 
-        regions.Add(new DiffRegion(start, end));
-        return regions;
+        if (start >= 0)
+            Close();
+
+        return (regions, total);
     }
 
     private static ContextWindow ExtractContextWindow(string expected, string actual, int diffStart, int diffEnd)
@@ -230,6 +240,11 @@ class StringDifferenceHighlighter : IStringDifferenceHighlighter
 
     private string? DetectSmartHint(string expected, string actual)
     {
+        // Every check below needs a whole-string copy (line-ending normalisation, tab expansion).
+        // Past this size those allocations cost more than the hint is worth.
+        if (Math.Max(expected.Length, actual.Length) > MaxHintScanLength)
+            return null;
+
         var comparer = _sensitivity == Case.Insensitive
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;

--- a/src/Shouldly/Internals/Assertions/StringShouldBeAssertion.cs
+++ b/src/Shouldly/Internals/Assertions/StringShouldBeAssertion.cs
@@ -35,8 +35,9 @@ class StringShouldBeAssertion : IAssertion
 
     public string GenerateMessage(string? customMessage)
     {
-        var _actualTrimmed = Trim(_actual);
-        var _expectedTrimmed = Trim(_expected);
+        var actualValue = Echo(_actual);
+        var expectedValue = Echo(_expected);
+
         string? codeText;
         if (_actualExpression != null)
         {
@@ -50,19 +51,21 @@ class StringShouldBeAssertion : IAssertion
                     $"{nameof(ShouldlyConfiguration.AssertCallerArgumentExpressionIsUsed)} trip-wire being armed. " +
                     $"Wrap the call site in {nameof(ShouldlyConfiguration)}.{nameof(ShouldlyConfiguration.AllowStackWalking)}() to opt out.");
 
+            // No call-site text to show, so the rendered value stands in for it. Using the same
+            // echo means the "but was" line below collapses to " not" instead of repeating it.
 #if NETSTANDARD2_0
             codeText = ShouldlyConfiguration.IsSourceDisabledInErrors()
-                ? _actual.ToStringAwesomely()
+                ? actualValue
                 : _codeTextGetter.GetCodeText(_actual);
 #else
-            codeText = _actual.ToStringAwesomely();
+            codeText = actualValue;
 #endif
         }
         var withOption = string.IsNullOrEmpty(_options) ? null : $" with options: {_options}";
-        var actualValue = _actualTrimmed.ToStringAwesomely();
-        var expectedValue = _expectedTrimmed.ToStringAwesomely();
 
-        var differences = _diffHighlighter.HighlightDifferences(_expectedTrimmed, _actualTrimmed);
+        // Differences come from the full values. Truncating first would let a difference that
+        // sits past the echo budget disappear from the message entirely.
+        var differences = _diffHighlighter.HighlightDifferences(_expected, _actual);
 
         var actual = codeText == actualValue ?
             " not" :
@@ -102,19 +105,21 @@ class StringShouldBeAssertion : IAssertion
         return message;
     }
 
-    private static string? Trim(string? value)
+    // Renders a value for the "should be X but was Y" lines, clipped to
+    // ShouldlyConfiguration.MaxStringLengthInMessages. Truncation is always announced —
+    // silently swallowing the tail leaves no clue that the printed value is partial.
+    private static string? Echo(string? value)
     {
-        if (value == null)
+        var limit = ShouldlyConfiguration.MaxStringLengthInMessages;
+
+        if (value == null || value.Length <= limit)
         {
-            return null;
+            return value.ToStringAwesomely();
         }
 
-        if (value.Length <= 5000)
-        {
-            return value;
-        }
-
-        return value[..5000];
+        return $"{value[..limit].ToStringAwesomely()} " +
+               $"(truncated to {limit} of {value.Length} characters, see " +
+               $"{nameof(ShouldlyConfiguration)}.{nameof(ShouldlyConfiguration.MaxStringLengthInMessages)})";
     }
 
     public bool IsSatisfied() =>

--- a/src/Shouldly/ShouldlyConfiguration.cs
+++ b/src/Shouldly/ShouldlyConfiguration.cs
@@ -82,4 +82,37 @@ public static partial class ShouldlyConfiguration
     }
 
     private const string EscapeStyleKey = "ShouldlyEscapeStyle";
+
+    /// <summary>
+    /// Maximum number of characters of the actual and expected values echoed back in string
+    /// assertion failure messages. Longer values are truncated, and the message says so along
+    /// with the value's full length.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This only bounds the verbatim echo. The <c>difference</c> section is always computed from
+    /// the full, untruncated values, so lowering this can never hide a difference — it just trims
+    /// the surrounding noise. Raise it when you want more of the raw value in the message.
+    /// </para>
+    /// <para>
+    /// Scoped to the logical call context. Flows down through async/await and
+    /// Task.Run by default; concurrent contexts get their own value.
+    /// </para>
+    /// </remarks>
+    public static int MaxStringLengthInMessages
+    {
+        get => (int?)CallContext.LogicalGetData(MaxStringLengthInMessagesKey) ?? DefaultMaxStringLengthInMessages;
+        set
+        {
+            if (value < 1)
+                throw new ArgumentOutOfRangeException(nameof(value), value,
+                    $"{nameof(MaxStringLengthInMessages)} must be at least 1.");
+
+            CallContext.LogicalSetData(MaxStringLengthInMessagesKey, value);
+        }
+    }
+
+    private const int DefaultMaxStringLengthInMessages = 1000;
+
+    private const string MaxStringLengthInMessagesKey = "ShouldlyMaxStringLengthInMessages";
 }


### PR DESCRIPTION
String `ShouldBe` messages used to echo up to a hardcoded 5000 characters of each value and computed the `difference` section from those already-truncated values, so two long strings differing past character 5000 produced a ~10 KB message showing identical-looking values and no difference at all. Now the difference is always computed from the full values while only the echo is clipped — to the new `ShouldlyConfiguration.MaxStringLengthInMessages` (default 1000, logical-call-context scoped, validated `>= 1`) — and truncation is announced with the value's full length. The difference section is independently bounded: character mode walks the differing span in O(1) memory (max 3 regions), line mode caps at 20 changed lines per side with an `... and N more line(s)` marker, and very large / multi-MB values fall back to character mode and skip the smart-hint scan. Adds `MessageTruncation` tests, documents the new setting plus the existing `DiffStyle`/`EscapeStyle` in configuration.md and the 4→5 upgrade guide, and updates the approved public-API snapshot. Also fixes `.gitignore` to exclude the root `TestResults/` output directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)