### PR TITLE
Report dictionary assertion failures over non-IDictionary sequences

### DIFF
--- a/src/Shouldly.Tests/Dictionaries/NonDictionaryKeyValueSequences.cs
+++ b/src/Shouldly.Tests/Dictionaries/NonDictionaryKeyValueSequences.cs
@@ -1,0 +1,103 @@
+namespace Shouldly.Tests.Dictionaries;
+
+public class NonDictionaryKeyValueSequences
+{
+    private static IEnumerable<KeyValuePair<string, int>> PairList() =>
+        new List<KeyValuePair<string, int>> { new("a", 1) };
+
+    private static Dictionary<string, int> Dictionary() =>
+        new() { ["a"] = 1 };
+
+    [Fact]
+    public void ShouldContainKeyAndValueReportsAWrongValue()
+    {
+        var exception = Should.Throw<ShouldAssertException>(() =>
+            PairList().ShouldContainKeyAndValue("a", 2));
+
+        exception.Message.ShouldContain("a");
+        exception.Message.ShouldContain("but value was");
+    }
+
+    [Fact]
+    public void ShouldContainKeyAndValueReportsAMissingKey()
+    {
+        var exception = Should.Throw<ShouldAssertException>(() =>
+            PairList().ShouldContainKeyAndValue("z", 1));
+
+        exception.Message.ShouldContain("but the key does not exist");
+    }
+
+    [Fact]
+    public void ShouldNotContainValueForKeyReportsAPresentPair()
+    {
+        var exception = Should.Throw<ShouldAssertException>(() =>
+            PairList().ShouldNotContainValueForKey("a", 1));
+
+        exception.Message.ShouldContain("but does");
+    }
+
+    [Fact]
+    public void ShouldNotContainValueForKeyReportsAMissingKey()
+    {
+        var exception = Should.Throw<ShouldAssertException>(() =>
+            PairList().ShouldNotContainValueForKey("z", 1));
+
+        exception.Message.ShouldContain("but the key does not exist");
+    }
+
+    [Fact]
+    public void ArrayOfPairsReportsAWrongValue()
+    {
+        KeyValuePair<string, int>[] pairs = [new("a", 1)];
+
+        Should.Throw<ShouldAssertException>(() =>
+            pairs.ShouldContainKeyAndValue("a", 2));
+    }
+
+    [Fact]
+    public void LinqProjectionOverADictionaryReportsAWrongValue()
+    {
+        var exception = Should.Throw<ShouldAssertException>(() =>
+            Dictionary().Where(pair => true).ShouldContainKeyAndValue("a", 999));
+
+        exception.Message.ShouldContain("but value was");
+    }
+
+    [Fact]
+    public void LinqProjectionOverADictionaryReportsAPresentPair()
+    {
+        Should.Throw<ShouldAssertException>(() =>
+            Dictionary().Select(pair => pair).ShouldNotContainValueForKey("a", 1));
+    }
+
+    [Fact]
+    public void PassingAssertionsAreUnaffected()
+    {
+        PairList().ShouldContainKeyAndValue("a", 1);
+        PairList().ShouldNotContainValueForKey("a", 2);
+        PairList().ShouldContainKey("a");
+        PairList().ShouldNotContainKey("z");
+    }
+
+    [Fact]
+    public void CollectionValuesStillCompareStructurallyOverAPairSequence()
+    {
+        IEnumerable<KeyValuePair<string, int[]>> pairs =
+            new List<KeyValuePair<string, int[]>> { new("k", [1, 2, 3]) };
+
+        pairs.ShouldContainKeyAndValue("k", [1, 2, 3]);
+        Should.Throw<ShouldAssertException>(() => pairs.ShouldContainKeyAndValue("k", [1, 2, 4]));
+    }
+
+    [Fact]
+    public void NullValuesAreReportedOverAPairSequence()
+    {
+        IEnumerable<KeyValuePair<string, string?>> pairs =
+            new List<KeyValuePair<string, string?>> { new("k", null) };
+
+        var exception = Should.Throw<ShouldAssertException>(() =>
+            pairs.ShouldContainKeyAndValue("k", "x"));
+
+        exception.Message.ShouldContain("but value was");
+    }
+}

--- a/src/Shouldly/MessageGenerators/DictionaryMessageLookup.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryMessageLookup.cs
@@ -1,0 +1,59 @@
+namespace Shouldly.MessageGenerators;
+
+/// <summary>
+/// Looks up a key in the <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey,TValue}"/> a dictionary assertion was given.
+/// </summary>
+static class DictionaryMessageLookup
+{
+    public static bool TryGetValue(object? actual, object key, out object? value)
+    {
+        if (actual is IDictionary dictionary)
+        {
+            if (dictionary.Contains(key))
+            {
+                value = dictionary[key];
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        if (actual is IEnumerable sequence)
+        {
+            foreach (var entry in sequence)
+            {
+                if (entry != null && TryReadPair(entry, out var entryKey, out var entryValue) && Equals(entryKey, key))
+                {
+                    value = entryValue;
+                    return true;
+                }
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    [UnconditionalSuppressMessage("Trimming", "IL2075",
+        Justification = "KeyValuePair<TKey, TValue> is a BCL type whose public Key and Value properties are preserved by the trimmer.")]
+    private static bool TryReadPair(object entry, out object? key, out object? value)
+    {
+        var type = entry.GetType();
+        if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>))
+        {
+            var keyProperty = type.GetProperty(nameof(KeyValuePair<int, int>.Key));
+            var valueProperty = type.GetProperty(nameof(KeyValuePair<int, int>.Value));
+            if (keyProperty != null && valueProperty != null)
+            {
+                key = keyProperty.GetValue(entry);
+                value = valueProperty.GetValue(entry);
+                return true;
+            }
+        }
+
+        key = null;
+        value = null;
+        return false;
+    }
+}

--- a/src/Shouldly/MessageGenerators/DictionaryShouldContainKeyAndValueMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryShouldContainKeyAndValueMessageGenerator.cs
@@ -9,7 +9,6 @@ class DictionaryShouldContainKeyAndValueMessageGenerator : ShouldlyMessageGenera
 
     public override string GenerateErrorMessage(IShouldlyAssertionContext context)
     {
-        Debug.Assert(context.Actual is IDictionary);
         Debug.Assert(context.Key is object);
 
         const string format =
@@ -23,14 +22,13 @@ class DictionaryShouldContainKeyAndValueMessageGenerator : ShouldlyMessageGenera
             """;
 
         var codePart = context.CodePart;
-        var dictionary = (IDictionary)context.Actual;
-        var keyExists = dictionary.Contains(context.Key);
+        var keyExists = DictionaryMessageLookup.TryGetValue(context.Actual, context.Key, out var actualValue);
         var expected = context.Expected.ToStringAwesomely();
         var keyValue = context.Key.ToStringAwesomely();
 
         if (keyExists)
         {
-            var actualValueString = dictionary[context.Key].ToStringAwesomely();
+            var actualValueString = actualValue.ToStringAwesomely();
             var valueString =
                 $"""
                      but value was

--- a/src/Shouldly/MessageGenerators/DictionaryShouldNotContainValueForKeyMessageGenerator.cs
+++ b/src/Shouldly/MessageGenerators/DictionaryShouldNotContainValueForKeyMessageGenerator.cs
@@ -8,7 +8,6 @@ class DictionaryShouldNotContainValueForKeyMessageGenerator : ShouldlyMessageGen
 
     public override string GenerateErrorMessage(IShouldlyAssertionContext context)
     {
-        Debug.Assert(context.Actual is IDictionary);
         Debug.Assert(context.Key is object);
 
         const string format =
@@ -22,8 +21,7 @@ class DictionaryShouldNotContainValueForKeyMessageGenerator : ShouldlyMessageGen
             """;
 
         var codePart = context.CodePart;
-        var dictionary = (IDictionary)context.Actual;
-        var keyExists = dictionary.Contains(context.Key);
+        var keyExists = DictionaryMessageLookup.TryGetValue(context.Actual, context.Key, out _);
         var expected = context.Expected.ToStringAwesomely();
         var keyValue = context.Key.ToStringAwesomely();
 


### PR DESCRIPTION
Fixes #601.

`ShouldContainKeyAndValue` and `ShouldNotContainValueForKey` accept any `IEnumerable<KeyValuePair<TKey, TValue>>`, but both message generators cast the actual value to the non-generic `IDictionary`. A failing assertion over a list or array of pairs, a LINQ projection, or a mocked `IDictionary<,>` throws `InvalidCastException` instead of `ShouldAssertException`.

The message generators now look the key up through `IDictionary` when the value is one, and otherwise scan the pairs. Messages for dictionaries are unchanged. Ten tests added.

Verified on a fresh clone with `build.ps1`'s build, pack and test commands: the new tests fail with `InvalidCastException` before the change and pass after.

Prepared with AI assistance (Claude); reviewed and verified by me.
