### PR TITLE
Fix #1325: compare dictionary values structurally, like ShouldBe

### DIFF
--- a/documentation/documentation/dictionary/containKeyAndValue.md
+++ b/documentation/documentation/dictionary/containKeyAndValue.md
@@ -50,3 +50,19 @@ websters
     but does
 ```
 <!-- endInclude -->
+
+
+## Value comparison
+
+The value is compared the same way [`ShouldBe`](../equality/shouldBe.md) compares it, not with `object.Equals`. Collection values are compared element-wise, numeric values honour `ShouldlyConfiguration.DefaultFloatingPointTolerance`, and `IEquatable<T>`/`IComparable<T>` are preferred over `Equals`:
+
+```cs
+var dictionary = new Dictionary<string, int[]> { ["key"] = [1, 2, 3] };
+
+// Passes — a different array instance with the same contents.
+dictionary.ShouldContainKeyAndValue("key", [1, 2, 3]);
+```
+
+This is not a member-wise comparison: a type that doesn't override `Equals` is still compared by reference. For member-wise comparison of a whole object graph, use `ShouldBeEquivalentTo`.
+
+The key, by contrast, is always looked up with the dictionary's own key comparer.

--- a/documentation/documentation/dictionary/containKeyAndValue.md
+++ b/documentation/documentation/dictionary/containKeyAndValue.md
@@ -63,6 +63,8 @@ var dictionary = new Dictionary<string, int[]> { ["key"] = [1, 2, 3] };
 dictionary.ShouldContainKeyAndValue("key", [1, 2, 3]);
 ```
 
-This is not a member-wise comparison: a type that doesn't override `Equals` is still compared by reference. For member-wise comparison of a whole object graph, use `ShouldBeEquivalentTo`.
+This is not a member-wise comparison. A value that is neither a collection nor implements `IEquatable<T>`, `IComparable<T>`, or `IComparable` falls through to `object.Equals`, so a reference type that doesn't override it is still compared by reference. For member-wise comparison of a whole object graph, use `ShouldBeEquivalentTo`.
+
+One caveat, shared with `ShouldBe`: the *elements* of a collection value are compared without their static element type, so an element type that implements `IEquatable<T>` but doesn't override `Equals` (which [CA1067](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1067) flags) is compared by reference. `ShouldBe` on the value itself knows the element type and does honour it; it loses the same way one level deeper, on nested collections.
 
 The key, by contrast, is always looked up with the dictionary's own key comparer.

--- a/documentation/documentation/upgrade/4to5.md
+++ b/documentation/documentation/upgrade/4to5.md
@@ -46,6 +46,24 @@ Messages for long strings get substantially shorter, and the `difference` sectio
 
 Line-mode diffs also now cap at 20 changed lines per side, with an `... and N more line(s)` marker.
 
+## Dictionary value assertions compare values structurally
+
+`ShouldContainKeyAndValue` and `ShouldNotContainValueForKey` compared the value with `object.Equals` in v4, while the rest of the library — including `ShouldBe` on the very same value — goes through Shouldly's structural comparer. A collection-valued dictionary therefore behaved differently depending on which assertion you reached for:
+
+```csharp
+var dictionary = new Dictionary<string, int[]> { ["key"] = [1, 2, 3] };
+
+dictionary["key"].ShouldBe([1, 2, 3]);                    // v4 and v5: passes
+dictionary.ShouldContainKeyAndValue("key", [1, 2, 3]);    // v4: fails.   v5: passes
+dictionary.ShouldNotContainValueForKey("key", [1, 2, 3]); // v4: passes.  v5: fails
+```
+
+In v5 both assertions compare the value exactly as `ShouldBe` does: collections element-wise, numerics across types and honouring `ShouldlyConfiguration.DefaultFloatingPointTolerance`, then `IEquatable<T>`/`IComparable<T>` ahead of `object.Equals`. `string` and the types registered in `ShouldlyConfiguration.CompareAsObjectTypes` keep comparing with their own `Equals`, as they already did under `ShouldBe`.
+
+Values that were already `Equals`-equal are unaffected, and this is *not* member-wise comparison — a reference type that doesn't override `Equals` still compares by reference. (Member-wise remains [`ShouldBeEquivalentTo`](#shouldbeequivalentto-has-been-rewritten).) The break is confined to `ShouldNotContainValueForKey` calls that passed only because two structurally-equal values were distinct instances; those now fail. `ShouldContainKeyAndValue` only goes from failing to passing, so it cannot break a green suite.
+
+Key lookup is unchanged — `ShouldContainKey` and friends still defer to the dictionary's own key comparer.
+
 ## The `Shouldly.Configuration` namespace has been removed
 
 The approval-test configuration types — `ShouldMatchConfiguration`, `ShouldMatchConfigurationBuilder`, and friends — lived in the `Shouldly.Configuration` namespace in v4. In v5 they have been collapsed into the root `Shouldly` namespace, and `Shouldly.Configuration` no longer exists. (`FirstNonShouldlyMethodFinder`, `ITestMethodFinder`, and `FindMethodUsingAttribute<T>` are gone entirely — see [`ShouldMatchApproved` no longer walks the stack](#shouldmatchapproved-no-longer-walks-the-stack).)

--- a/documentation/documentation/upgrade/4to5.md
+++ b/documentation/documentation/upgrade/4to5.md
@@ -58,9 +58,11 @@ dictionary.ShouldContainKeyAndValue("key", [1, 2, 3]);    // v4: fails.   v5: pa
 dictionary.ShouldNotContainValueForKey("key", [1, 2, 3]); // v4: passes.  v5: fails
 ```
 
-In v5 both assertions compare the value exactly as `ShouldBe` does: collections element-wise, numerics across types and honouring `ShouldlyConfiguration.DefaultFloatingPointTolerance`, then `IEquatable<T>`/`IComparable<T>` ahead of `object.Equals`. `string` and the types registered in `ShouldlyConfiguration.CompareAsObjectTypes` keep comparing with their own `Equals`, as they already did under `ShouldBe`.
+In v5 both assertions compare the value the way `ShouldBe` does: collections element-wise, numerics across types and honouring `ShouldlyConfiguration.DefaultFloatingPointTolerance`, then `IEquatable<T>`/`IComparable<T>` ahead of `object.Equals`. `string` and the types registered in `ShouldlyConfiguration.CompareAsObjectTypes` keep comparing with their own `Equals`, as they already did under `ShouldBe`.
 
-Values that were already `Equals`-equal are unaffected, and this is *not* member-wise comparison — a reference type that doesn't override `Equals` still compares by reference. (Member-wise remains [`ShouldBeEquivalentTo`](#shouldbeequivalentto-has-been-rewritten).) The break is confined to `ShouldNotContainValueForKey` calls that passed only because two structurally-equal values were distinct instances; those now fail. `ShouldContainKeyAndValue` only goes from failing to passing, so it cannot break a green suite.
+This is *not* member-wise comparison. A value that is neither a collection nor implements `IEquatable<T>`/`IComparable<T>`/`IComparable` still falls through to `object.Equals`, so a reference type that doesn't override it compares by reference. (Member-wise remains [`ShouldBeEquivalentTo`](#shouldbeequivalentto-has-been-rewritten).)
+
+The break runs in both directions, wherever `Equals` and structural equality disagree. The common direction is the one above — two structurally-equal but distinct instances, which makes `ShouldContainKeyAndValue` start passing and `ShouldNotContainValueForKey` start failing. The reverse happens when a value's `Equals` reports equality the structural walk doesn't: a collection type that overrides `Equals` to compare only an id, say, is now walked element-wise, so `ShouldContainKeyAndValue` can go from passing to failing. If a dictionary value assertion changes result on upgrade, check it against `dictionary[key].ShouldBe(value)` — that is now the definition.
 
 Key lookup is unchanged — `ShouldContainKey` and friends still defer to the dictionary's own key comparer.
 

--- a/src/Shouldly.Tests/Dictionaries/DictionaryValueEquality.cs
+++ b/src/Shouldly.Tests/Dictionaries/DictionaryValueEquality.cs
@@ -1,0 +1,111 @@
+namespace Shouldly.Tests.Dictionaries;
+
+using static DictionaryTestData;
+
+/// <summary>
+/// The dictionary value assertions compare the value the same way <c>ShouldBe</c> does, rather than
+/// with <see cref="object.Equals(object, object)"/>. See issue #1325.
+/// </summary>
+// FloatingPointValuesHonourTheDefaultTolerance mutates the global ShouldlyConfiguration.DefaultFloatingPointTolerance,
+// so the class runs in the non-parallel Global configuration collection to keep that change from leaking into
+// floating-point assertions in other test classes.
+[Collection(GlobalConfigCollection.Name)]
+public class DictionaryValueEquality
+{
+    [Fact]
+    public void CollectionValuesAreComparedStructurally()
+    {
+        var dictionary = new Dictionary<string, int[]> { ["key"] = [1, 2, 3] };
+
+        // A different array instance with identical contents.
+        dictionary.ShouldContainKeyAndValue("key", [1, 2, 3]);
+        Should.Throw<ShouldAssertException>(() => dictionary.ShouldNotContainValueForKey("key", [1, 2, 3]));
+    }
+
+    [Fact]
+    public void CollectionValuesWithDifferentContentsAreNotEqual()
+    {
+        var dictionary = new Dictionary<string, int[]> { ["key"] = [1, 2, 3] };
+
+        dictionary.ShouldNotContainValueForKey("key", [1, 2, 4]);
+        Should.Throw<ShouldAssertException>(() => dictionary.ShouldContainKeyAndValue("key", [1, 2, 4]));
+    }
+
+    [Fact]
+    public void CollectionValuesOfDifferentContainerTypesAreEqual()
+    {
+        var dictionary = new Dictionary<string, IEnumerable<int>> { ["key"] = new[] { 1, 2, 3 } };
+
+        dictionary.ShouldContainKeyAndValue("key", new List<int> { 1, 2, 3 });
+        Should.Throw<ShouldAssertException>(() => dictionary.ShouldNotContainValueForKey("key", new List<int> { 1, 2, 3 }));
+    }
+
+    [Fact]
+    public void NestedCollectionValuesAreComparedStructurally()
+    {
+        var dictionary = new Dictionary<string, int[][]> { ["key"] = [[1, 2], [3]] };
+
+        dictionary.ShouldContainKeyAndValue("key", [[1, 2], [3]]);
+        dictionary.ShouldNotContainValueForKey("key", [[1, 2], [4]]);
+    }
+
+    [Fact]
+    public void FloatingPointValuesHonourTheDefaultTolerance()
+    {
+        var dictionary = new Dictionary<string, double> { ["key"] = 1.0 };
+
+        dictionary.ShouldNotContainValueForKey("key", 1.05);
+
+        ShouldlyConfiguration.DefaultFloatingPointTolerance = 0.1;
+        try
+        {
+            dictionary.ShouldContainKeyAndValue("key", 1.05);
+        }
+        finally
+        {
+            ShouldlyConfiguration.DefaultFloatingPointTolerance = 0.0;
+        }
+    }
+
+    [Fact]
+    public void ReferenceTypesWithoutAnEqualsOverrideAreStillComparedByReference()
+    {
+        // Nothing about this change makes the comparison member-wise — that is ShouldBeEquivalentTo's job.
+        ClassDictionary().ShouldContainKeyAndValue(ThingKey, ThingValue);
+        ClassDictionary().ShouldNotContainValueForKey(ThingKey, new());
+    }
+
+    /// <summary>
+    /// <see cref="Strange"/> emulates JToken: implicitly convertible from a string, <see cref="IEnumerable{T}"/>,
+    /// and registered in <see cref="ShouldlyConfiguration.CompareAsObjectTypes"/> so that it is compared with its
+    /// own Equals rather than being walked as an (empty) enumerable. The dictionary value assertions honour that
+    /// registration for the same reason ShouldBe does.
+    /// </summary>
+    [Fact]
+    public void CompareAsObjectTypesIsHonoured()
+    {
+        var dictionary = new Dictionary<string, Strange> { ["key"] = new() };
+
+        dictionary.ShouldNotContainValueForKey("key", "string");
+        Should.Throw<ShouldAssertException>(() => dictionary.ShouldContainKeyAndValue("key", "string"));
+
+        var populated = new Dictionary<string, Strange> { ["key"] = "string" };
+        populated.ShouldContainKeyAndValue("key", "string");
+    }
+
+    [Fact]
+    public void StringValuesAreComparedOrdinally()
+    {
+        StringDictionary().ShouldContainKeyAndValue("Foo", "Bar");
+        StringDictionary().ShouldNotContainValueForKey("Foo", "bar");
+    }
+
+    [Fact]
+    public void MissingKeyStillFailsBothAssertions()
+    {
+        var dictionary = new Dictionary<string, int[]> { ["key"] = [1, 2, 3] };
+
+        Should.Throw<ShouldAssertException>(() => dictionary.ShouldContainKeyAndValue("missing", [1, 2, 3]));
+        Should.Throw<ShouldAssertException>(() => dictionary.ShouldNotContainValueForKey("missing", [1, 2, 3]));
+    }
+}

--- a/src/Shouldly.Tests/Dictionaries/DictionaryValueEquality.cs
+++ b/src/Shouldly.Tests/Dictionaries/DictionaryValueEquality.cs
@@ -100,6 +100,30 @@ public class DictionaryValueEquality
         StringDictionary().ShouldNotContainValueForKey("Foo", "bar");
     }
 
+    /// <summary>
+    /// A limitation shared with <c>ShouldBe</c>, pinned here so the divergence is deliberate rather than
+    /// discovered: the elements of a collection value are compared without their static element type, so an
+    /// element implementing <see cref="IEquatable{T}"/> without an <see cref="object.Equals(object)"/> override
+    /// (CA1067) falls back to reference equality. <c>ShouldBe</c> on the value itself has the element type
+    /// statically and honours it; it loses the same way one level deeper, on nested collections.
+    /// </summary>
+    [Fact]
+    public void ElementsOfACollectionValueDoNotHonourIEquatableWithoutAnEqualsOverride()
+    {
+        var element = new EquatableWithoutEqualsOverride(1);
+        var dictionary = new Dictionary<string, EquatableWithoutEqualsOverride[]> { ["key"] = [element] };
+        EquatableWithoutEqualsOverride[] equalButNotIdentical = [new(1)];
+
+        dictionary.ShouldNotContainValueForKey("key", equalButNotIdentical);
+
+        // The same elements do compare equal where the element type is statically known...
+        dictionary["key"].ShouldBe(equalButNotIdentical);
+
+        // ...and where the value is the equatable itself rather than an element of one.
+        new Dictionary<string, EquatableWithoutEqualsOverride> { ["key"] = element }
+            .ShouldContainKeyAndValue("key", new(1));
+    }
+
     [Fact]
     public void MissingKeyStillFailsBothAssertions()
     {
@@ -109,3 +133,16 @@ public class DictionaryValueEquality
         Should.Throw<ShouldAssertException>(() => dictionary.ShouldNotContainValueForKey("missing", [1, 2, 3]));
     }
 }
+
+#pragma warning disable CA1067 // Deliberately no object.Equals override — that shape is what this file pins.
+/// <summary>
+/// Implements <see cref="IEquatable{T}"/> without overriding <see cref="object.Equals(object)"/>, so a typed
+/// comparer and the object comparer disagree about two instances carrying the same value.
+/// </summary>
+file class EquatableWithoutEqualsOverride(int value) : IEquatable<EquatableWithoutEqualsOverride>
+{
+    private int Value { get; } = value;
+
+    public bool Equals(EquatableWithoutEqualsOverride? other) => other is not null && other.Value == Value;
+}
+#pragma warning restore CA1067

--- a/src/Shouldly.Tests/TestHelpers/GlobalConfigCollection.cs
+++ b/src/Shouldly.Tests/TestHelpers/GlobalConfigCollection.cs
@@ -1,0 +1,13 @@
+namespace Shouldly.Tests.TestHelpers;
+
+/// <summary>
+/// Collection for tests that mutate global <see cref="ShouldlyConfiguration"/> state (for example
+/// <see cref="ShouldlyConfiguration.DefaultFloatingPointTolerance"/>). Disabling parallelization keeps
+/// the collection from running concurrently with any other test, so a temporary global change cannot
+/// leak into an assertion running in a different test class.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class GlobalConfigCollection
+{
+    public const string Name = "Global configuration";
+}

--- a/src/Shouldly/Internals/Is.cs
+++ b/src/Shouldly/Internals/Is.cs
@@ -35,6 +35,15 @@ static class Is
     /// <see cref="object.Equals(object)"/> rather than being walked as enumerables. Shared so that every
     /// assertion comparing one value — <c>ShouldBe</c>, the dictionary value assertions — agrees on equality.
     /// </summary>
+    /// <remarks>
+    /// Agreement stops at the elements of a collection-typed <typeparamref name="T"/>. The element type isn't
+    /// available here, so elements go through the default object comparer, which — unlike
+    /// <c>EqualityComparer&lt;TElement&gt;</c> — can't see a typed <see cref="IEquatable{T}"/> implementation.
+    /// An element type that implements <see cref="IEquatable{T}"/> without overriding
+    /// <see cref="object.Equals(object)"/> (which CA1067 flags) therefore compares by reference, where
+    /// <c>ShouldBe</c>'s enumerable overload — which has the element type statically — honours it. That overload
+    /// loses the same way one level deeper, on nested collections.
+    /// </remarks>
     public static IEqualityComparer<T> ScalarComparerFor<T>() =>
         ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName!) || typeof(T) == typeof(string)
             ? new ObjectEqualityComparer<T>()

--- a/src/Shouldly/Internals/Is.cs
+++ b/src/Shouldly/Internals/Is.cs
@@ -28,6 +28,18 @@ static class Is
     private static IEqualityComparer<T> GetEqualityComparer<T>(IEqualityComparer? innerComparer = null) =>
         new Internals.EqualityComparer<T>(innerComparer);
 
+    /// <summary>
+    /// The comparer used to compare a single value of type <typeparamref name="T"/>: Shouldly's structural
+    /// comparer, except for <see cref="string"/> and the types registered in
+    /// <see cref="ShouldlyConfiguration.CompareAsObjectTypes"/>, which are compared with their own
+    /// <see cref="object.Equals(object)"/> rather than being walked as enumerables. Shared so that every
+    /// assertion comparing one value — <c>ShouldBe</c>, the dictionary value assertions — agrees on equality.
+    /// </summary>
+    public static IEqualityComparer<T> ScalarComparerFor<T>() =>
+        ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName!) || typeof(T) == typeof(string)
+            ? new ObjectEqualityComparer<T>()
+            : GetEqualityComparer<T>();
+
     public static bool Equal<T>(IEnumerable<T>? actual, IEnumerable<T>? expected) =>
         // The initial implementation of this functionality call Equal(actualEnum.Current, expectedEnum.Current), which
         // internally calls GetEqualityComparer<T>() to get the comparer.  As this is the case, we can just call GetEqualityComparer<T>()

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBe/GenericShouldBeTestExtensions.cs
@@ -19,10 +19,7 @@ public static partial class ShouldBeTestExtensions
         string? customMessage = null,
         [CallerArgumentExpression(nameof(actual))] string? actualExpression = null)
     {
-        if (ShouldlyConfiguration.CompareAsObjectTypes.Contains(typeof(T).FullName!) || typeof(T) == typeof(string))
-            actual.AssertAwesomely(v => Is.Equal(v, expected, new ObjectEqualityComparer<T>()), actual, expected, customMessage, actualExpression: actualExpression);
-        else
-            actual.AssertAwesomely(v => Is.Equal(v, expected), actual, expected, customMessage, actualExpression: actualExpression);
+        actual.AssertAwesomely(v => Is.Equal(v, expected, Is.ScalarComparerFor<T>()), actual, expected, customMessage, actualExpression: actualExpression);
     }
 
     /// <summary>

--- a/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
+++ b/src/Shouldly/ShouldlyExtensionMethods/ShouldBeDictionaryTestExtensions.cs
@@ -44,23 +44,27 @@ public static partial class ShouldBeDictionaryTestExtensions
 
     /// <summary>
     /// Asserts that the dictionary contains the specified key with the specified value.
+    /// The value is compared the same way <c>ShouldBe</c> compares it, so collection values are
+    /// compared element-wise rather than by reference.
     /// </summary>
     public static void ShouldContainKeyAndValue<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key, TValue val, string? customMessage = null,
         [CallerArgumentExpression(nameof(dictionary))] string? actualExpression = null)
         where TKey : notnull
     {
-        if (!TryGetValue(dictionary, key, out var actual) || !Equals(actual, val))
+        if (!TryGetValue(dictionary, key, out var actual) || !Is.Equal(actual, val, Is.ScalarComparerFor<TValue>()))
             throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage, actualExpression: actualExpression).ToString());
     }
 
     /// <summary>
     /// Asserts that the dictionary does not contain the specified value for the specified key.
+    /// The value is compared the same way <c>ShouldBe</c> compares it, so collection values are
+    /// compared element-wise rather than by reference.
     /// </summary>
     public static void ShouldNotContainValueForKey<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> dictionary, TKey key, TValue val, string? customMessage = null,
         [CallerArgumentExpression(nameof(dictionary))] string? actualExpression = null)
         where TKey : notnull
     {
-        if (!TryGetValue(dictionary, key, out var actual) || Equals(actual, val))
+        if (!TryGetValue(dictionary, key, out var actual) || Is.Equal(actual, val, Is.ScalarComparerFor<TValue>()))
             throw new ShouldAssertException(new ExpectedActualKeyShouldlyMessage(val, dictionary, key, customMessage, actualExpression: actualExpression).ToString());
     }
 


### PR DESCRIPTION
Fixes #1325.

`ShouldContainKeyAndValue` and `ShouldNotContainValueForKey` compared the value with `object.Equals`, so a collection-valued dictionary behaved differently from `ShouldBe` on the very same value. Now they both go through Shouldly's structural comparer.

- Added `Is.ScalarComparerFor<T>()` and routed both dictionary value assertions and `ShouldBe` through it, so they agree on equality (it also de-duplicates the `string`/`CompareAsObjectTypes` branch that was inlined in `ShouldBe`).
- `string` and the types in `ShouldlyConfiguration.CompareAsObjectTypes` still compare with their own `Equals`, and floating-point values honour `DefaultFloatingPointTolerance` — same as `ShouldBe`.
- Added `DictionaryValueEquality` tests, with a non-parallel `GlobalConfigCollection` for the one test that mutates global config.
- Documented the change in the 4→5 upgrade guide and the `containKeyAndValue` docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)