### PR TITLE
Fix #1318: ShouldBe(ignoreOrder: true) passing for unequal collections with default value

### DIFF
--- a/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderDefaultValueScenario.cs
+++ b/src/Shouldly.Tests/ShouldBe/EnumerableType/IgnoreOrderDefaultValueScenario.cs
@@ -1,0 +1,70 @@
+namespace Shouldly.Tests.ShouldBe.EnumerableType;
+
+/// <summary>
+/// Regression coverage for the order-insensitive comparison matching an unmatched element against <c>default(T)</c>.
+/// </summary>
+public class IgnoreOrderDefaultValueScenario
+{
+    [Fact]
+    public void ShouldFailWhenAnUnmatchedElementCollidesWithDefaultInt()
+    {
+        int[] actual = [5, 5];
+        int[] expected = [5, 0];
+
+        Should.Throw<ShouldAssertException>(() => actual.ShouldBe(expected, ignoreOrder: true));
+    }
+
+    [Fact]
+    public void ShouldFailForSingleElementMismatchWhenExpectedIsDefaultInt()
+    {
+        int[] actual = [1];
+        int[] expected = [0];
+
+        Should.Throw<ShouldAssertException>(() => actual.ShouldBe(expected, ignoreOrder: true));
+    }
+
+    [Fact]
+    public void ShouldFailWhenAnUnmatchedElementCollidesWithNull()
+    {
+        string?[] actual = ["a"];
+        string?[] expected = [null];
+
+        Should.Throw<ShouldAssertException>(() => actual.ShouldBe(expected, ignoreOrder: true));
+    }
+
+    [Fact]
+    public void ShouldFailWhenBothContainDefaultButRemainingElementsDiffer()
+    {
+        int[] actual = [0, 0];
+        int[] expected = [0, 5];
+
+        Should.Throw<ShouldAssertException>(() => actual.ShouldBe(expected, ignoreOrder: true));
+    }
+
+    [Fact]
+    public void ShouldPassWhenMultisetsAreEqualIncludingDefault()
+    {
+        int[] actual = [5, 0];
+        int[] expected = [0, 5];
+
+        actual.ShouldBe(expected, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void ShouldPassWhenDefaultAppearsMultipleTimesInEqualMultisets()
+    {
+        int[] actual = [0, 0, 7];
+        int[] expected = [7, 0, 0];
+
+        actual.ShouldBe(expected, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void ShouldPassWhenNullsMatchAcrossEqualMultisets()
+    {
+        string?[] actual = ["a", null, "b"];
+        string?[] expected = [null, "b", "a"];
+
+        actual.ShouldBe(expected, ignoreOrder: true);
+    }
+}

--- a/src/Shouldly/Internals/Is.cs
+++ b/src/Shouldly/Internals/Is.cs
@@ -81,12 +81,17 @@ static class Is
         var expectedList = expected.ToList();
         foreach (var actualElement in actual)
         {
-            var match = expectedList.FirstOrDefault(x => Equal(x, actualElement, comparer));
-            if (!expectedList.Remove(match!)) // List<T>.Remove works fine when null is passed.
+            // Match by index rather than FirstOrDefault + Remove: when no element is equivalent,
+            // FirstOrDefault returns default(T), and Remove(default(T)) would succeed whenever
+            // default(T) (e.g. 0 or null) is present in the list.
+            var index = expectedList.FindIndex(x => Equal(x, actualElement, comparer));
+            if (index < 0)
                 return false;
+
+            expectedList.RemoveAt(index);
         }
 
-        return !expectedList.Any();
+        return expectedList.Count == 0;
     }
 
     public static bool Equal(IEnumerable<decimal> actual, IEnumerable<decimal> expected, decimal tolerance)


### PR DESCRIPTION
Fixes #1318 

## Root cause

The order-insensitive comparison in `Is.EqualIgnoreOrder` (`src/Shouldly/Internals/Is.cs`) matches each actual element with `FirstOrDefault` and then removes the match:

```csharp
var expectedList = expected.ToList();
foreach (var actualElement in actual)
{
    var match = expectedList.FirstOrDefault(x => Equal(x, actualElement, comparer));
    if (!expectedList.Remove(match!)) // List<T>.Remove works fine when null is passed.
        return false;
}

return !expectedList.Any();
```

When no element is equivalent to `actualElement`, `FirstOrDefault` returns `default(T)`. If `default(T)` happens to be an element of `expectedList` (`0` for `int`, `null` for a reference type), `expectedList.Remove(default(T))` succeeds and wrongly consumes that element, so an unmatched actual element is treated as matched and the method can return `true` for unequal collections.