### PR TITLE
Detect reference cycles through collections, sets, and dictionaries

### DIFF
--- a/src/Shouldly.Tests/ShouldBeEquivalentTo/CyclicCollectionScenario.cs
+++ b/src/Shouldly.Tests/ShouldBeEquivalentTo/CyclicCollectionScenario.cs
@@ -1,0 +1,94 @@
+namespace Shouldly.Tests.ShouldBeEquivalentTo;
+
+/// <summary>
+/// Regression coverage for cycles that close through a collection, array, set or dictionary node.
+/// </summary>
+public class CyclicCollectionScenario
+{
+    [Fact]
+    public void ShouldPassWhenListContainsItself()
+    {
+        var subject = new List<object> { 1 };
+        subject.Add(subject);
+
+        var expected = new List<object> { 1 };
+        expected.Add(expected);
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldDetectDifferencesAlongsideSelfReferentialList()
+    {
+        var subject = new List<object> { 1 };
+        subject.Add(subject);
+
+        var expected = new List<object> { 2 };
+        expected.Add(expected);
+
+        // The cycle terminates, but the differing sibling element is still reported.
+        Should.Throw<ShouldAssertException>(() => subject.ShouldBeEquivalentTo(expected));
+    }
+
+    [Fact]
+    public void ShouldPassWhenTwoListsFormMutualCycle()
+    {
+        var subjectA = new List<object>();
+        var subjectB = new List<object> { subjectA };
+        subjectA.Add(subjectB);
+
+        var expectedA = new List<object>();
+        var expectedB = new List<object> { expectedA };
+        expectedA.Add(expectedB);
+
+        subjectA.ShouldBeEquivalentTo(expectedA);
+    }
+
+    [Fact]
+    public void ShouldPassWhenArrayContainsItself()
+    {
+        var subject = new object[1];
+        subject[0] = subject;
+
+        var expected = new object[1];
+        expected[0] = expected;
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldPassWhenSetContainsItself()
+    {
+        var subject = new HashSet<object> { 1 };
+        subject.Add(subject);
+
+        var expected = new HashSet<object> { 1 };
+        expected.Add(expected);
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldPassWhenDictionaryValueContainsItself()
+    {
+        var subject = new Dictionary<string, object> { ["value"] = 1 };
+        subject["self"] = subject;
+
+        var expected = new Dictionary<string, object> { ["value"] = 1 };
+        expected["self"] = expected;
+
+        subject.ShouldBeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void ShouldDetectDifferencesAlongsideSelfReferentialDictionary()
+    {
+        var subject = new Dictionary<string, object> { ["value"] = 1 };
+        subject["self"] = subject;
+
+        var expected = new Dictionary<string, object> { ["value"] = 2 };
+        expected["self"] = expected;
+
+        Should.Throw<ShouldAssertException>(() => subject.ShouldBeEquivalentTo(expected));
+    }
+}

--- a/src/Shouldly/Equivalency/EquivalencyComparison.cs
+++ b/src/Shouldly/Equivalency/EquivalencyComparison.cs
@@ -13,10 +13,16 @@ internal sealed class EquivalencyComparison
     private readonly List<EquivalencyDifference> _differences = [];
     private readonly HashSet<VisitedPair> _visitedPairs = [];
 
-    private EquivalencyComparison(IEquivalencyShapeProvider shapes, EquivalencyOptions options)
+    // Pairs currently on the recursion stack (ancestors of the node being compared). Unlike
+    // _visitedPairs (a per-comparison dedup cache that only grows), entries are pushed on the way
+    // down and popped on the way back up, so this set always reflects the live ancestor chain.
+    private readonly HashSet<VisitedPair> _activePairs;
+
+    private EquivalencyComparison(IEquivalencyShapeProvider shapes, EquivalencyOptions options, HashSet<VisitedPair>? activePairs = null)
     {
         _shapes = shapes;
         _options = options;
+        _activePairs = activePairs ?? [];
     }
 
     public static void Assert(
@@ -60,40 +66,64 @@ internal sealed class EquivalencyComparison
         var annotatedPath = AnnotateWithType(path, comparisonType);
 
         var shape = _shapes.GetShape(comparisonType);
-        switch (shape.Kind)
+
+        // Cycle / identity guard for composite reference nodes. Leaves compare by value and cannot
+        // form cycles; value types are copied and cannot participate in reference-identity cycles.
+        // Tracking every composite kind here means a cycle that closes through a
+        // collection, dictionary or set terminates instead of recursing until StackOverflow.
+        var tracked = shape.Kind != EquivalencyNodeKind.Leaf && actual is not ValueType && expected is not ValueType;
+        VisitedPair pair = default;
+        if (tracked)
         {
-            case EquivalencyNodeKind.Leaf:
-                if (!LeafEquals(actual, expected))
-                    AddDifference(EquivalencyDifferenceKind.ValueMismatch, annotatedPath, expected, actual);
-                break;
+            if (ReferenceEquals(actual, expected))
+                return;
 
-            case EquivalencyNodeKind.Dictionary:
-                CompareDictionaries(actual, expected, shape, annotatedPath);
-                break;
+            pair = new(actual, expected);
 
-            case EquivalencyNodeKind.Set:
-                CompareUnordered(actual, expected, shape.ElementType, annotatedPath);
-                break;
+            // An in-progress ancestor pair reappearing is a cycle: treat it as equivalent (already
+            // being compared). A pair already recorded in _visitedPairs was fully compared earlier in
+            // this walk (a shared subgraph), so skip re-reporting the same differences.
+            if (_activePairs.Contains(pair) || !_visitedPairs.Add(pair))
+                return;
 
-            case EquivalencyNodeKind.Sequence:
-                CompareSequences(actual, expected, shape.ElementType, annotatedPath);
-                break;
+            _activePairs.Add(pair);
+        }
 
-            default:
-                CompareComplex(actual, expected, shape, annotatedPath);
-                break;
+        try
+        {
+            switch (shape.Kind)
+            {
+                case EquivalencyNodeKind.Leaf:
+                    if (!LeafEquals(actual, expected))
+                        AddDifference(EquivalencyDifferenceKind.ValueMismatch, annotatedPath, expected, actual);
+                    break;
+
+                case EquivalencyNodeKind.Dictionary:
+                    CompareDictionaries(actual, expected, shape, annotatedPath);
+                    break;
+
+                case EquivalencyNodeKind.Set:
+                    CompareUnordered(actual, expected, shape.ElementType, annotatedPath);
+                    break;
+
+                case EquivalencyNodeKind.Sequence:
+                    CompareSequences(actual, expected, shape.ElementType, annotatedPath);
+                    break;
+
+                default:
+                    CompareComplex(actual, expected, shape, annotatedPath);
+                    break;
+            }
+        }
+        finally
+        {
+            if (tracked)
+                _activePairs.Remove(pair);
         }
     }
 
     private void CompareComplex(object actual, object expected, EquivalencyTypeShape shape, List<string> path)
     {
-        if (ReferenceEquals(actual, expected))
-            return;
-
-        // Cycle tracking by reference identity; value types cannot participate in cycles.
-        if (actual is not ValueType && expected is not ValueType && !_visitedPairs.Add(new(actual, expected)))
-            return;
-
         var actualType = actual.GetType();
         var actualShape = actualType == shape.Type ? shape : _shapes.GetShape(actualType);
 
@@ -272,7 +302,11 @@ internal sealed class EquivalencyComparison
     /// <summary>Runs a full sub-comparison, discarding differences; used for order-insensitive matching.</summary>
     private bool IsEquivalent(object? actual, object? expected, Type? declaredType)
     {
-        var comparison = new EquivalencyComparison(_shapes, _options);
+        // Share the live ancestor set. Entries are pushed and popped in CompareNodes, so the set is restored
+        // when this returns and sibling trials never observe each other's entries. The sub-comparison
+        // still gets a fresh _visitedPairs, keeping each trial's shared-subgraph dedup independent - a
+        // pair fully compared in one trial must be re-derived in another rather than assumed equal.
+        var comparison = new EquivalencyComparison(_shapes, _options, _activePairs);
         comparison.CompareNodes(actual, expected, declaredType, []);
         return comparison._differences.Count == 0;
     }


### PR DESCRIPTION
Fixes #1307 

## Problem

`ShouldBeEquivalentTo` throws an uncatchable `StackOverflowException` when the compared graphs contain a reference cycle that closes through a **collection, array, set, or dictionary** node.

## Root cause

Cycle tracking (`_visitedPairs`) was only consulted in `CompareComplex`. The `CompareSequences`, `CompareUnordered` (sets / `IgnoreOrder`), `CompareDictionaries`, and multidimensional-array branches never registered or checked visited pairs, so a cycle routed through any of them never terminated.

The set / `IgnoreOrder` / dictionary-key paths recurse through `IsEquivalent`, which starts a **fresh** comparison with an empty `_visitedPairs`.

## Fix

- **Hoist the cycle/identity guard into `CompareNodes`** so every composite reference node (sequence, array, set, dictionary, complex) is tracked.
- **Add a stack-scoped `_activePairs` set** that represents the live ancestor chain, and **share it into `IsEquivalent`** so cycles that close through order-insensitive matching also terminate.
