### PR TITLE
Fix Type-based exception assignability

### DIFF
--- a/src/Shouldly.Tests/ShouldThrow/ActionDelegateScenario.cs
+++ b/src/Shouldly.Tests/ShouldThrow/ActionDelegateScenario.cs
@@ -37,4 +37,15 @@ public class ActionDelegateScenario
         ex.ShouldBeOfType<NotImplementedException>();
         ex.ShouldNotBe(null);
     }
+
+    [Fact]
+    public void ShouldPassWhenDerivedExceptionIsThrown_ExceptionTypePassedIn()
+    {
+        var expected = new ArgumentNullException();
+        var action = new Action(() => throw expected);
+
+        var ex = action.ShouldThrow(typeof(ArgumentException));
+
+        ex.ShouldBeSameAs(expected);
+    }
 }

--- a/src/Shouldly.Tests/ShouldThrow/FuncOfObjectScenario.cs
+++ b/src/Shouldly.Tests/ShouldThrow/FuncOfObjectScenario.cs
@@ -37,4 +37,15 @@ public class FuncOfObjectScenario
         ex.ShouldBeOfType<NotImplementedException>();
         ex.ShouldNotBe(null);
     }
+
+    [Fact]
+    public void ShouldPassWhenDerivedExceptionIsThrown_ExceptionTypePassedIn()
+    {
+        var expected = new ArgumentNullException();
+        var action = new Func<object>(() => throw expected);
+
+        var ex = action.ShouldThrow(typeof(ArgumentException));
+
+        ex.ShouldBeSameAs(expected);
+    }
 }

--- a/src/Shouldly.Tests/ShouldThrow/TaskScenario.cs
+++ b/src/Shouldly.Tests/ShouldThrow/TaskScenario.cs
@@ -41,4 +41,15 @@ public class TaskScenario
         ex.ShouldNotBe(null);
         ex.ShouldBeOfType<InvalidOperationException>();
     }
+
+    [Fact]
+    public void ShouldPassWhenDerivedExceptionIsThrown_ExceptionTypePassedIn()
+    {
+        var expected = new ArgumentNullException();
+        var task = Task.FromException(expected);
+
+        var ex = task.ShouldThrow(typeof(ArgumentException));
+
+        ex.ShouldBeSameAs(expected);
+    }
 }

--- a/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
+++ b/src/Shouldly.Tests/ShouldThrowAsync/FuncOfTaskScenarioAsync.cs
@@ -168,4 +168,37 @@ public class FuncOfTaskScenarioAsync
 
         throw new XunitException("ShouldThrowAsync did not throw");
     }
+
+    [Fact]
+    public async Task ShouldPassWhenCanceledTaskThrowsDerivedException_ExceptionTypePassedIn()
+    {
+        var expected = new OperationCanceledException();
+
+        async Task ThrowAsync()
+        {
+            await Task.Yield();
+            throw expected;
+        }
+
+        var ex = await Should.ThrowAsync(ThrowAsync, typeof(Exception));
+
+        ex.ShouldBeSameAs(expected);
+    }
+
+    [Fact]
+    public async Task ShouldFailWhenExceptionIsNotAssignable_ExceptionTypePassedIn()
+    {
+        var task = Task.FromException(new InvalidOperationException());
+
+        try
+        {
+            await task.ShouldThrowAsync(typeof(ArgumentException));
+        }
+        catch (ShouldAssertException)
+        {
+            return;
+        }
+
+        throw new XunitException("ShouldThrowAsync did not throw");
+    }
 }

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrow.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrow.cs
@@ -58,7 +58,7 @@ public static partial class Should
         }
         catch (Exception e)
         {
-            if (e.GetType() == exceptionType)
+            if (exceptionType.IsInstanceOfType(e))
             {
                 return e;
             }
@@ -128,7 +128,7 @@ public static partial class Should
         }
         catch (Exception e)
         {
-            if (e.GetType() == exceptionType)
+            if (exceptionType.IsInstanceOfType(e))
             {
                 return e;
             }

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTask.cs
@@ -126,7 +126,7 @@ public static partial class Should
         {
             e = (e as AggregateException)?.InnerException ?? e;
 
-            if (e.GetType() == exceptionType)
+            if (exceptionType.IsInstanceOfType(e))
             {
                 return e;
             }

--- a/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
+++ b/src/Shouldly/ShouldStaticClasses/ShouldThrowTaskAsync.cs
@@ -78,7 +78,7 @@ public static partial class Should
         }
         catch (Exception e)
         {
-            if (e.GetType() == exceptionType)
+            if (exceptionType.IsInstanceOfType(e))
                 return e;
 
             throw new ShouldAssertException(new ExpectedActualShouldlyMessage(exceptionType, e.GetType(), customMessage, actualExpression: actualExpression).ToString());


### PR DESCRIPTION
Fixes #831.

## Summary

- make the non-generic `Type` overloads use assignability, matching the existing generic `Throw<TException>` and `ThrowAsync<TException>` behavior
- apply the rule consistently to `Action`, `Func<object?>`, synchronous `Task`/`Func<Task>`, and asynchronous `Task`/`Func<Task>` paths
- retain the original exception instance and preserve failures for unrelated exception types
- add regressions for every internal path, including the reported canceled-task shape

This is the behavior change proposed for v5 in the maintainer analysis on #831.

## Validation

- Release build: 0 warnings, 0 errors
- `Shouldly.Tests` on .NET 10: 964 passed
- affected `ShouldThrow` classes on .NET Framework 4.8: 25 passed
- `git diff --check`

